### PR TITLE
refactor: re-home motion types in xmNabla; depend on mu's HAL

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -2,3 +2,23 @@
 #add_subdirectory(ipc)
 add_subdirectory(event)
 add_subdirectory(math_utils)
+
+## Header-only motion-domain types/interfaces re-homed into xmNabla
+## (trajectory types + controller interface). These left xmSigma in the
+## single-target refactor and now live under xmnabla/.
+add_library(xmnabla_common INTERFACE)
+target_include_directories(xmnabla_common INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>)
+target_link_libraries(xmnabla_common INTERFACE xmotion::xmSigma)
+add_library(xmotion::xmnabla_common ALIAS xmnabla_common)
+
+install(TARGETS xmnabla_common
+    EXPORT xmNablaTargets
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+    RUNTIME DESTINATION bin
+    INCLUDES DESTINATION include)
+
+install(DIRECTORY include/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/src/common/event/CMakeLists.txt
+++ b/src/common/event/CMakeLists.txt
@@ -5,7 +5,7 @@ find_package(Threads REQUIRED)
 add_library(event STATIC
     src/async_event_dispatcher.cpp
     src/event_dispatcher.cpp)
-target_link_libraries(event PUBLIC xmotion::logging)
+target_link_libraries(event PUBLIC xmotion::xmSigma)
 target_include_directories(event PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>

--- a/src/common/include/xmnabla/control/controller_interface.hpp
+++ b/src/common/include/xmnabla/control/controller_interface.hpp
@@ -1,0 +1,21 @@
+/*
+ * controller_interface.hpp
+ *
+ * Created 4/15/22 5:02 PM
+ * Description:
+ * 
+ * Copyright (c) 2022 Ruixiang Du (rdu)
+ */
+
+#pragma once
+
+namespace xmotion {
+template<typename State, typename Output>
+class ControllerInterface {
+ public:
+  virtual ~ControllerInterface() = default;
+
+  virtual Output Update(const State &target, const State &estimated) = 0;
+};
+}  // namespace xmotion
+

--- a/src/common/include/xmnabla/types/trajectory.hpp
+++ b/src/common/include/xmnabla/types/trajectory.hpp
@@ -1,0 +1,27 @@
+/*
+ * @file trajectory_types.hpp
+ * @date 9/9/24
+ * @brief
+ *
+ * @copyright Copyright (c) 2024 Ruixiang Du (rdu)
+ */
+
+#pragma once
+
+#include "xmotion/types/geometry_types.hpp"
+
+namespace xmotion {
+struct TrajectoryPoint3d {
+  double time;
+  Position3d position;
+  Quaterniond orientation;
+
+  Velocity3d velocity;
+  Acceleration3d acceleration;
+};
+
+struct Trajectory3d {
+  std::vector<TrajectoryPoint3d> points;
+};
+}  // namespace xmotion
+

--- a/src/common/math_utils/CMakeLists.txt
+++ b/src/common/math_utils/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(math_utils STATIC src/matrix.cpp)
-target_link_libraries(math_utils PUBLIC xmotion::logging stb)
+target_link_libraries(math_utils PUBLIC xmotion::xmSigma stb)
 target_include_directories(math_utils PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>)

--- a/src/control/robot_base/CMakeLists.txt
+++ b/src/control/robot_base/CMakeLists.txt
@@ -8,7 +8,7 @@ add_library(robot_base
     src/differential_drive_robot.cpp
     src/swerve_drive_robot.cpp
     src/swerve_drive_kinematics.cpp)
-target_link_libraries(robot_base PUBLIC xmotion::interface xmotion::logging Eigen3::Eigen)
+target_link_libraries(robot_base PUBLIC xmotion::hal xmotion::xmSigma Eigen3::Eigen)
 target_include_directories(robot_base PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>

--- a/src/control/robot_base/include/robot_base/actuator/position_actuator_group.hpp
+++ b/src/control/robot_base/include/robot_base/actuator/position_actuator_group.hpp
@@ -13,7 +13,7 @@
 #include <vector>
 #include <memory>
 
-#include "interface/driver/motor_controller_interface.hpp"
+#include "xmmu/hal/motor_controller_interface.hpp"
 #include "logging/xlogger.hpp"
 
 namespace xmotion {

--- a/src/control/robot_base/include/robot_base/actuator/speed_actuator_group.hpp
+++ b/src/control/robot_base/include/robot_base/actuator/speed_actuator_group.hpp
@@ -13,7 +13,7 @@
 #include <vector>
 #include <memory>
 
-#include "interface/driver/motor_controller_interface.hpp"
+#include "xmmu/hal/motor_controller_interface.hpp"
 #include "logging/xlogger.hpp"
 
 namespace xmotion {

--- a/src/control/robot_base/include/robot_base/kinematics/swerve_drive_kinematics.hpp
+++ b/src/control/robot_base/include/robot_base/kinematics/swerve_drive_kinematics.hpp
@@ -19,7 +19,7 @@
 
 #include <eigen3/Eigen/Core>
 
-#include "interface/type/geometry_types.hpp"
+#include "xmotion/types/geometry_types.hpp"
 
 namespace xmotion {
 class SwerveDriveKinematics {

--- a/src/control/robot_base/include/robot_base/swerve_drive_robot.hpp
+++ b/src/control/robot_base/include/robot_base/swerve_drive_robot.hpp
@@ -31,8 +31,8 @@
 #include <array>
 #include <memory>
 
-#include "interface/type/geometry_types.hpp"
-#include "interface/driver/motor_controller_array_interface.hpp"
+#include "xmotion/types/geometry_types.hpp"
+#include "xmmu/hal/motor_controller_array_interface.hpp"
 
 #include "robot_base/kinematics/swerve_drive_kinematics.hpp"
 

--- a/src/estimation/CMakeLists.txt
+++ b/src/estimation/CMakeLists.txt
@@ -5,7 +5,7 @@ add_library(estimation STATIC
     src/mekf6.cpp
     src/mekf9.cpp)
 target_link_libraries(estimation PUBLIC
-    xmotion::interface
+    xmotion::hal
     Eigen3::Eigen)
 target_include_directories(estimation PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/src/estimation/app/mekf_ros_node.hpp
+++ b/src/estimation/app/mekf_ros_node.hpp
@@ -13,7 +13,7 @@
 #include <sensor_msgs/msg/imu.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 
-#include "interface/driver/imu_interface.hpp"
+#include "xmmu/hal/imu_interface.hpp"
 #include "estimation/mekf6.hpp"
 
 namespace xmotion {

--- a/src/mapping/map_processing/CMakeLists.txt
+++ b/src/mapping/map_processing/CMakeLists.txt
@@ -13,11 +13,11 @@ add_library(map_processing
     src/trajectory_processor.cpp
 )
 target_link_libraries(map_processing PUBLIC
-    xmotion::interface
+    xmotion::xmSigma
+    xmotion::xmnabla_common
     pnm
     rapidcsv
     math_utils
-    xmotion::logging
     Eigen3::Eigen
     ${OpenCV_LIBS}
     ${PCL_LIBRARIES})

--- a/src/mapping/map_processing/include/map_processing/pgm_map.hpp
+++ b/src/mapping/map_processing/include/map_processing/pgm_map.hpp
@@ -19,7 +19,7 @@
 
 #include <opencv4/opencv2/opencv.hpp>
 
-#include "interface/type/geometry_types.hpp"
+#include "xmotion/types/geometry_types.hpp"
 
 namespace xmotion {
 class PgmMap {

--- a/src/mapping/map_processing/include/map_processing/point_cloud_processor.hpp
+++ b/src/mapping/map_processing/include/map_processing/point_cloud_processor.hpp
@@ -13,7 +13,7 @@
 #include <pcl/point_types.h>
 #include <pcl/point_cloud.h>
 
-#include "interface/type/geometry_types.hpp"
+#include "xmotion/types/geometry_types.hpp"
 
 namespace xmotion {
 class PointCloudProcessor {

--- a/src/mapping/map_processing/include/map_processing/trajectory_processor.hpp
+++ b/src/mapping/map_processing/include/map_processing/trajectory_processor.hpp
@@ -11,7 +11,7 @@
 
 #include <string>
 
-#include "interface/type/trajectory_types.hpp"
+#include "xmnabla/types/trajectory.hpp"
 
 namespace xmotion {
 class TrajectoryProcessor {

--- a/src/planning/decision/reachability/tests/CMakeLists.txt
+++ b/src/planning/decision/reachability/tests/CMakeLists.txt
@@ -24,7 +24,7 @@ add_executable(test_markov_motion test_markov_motion.cpp)
 target_link_libraries(test_markov_motion reachability utilities)
 
 add_executable(test_bigaussian test_bigaussian.cpp)
-target_link_libraries(test_bigaussian reachability xmotion::logging)
+target_link_libraries(test_bigaussian reachability xmotion::xmSigma)
 
 add_executable(test_matrix test_matrix.cpp)
 # target_link_libraries(test_matrix)

--- a/src/planning/sampling/test/CMakeLists.txt
+++ b/src/planning/sampling/test/CMakeLists.txt
@@ -4,22 +4,22 @@
 ## tests
 if (ENABLE_VISUALIZATION)
   add_executable(test_rvspace test_rvspace.cpp)
-  target_link_libraries(test_rvspace sampling xmotion::interface stopwatch)
+  target_link_libraries(test_rvspace sampling stopwatch)
 
   add_executable(test_rng test_rng.cpp)
   target_link_libraries(test_rng sampling)
 
   add_executable(test_rrt test_rrt.cpp)
-  target_link_libraries(test_rrt sampling xmotion::interface stopwatch)
+  target_link_libraries(test_rrt sampling stopwatch)
 
   add_executable(test_kdtree test_kdtree.cpp)
-  target_link_libraries(test_kdtree sampling xmotion::interface stopwatch)
+  target_link_libraries(test_kdtree sampling stopwatch)
 
   add_executable(test_rrg test_rrg.cpp)
-  target_link_libraries(test_rrg sampling xmotion::interface stopwatch)
+  target_link_libraries(test_rrg sampling stopwatch)
 
   add_executable(test_rrts test_rrts.cpp)
-  target_link_libraries(test_rrts sampling xmotion::interface stopwatch)
+  target_link_libraries(test_rrts sampling stopwatch)
 
   add_executable(test_rrt_draw test_rrt_draw.cpp)
   target_link_libraries(test_rrt_draw sampling)

--- a/src/planning/state_lattice/CMakeLists.txt
+++ b/src/planning/state_lattice/CMakeLists.txt
@@ -13,7 +13,7 @@ set(LATTICE_LIB_SRC
   src/lattice_viz.cpp 
 )
 add_library(lattice STATIC ${LATTICE_LIB_SRC})
-target_link_libraries(lattice control xmotion::logging utilities cvdraw)
+target_link_libraries(lattice control xmotion::xmSigma utilities cvdraw)
 target_include_directories(lattice PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>


### PR DESCRIPTION
Part of a coordinated 4-PR foundation refactor (**merge order: Σ → μ → ∇ → umbrella**; needs the xmSigma + xmMu PRs first).

`trajectory_types` + `ControllerInterface` move out of xmSigma into xmNabla under `xmnabla/{types,control}/` as a header-only `xmotion::xmnabla_common` target. Moved includes re-prefixed (`interface/type/* → xmotion/types/*`, `interface/driver/* → xmmu/hal/*`, `interface/{type/trajectory,control} → xmnabla/*`). The old `xmotion::interface` link splits per consumer into `xmotion::xmSigma` (types) + `xmotion::hal` (driver interfaces); formalizes **Σ ← μ ← ∇**. 14/14 tests pass.