### PR TITLE
refactor: consume xmSigma via the xmsigma/ include namespace

### DIFF
--- a/src/common/include/xmnabla/types/trajectory.hpp
+++ b/src/common/include/xmnabla/types/trajectory.hpp
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include "xmotion/types/geometry_types.hpp"
+#include "xmsigma/types/geometry_types.hpp"
 
 namespace xmotion {
 struct TrajectoryPoint3d {

--- a/src/common/math_utils/include/math_utils/details/eigen_io_impl.hpp
+++ b/src/common/math_utils/include/math_utils/details/eigen_io_impl.hpp
@@ -28,7 +28,7 @@
 #define STB_IMAGE_WRITE_IMPLEMENTATION
 #include "stb_image_write.h"
 
-#include "logging/xlogger.hpp"
+#include "xmsigma/logging/xlogger.hpp"
 
 namespace xmotion {
 template <typename Scalar, int RowsAtCompileTime, int ColsAtCompileTime>

--- a/src/control/robot_base/include/robot_base/actuator/position_actuator_group.hpp
+++ b/src/control/robot_base/include/robot_base/actuator/position_actuator_group.hpp
@@ -14,7 +14,7 @@
 #include <memory>
 
 #include "xmmu/hal/motor_controller_interface.hpp"
-#include "logging/xlogger.hpp"
+#include "xmsigma/logging/xlogger.hpp"
 
 namespace xmotion {
 class PositionActuatorGroup final : public MotorControllerInterface {

--- a/src/control/robot_base/include/robot_base/actuator/speed_actuator_group.hpp
+++ b/src/control/robot_base/include/robot_base/actuator/speed_actuator_group.hpp
@@ -14,7 +14,7 @@
 #include <memory>
 
 #include "xmmu/hal/motor_controller_interface.hpp"
-#include "logging/xlogger.hpp"
+#include "xmsigma/logging/xlogger.hpp"
 
 namespace xmotion {
 class SpeedActuatorGroup final : public MotorControllerInterface {

--- a/src/control/robot_base/include/robot_base/kinematics/swerve_drive_kinematics.hpp
+++ b/src/control/robot_base/include/robot_base/kinematics/swerve_drive_kinematics.hpp
@@ -19,7 +19,7 @@
 
 #include <eigen3/Eigen/Core>
 
-#include "xmotion/types/geometry_types.hpp"
+#include "xmsigma/types/geometry_types.hpp"
 
 namespace xmotion {
 class SwerveDriveKinematics {

--- a/src/control/robot_base/include/robot_base/swerve_drive_robot.hpp
+++ b/src/control/robot_base/include/robot_base/swerve_drive_robot.hpp
@@ -31,7 +31,7 @@
 #include <array>
 #include <memory>
 
-#include "xmotion/types/geometry_types.hpp"
+#include "xmsigma/types/geometry_types.hpp"
 #include "xmmu/hal/motor_controller_array_interface.hpp"
 
 #include "robot_base/kinematics/swerve_drive_kinematics.hpp"

--- a/src/control/robot_base/src/differential_drive_robot.cpp
+++ b/src/control/robot_base/src/differential_drive_robot.cpp
@@ -11,7 +11,7 @@
 
 #include <cmath>
 
-#include "logging/xlogger.hpp"
+#include "xmsigma/logging/xlogger.hpp"
 
 namespace xmotion {
 DifferentialDriveRobot::DifferentialDriveRobot(const Config& config)

--- a/src/control/robot_base/src/swerve_drive_kinematics.cpp
+++ b/src/control/robot_base/src/swerve_drive_kinematics.cpp
@@ -10,7 +10,7 @@
 
 #include <iostream>
 
-#include "logging/xlogger.hpp"
+#include "xmsigma/logging/xlogger.hpp"
 
 namespace xmotion {
 namespace {

--- a/src/control/robot_base/src/swerve_drive_robot.cpp
+++ b/src/control/robot_base/src/swerve_drive_robot.cpp
@@ -8,7 +8,7 @@
 
 #include "robot_base/swerve_drive_robot.hpp"
 
-#include "logging/xlogger.hpp"
+#include "xmsigma/logging/xlogger.hpp"
 
 namespace xmotion {
 SwerveDriveRobot::SwerveDriveRobot(const SwerveDriveRobot::Config& config)

--- a/src/control/robot_base/test/test_differential_drive_robot.cpp
+++ b/src/control/robot_base/test/test_differential_drive_robot.cpp
@@ -13,7 +13,7 @@
 #include <thread>
 #include <cmath>
 
-#include "logging/xlogger.hpp"
+#include "xmsigma/logging/xlogger.hpp"
 
 #include "input_hid/joystick.hpp"
 

--- a/src/mapping/map_processing/include/map_processing/pgm_map.hpp
+++ b/src/mapping/map_processing/include/map_processing/pgm_map.hpp
@@ -19,7 +19,7 @@
 
 #include <opencv4/opencv2/opencv.hpp>
 
-#include "xmotion/types/geometry_types.hpp"
+#include "xmsigma/types/geometry_types.hpp"
 
 namespace xmotion {
 class PgmMap {

--- a/src/mapping/map_processing/include/map_processing/point_cloud_processor.hpp
+++ b/src/mapping/map_processing/include/map_processing/point_cloud_processor.hpp
@@ -13,7 +13,7 @@
 #include <pcl/point_types.h>
 #include <pcl/point_cloud.h>
 
-#include "xmotion/types/geometry_types.hpp"
+#include "xmsigma/types/geometry_types.hpp"
 
 namespace xmotion {
 class PointCloudProcessor {

--- a/src/mapping/map_processing/src/pgm_map.cpp
+++ b/src/mapping/map_processing/src/pgm_map.cpp
@@ -9,7 +9,7 @@
 
 #include "map_processing/pgm_map.hpp"
 
-#include "logging/xlogger.hpp"
+#include "xmsigma/logging/xlogger.hpp"
 #include "math_utils/eigen_io.hpp"
 
 #include "pnm/pnm.hpp"

--- a/src/mapping/map_processing/src/point_cloud_processor.cpp
+++ b/src/mapping/map_processing/src/point_cloud_processor.cpp
@@ -8,7 +8,7 @@
 
 #include "map_processing/point_cloud_processor.hpp"
 
-#include "logging/xlogger.hpp"
+#include "xmsigma/logging/xlogger.hpp"
 
 #include <pcl/io/pcd_io.h>
 #include <pcl/io/ply_io.h>

--- a/src/mapping/map_processing/src/trajectory_processor.cpp
+++ b/src/mapping/map_processing/src/trajectory_processor.cpp
@@ -11,7 +11,7 @@
 #include <Eigen/Dense>
 #include "rapidcsv.h"
 
-#include "logging/xlogger.hpp"
+#include "xmsigma/logging/xlogger.hpp"
 
 namespace xmotion {
 void TrajectoryProcessor::LoadData(const std::string& filename,

--- a/src/planning/decision/reachability/src/monte_carlo_sim.cpp
+++ b/src/planning/decision/reachability/src/monte_carlo_sim.cpp
@@ -8,7 +8,7 @@
  */
 
 #include "reachability/monte_carlo_sim.hpp"
-#include "logging/loggers.hpp"
+#include "xmsigma/logging/loggers.hpp"
 
 using namespace xmotion;
 

--- a/src/planning/decision/reachability/tests/test_bigaussian.cpp
+++ b/src/planning/decision/reachability/tests/test_bigaussian.cpp
@@ -5,7 +5,7 @@
 // #include <gsl/gsl_randist.h>
 #include "random/bigaussian_sampler.hpp"
 
-#include "logging/loggers.hpp"
+#include "xmsigma/logging/loggers.hpp"
 
 using namespace xmotion;
 

--- a/src/planning/state_lattice/src/lookup_table.cpp
+++ b/src/planning/state_lattice/src/lookup_table.cpp
@@ -13,7 +13,7 @@
 
 #include "state_lattice/primitive_generator.hpp"
 
-#include "logging/loggers.hpp"
+#include "xmsigma/logging/loggers.hpp"
 
 using namespace xmotion;
 

--- a/src/planning/state_lattice/src/state_lattice.cpp
+++ b/src/planning/state_lattice/src/state_lattice.cpp
@@ -12,7 +12,7 @@
 #include <iostream>
 #include <cmath>
 
-#include "logging/loggers.hpp"
+#include "xmsigma/logging/loggers.hpp"
 
 using namespace xmotion;
 


### PR DESCRIPTION
Coordinated 4-PR change (needs xmSigma + xmMu PRs first). `logging/→xmsigma/logging/` + `xmotion/types/→xmsigma/types/` across nabla's libs (19 sites). Bundled xmSigma/xmMu bumped to the layout commits; robot_base/estimation compile against `xmsigma/`.