### PR TITLE
feat(estimation): MEKF9 — 9-DOF filter with magnetometer

### DIFF
--- a/src/estimation/include/xmnav/estimation/mekf9.hpp
+++ b/src/estimation/include/xmnav/estimation/mekf9.hpp
@@ -1,7 +1,22 @@
 /*
  * @file mekf9.hpp
  * @date 5/7/24
- * @brief
+ * @brief Multiplicative extended Kalman filter, 9-DOF IMU
+ *        (gyro + accel + magnetometer).
+ *
+ * 18-error-state MEKF estimating attitude plus gyro, accelerometer, and
+ * magnetometer biases. The magnetometer observation makes heading (and the
+ * gyro z-bias) observable, which the gravity-only Mekf6 cannot see. The
+ * derivation is docs/typst/main.typ (18-state model with the magnetometer
+ * measurement); conventions match Mekf6:
+ *
+ *  - q_hat is body-to-inertial (C^i_b = R(q_hat)).
+ *  - Gravity is (0, 0, -g) in the inertial frame.
+ *  - mag_reference is the local magnetic field in the inertial frame, in the
+ *    same (arbitrary but consistent) units as the magnetometer output.
+ *
+ * Error state (18x1): [alpha, delta v, delta r, beta_omega, beta_f, beta_m],
+ * folded into the nominal states and reset after every measurement update.
  *
  * @copyright Copyright (c) 2024 Ruixiang Du (rdu)
  */
@@ -12,7 +27,90 @@
 #include <eigen3/Eigen/Geometry>
 
 namespace xmotion {
-class Mekf9 {};
+class Mekf9 {
+ public:
+  static constexpr int StateDimension = 18;
+  static constexpr int ControlInputDimension = 3;
+  static constexpr int ObservationDimension = 3;  // per vector observation
+
+  // error state: [alpha, delta v, delta r, beta omega, beta f, beta m]
+  using State = Eigen::Matrix<double, StateDimension, 1>;
+  using ControlInput = Eigen::Matrix<double, ControlInputDimension, 1>;
+  using Observation = Eigen::Matrix<double, ObservationDimension, 1>;
+
+  using StateCovariance = Eigen::Matrix<double, StateDimension, StateDimension>;
+  using ProcessNoiseCovariance =
+      Eigen::Matrix<double, StateDimension, StateDimension>;
+  using ObservationNoiseCovariance =
+      Eigen::Matrix<double, ObservationDimension, ObservationDimension>;
+
+  struct Params {
+    Eigen::Quaterniond init_quaternion = Eigen::Quaterniond::Identity();
+    Eigen::Vector3d init_gyro_bias = Eigen::Vector3d::Zero();
+    Eigen::Vector3d init_accel_bias = Eigen::Vector3d::Zero();
+    Eigen::Vector3d init_mag_bias = Eigen::Vector3d::Zero();
+
+    StateCovariance init_state_cov = StateCovariance::Identity();
+    ObservationNoiseCovariance accel_noise_cov =
+        ObservationNoiseCovariance::Identity();
+    ObservationNoiseCovariance mag_noise_cov =
+        ObservationNoiseCovariance::Identity();
+
+    // white-noise standard deviations
+    Eigen::Vector3d sigma_omega = Eigen::Vector3d::Zero();
+    Eigen::Vector3d sigma_f = Eigen::Vector3d::Zero();
+    Eigen::Vector3d sigma_beta_omega = Eigen::Vector3d::Zero();
+    Eigen::Vector3d sigma_beta_f = Eigen::Vector3d::Zero();
+    Eigen::Vector3d sigma_beta_m = Eigen::Vector3d::Zero();
+
+    double gravity_constant = 9.81;
+    // local magnetic field in the inertial frame (magnitude sets the units
+    // the magnetometer is expected to report)
+    Eigen::Vector3d mag_reference = Eigen::Vector3d(1.0, 0.0, 0.0);
+
+    // observation gates (<= 0 disables): accel by | ||a|| - g |, mag by
+    // | ||m|| - ||mag_reference|| | (soft iron / interference rejection)
+    double accel_gate_threshold = 0.5;
+    double mag_gate_threshold = 0.2;
+  };
+
+ public:
+  void Initialize(const Params &params);
+
+  // One predict cycle plus gated accelerometer and magnetometer updates.
+  // Returns false and leaves the state untouched on invalid input.
+  bool Update(const ControlInput &gyro_tilde, const Observation &accel_tilde,
+              const Observation &mag_tilde, double dt);
+
+  const Eigen::Quaterniond &GetQuaternion() const { return q_hat_; }
+  const Eigen::Vector3d &GetGyroBias() const { return b_omega_; }
+  const Eigen::Vector3d &GetAccelBias() const { return b_f_; }
+  const Eigen::Vector3d &GetMagBias() const { return b_m_; }
+  const StateCovariance &GetCovariance() const { return P_; }
+
+  bool LastUpdateUsedAccel() const { return last_accel_used_; }
+  bool LastUpdateUsedMag() const { return last_mag_used_; }
+
+ private:
+  ProcessNoiseCovariance GetQMatrix(double dt) const;
+  // one vector-observation update: residual dy against predicted h, with the
+  // attitude block [h]x and the identity block at bias_index; folds + resets
+  void ApplyVectorObservation(const Eigen::Vector3d &delta_y,
+                              const Eigen::Vector3d &h, int bias_index,
+                              const ObservationNoiseCovariance &R);
+
+  StateCovariance P_ = StateCovariance::Identity();
+
+  Params params_;
+  // nominal states
+  Eigen::Quaterniond q_hat_ = Eigen::Quaterniond::Identity();
+  Eigen::Vector3d b_omega_ = Eigen::Vector3d::Zero();
+  Eigen::Vector3d b_f_ = Eigen::Vector3d::Zero();
+  Eigen::Vector3d b_m_ = Eigen::Vector3d::Zero();
+
+  bool last_accel_used_ = false;
+  bool last_mag_used_ = false;
+};
 }  // namespace xmotion
 
 #endif  // XMOTION_MEKF_9_HPP_

--- a/src/estimation/src/mekf9.cpp
+++ b/src/estimation/src/mekf9.cpp
@@ -2,11 +2,158 @@
  * mekf9.cpp
  *
  * Created on 5/7/24 11:08 PM
- * Description:
+ * Description: 18-state error-state MEKF cycle (gyro + accel + mag), per the
+ * derivation in docs/typst/main.typ. Vector observations are processed
+ * sequentially with an error-state fold + reset after each, so the second
+ * observation linearizes about the freshest attitude.
  *
  * Copyright (c) 2024 Ruixiang Du (rdu)
  */
 
 #include "xmnav/estimation/mekf9.hpp"
 
-namespace xmotion {}  // namespace xmotion
+#include <cmath>
+
+#include "xmbase/math/matrix_utils.hpp"
+
+namespace xmotion {
+namespace {
+using MathUtils::SkewSymmetric;
+
+using Mat3 = Eigen::Matrix<double, 3, 3>;
+
+Mat3 DiagSq(const Eigen::Vector3d &sigma) {
+  return sigma.cwiseProduct(sigma).asDiagonal();
+}
+}  // namespace
+
+void Mekf9::Initialize(const Params &params) {
+  params_ = params;
+  q_hat_ = params.init_quaternion.normalized();
+  b_omega_ = params.init_gyro_bias;
+  b_f_ = params.init_accel_bias;
+  b_m_ = params.init_mag_bias;
+  P_ = params.init_state_cov;
+  last_accel_used_ = false;
+  last_mag_used_ = false;
+}
+
+// Discrete process noise per the corrected derivation; the magnetometer bias
+// walk only touches its own diagonal block.
+Mekf9::ProcessNoiseCovariance Mekf9::GetQMatrix(double dt) const {
+  ProcessNoiseCovariance Q = ProcessNoiseCovariance::Zero();
+
+  const Mat3 s_w = DiagSq(params_.sigma_omega);
+  const Mat3 s_f = DiagSq(params_.sigma_f);
+  const Mat3 s_bw = DiagSq(params_.sigma_beta_omega);
+  const Mat3 s_bf = DiagSq(params_.sigma_beta_f);
+  const Mat3 s_bm = DiagSq(params_.sigma_beta_m);
+
+  const double dt2 = dt * dt;
+  const double dt3 = dt2 * dt;
+  const double dt4 = dt3 * dt;
+  const double dt5 = dt4 * dt;
+
+  Q.block<3, 3>(0, 0) = s_w * dt + s_bw * dt3 / 3.0;
+  Q.block<3, 3>(0, 9) = -s_bw * dt2 / 2.0;
+  Q.block<3, 3>(9, 0) = Q.block<3, 3>(0, 9).transpose();
+  Q.block<3, 3>(9, 9) = s_bw * dt;
+
+  Q.block<3, 3>(3, 3) = s_f * dt + s_bf * dt3 / 3.0;
+  Q.block<3, 3>(3, 6) = s_f * dt2 / 2.0 + s_bf * dt4 / 8.0;
+  Q.block<3, 3>(6, 3) = Q.block<3, 3>(3, 6).transpose();
+  Q.block<3, 3>(3, 12) = -s_bf * dt2 / 2.0;
+  Q.block<3, 3>(12, 3) = Q.block<3, 3>(3, 12).transpose();
+  Q.block<3, 3>(6, 6) = s_f * dt3 / 3.0 + s_bf * dt5 / 20.0;
+  Q.block<3, 3>(6, 12) = -s_bf * dt3 / 6.0;
+  Q.block<3, 3>(12, 6) = Q.block<3, 3>(6, 12).transpose();
+  Q.block<3, 3>(12, 12) = s_bf * dt;
+
+  Q.block<3, 3>(15, 15) = s_bm * dt;
+
+  return Q;
+}
+
+void Mekf9::ApplyVectorObservation(const Eigen::Vector3d &delta_y,
+                                   const Eigen::Vector3d &h, int bias_index,
+                                   const ObservationNoiseCovariance &R) {
+  Eigen::Matrix<double, ObservationDimension, StateDimension> H =
+      Eigen::Matrix<double, ObservationDimension, StateDimension>::Zero();
+  H.block<3, 3>(0, 0) = SkewSymmetric(h);
+  H.block<3, 3>(0, bias_index) = Mat3::Identity();
+
+  const Eigen::Matrix<double, ObservationDimension, ObservationDimension> S =
+      H * P_ * H.transpose() + R;
+  const Eigen::Matrix<double, StateDimension, ObservationDimension> K =
+      (S.ldlt().solve(H * P_)).transpose();
+
+  const State x = K * delta_y;  // prior error mean is zero after every reset
+
+  const StateCovariance IKH = StateCovariance::Identity() - K * H;
+  P_ = IKH * P_ * IKH.transpose() + K * R * K.transpose();
+  P_ = 0.5 * (P_ + P_.transpose());
+
+  // fold into the nominal states, reset the error state
+  q_hat_ = q_hat_ * Eigen::Quaterniond(1.0, x(0) / 2.0, x(1) / 2.0, x(2) / 2.0);
+  q_hat_.normalize();
+  b_omega_ += x.segment<3>(9);
+  b_f_ += x.segment<3>(12);
+  b_m_ += x.segment<3>(15);
+}
+
+bool Mekf9::Update(const ControlInput &gyro_tilde,
+                   const Observation &accel_tilde, const Observation &mag_tilde,
+                   double dt) {
+  if (!(dt > 0.0) || !gyro_tilde.allFinite() || !accel_tilde.allFinite() ||
+      !mag_tilde.allFinite()) {
+    return false;
+  }
+
+  const Eigen::Vector3d gyro = gyro_tilde - b_omega_;
+  const Eigen::Vector3d accel = accel_tilde - b_f_;
+  const Eigen::Vector3d mag = mag_tilde - b_m_;
+
+  // --- propagate the nominal attitude ---
+  q_hat_ = Eigen::Quaterniond(
+      q_hat_.coeffs() +
+      0.5 * dt *
+          (q_hat_ * Eigen::Quaterniond(0, gyro(0), gyro(1), gyro(2))).coeffs());
+  q_hat_.normalize();
+
+  // --- propagate the error-state covariance ---
+  const Mat3 C_i_b = q_hat_.toRotationMatrix();
+
+  StateCovariance F = StateCovariance::Zero();
+  F.block<3, 3>(0, 0) = -SkewSymmetric(gyro);
+  F.block<3, 3>(0, 9) = -Mat3::Identity();
+  F.block<3, 3>(3, 0) = -C_i_b * SkewSymmetric(accel);
+  F.block<3, 3>(3, 12) = -C_i_b;
+  F.block<3, 3>(6, 3) = Mat3::Identity();
+
+  const StateCovariance Phi = StateCovariance::Identity() + F * dt;
+  P_ = Phi * P_ * Phi.transpose() + GetQMatrix(dt);
+  P_ = 0.5 * (P_ + P_.transpose());
+
+  // --- gravity observation (gated) ---
+  const Eigen::Vector3d g_i(0.0, 0.0, -params_.gravity_constant);
+  last_accel_used_ =
+      params_.accel_gate_threshold <= 0.0 ||
+      std::abs(accel.norm() - params_.gravity_constant) <=
+          params_.accel_gate_threshold;
+  if (last_accel_used_) {
+    const Eigen::Vector3d h_a = q_hat_.conjugate() * g_i;
+    ApplyVectorObservation(accel - h_a, h_a, 12, params_.accel_noise_cov);
+  }
+
+  // --- magnetometer observation (gated) ---
+  last_mag_used_ = params_.mag_gate_threshold <= 0.0 ||
+                   std::abs(mag.norm() - params_.mag_reference.norm()) <=
+                       params_.mag_gate_threshold;
+  if (last_mag_used_) {
+    const Eigen::Vector3d h_m = q_hat_.conjugate() * params_.mag_reference;
+    ApplyVectorObservation(mag - h_m, h_m, 15, params_.mag_noise_cov);
+  }
+
+  return true;
+}
+}  // namespace xmotion

--- a/src/estimation/test/CMakeLists.txt
+++ b/src/estimation/test/CMakeLists.txt
@@ -1,3 +1,7 @@
 add_executable(test_mekf6 test_mekf6.cpp)
 target_link_libraries(test_mekf6 estimation gtest gtest_main)
 gtest_discover_tests(test_mekf6)
+
+add_executable(test_mekf9 test_mekf9.cpp)
+target_link_libraries(test_mekf9 estimation gtest gtest_main)
+gtest_discover_tests(test_mekf9)

--- a/src/estimation/test/test_mekf9.cpp
+++ b/src/estimation/test/test_mekf9.cpp
@@ -1,0 +1,154 @@
+/*
+ * test_mekf9.cpp
+ *
+ * MEKF9 tests against synthetic 9-DOF truth. With two independent vector
+ * observations (gravity + magnetic field), the full attitude — including
+ * heading — and all three gyro-bias axes are observable, which is exactly
+ * what these tests assert beyond the Mekf6 suite.
+ *
+ * Copyright (c) 2026 Ruixiang Du (rdu)
+ */
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+#include <eigen3/Eigen/Eigenvalues>
+
+#include "xmnav/estimation/mekf9.hpp"
+
+using namespace xmotion;
+
+namespace {
+
+constexpr double kGravity = 9.81;
+const Eigen::Vector3d kMagRef(0.5, 0.0, -0.6);  // north component + dip
+
+Mekf9::Params DefaultParams() {
+  Mekf9::Params p;
+  p.gravity_constant = kGravity;
+  p.mag_reference = kMagRef;
+  p.init_state_cov = Mekf9::StateCovariance::Identity() * 0.1;
+  p.accel_noise_cov = Mekf9::ObservationNoiseCovariance::Identity() * 0.05;
+  p.mag_noise_cov = Mekf9::ObservationNoiseCovariance::Identity() * 0.01;
+  p.sigma_omega = Eigen::Vector3d::Constant(0.01);
+  p.sigma_f = Eigen::Vector3d::Constant(0.05);
+  p.sigma_beta_omega = Eigen::Vector3d::Constant(0.001);
+  p.sigma_beta_f = Eigen::Vector3d::Constant(0.001);
+  p.sigma_beta_m = Eigen::Vector3d::Constant(0.001);
+  return p;
+}
+
+// sensor-clean scenarios state their knowledge as tight bias priors, which
+// resolves the attitude/bias split of constant residuals
+Mekf9::Params CleanSensorParams() {
+  Mekf9::Params p = DefaultParams();
+  p.init_state_cov.block<3, 3>(12, 12) = Eigen::Matrix3d::Identity() * 1e-8;
+  p.init_state_cov.block<3, 3>(15, 15) = Eigen::Matrix3d::Identity() * 1e-8;
+  p.sigma_beta_f = Eigen::Vector3d::Constant(1e-6);
+  p.sigma_beta_m = Eigen::Vector3d::Constant(1e-6);
+  return p;
+}
+
+Eigen::Vector3d GravityReading(const Eigen::Quaterniond& q_true) {
+  return q_true.conjugate() * Eigen::Vector3d(0, 0, -kGravity);
+}
+
+Eigen::Vector3d MagReading(const Eigen::Quaterniond& q_true) {
+  return q_true.conjugate() * kMagRef;
+}
+
+// full attitude error angle (heading included)
+double FullAngleError(const Eigen::Quaterniond& a, const Eigen::Quaterniond& b) {
+  double d = std::min(1.0, std::abs(a.coeffs().dot(b.coeffs())));
+  return 2.0 * std::acos(d);
+}
+
+}  // namespace
+
+TEST(Mekf9Test, FullAttitudeConvergenceIncludingYaw) {
+  // 30 deg yaw + 10 deg roll — yaw is invisible to gravity, visible to mag
+  Eigen::Quaterniond q_true =
+      Eigen::AngleAxisd(30.0 * M_PI / 180.0, Eigen::Vector3d::UnitZ()) *
+      Eigen::AngleAxisd(10.0 * M_PI / 180.0, Eigen::Vector3d::UnitX());
+
+  Mekf9 mekf;
+  mekf.Initialize(CleanSensorParams());
+
+  for (int i = 0; i < 6000; ++i) {
+    ASSERT_TRUE(mekf.Update(Eigen::Vector3d::Zero(), GravityReading(q_true),
+                            MagReading(q_true), 0.01));
+  }
+
+  EXPECT_LT(FullAngleError(mekf.GetQuaternion(), q_true), 0.5 * M_PI / 180.0);
+}
+
+TEST(Mekf9Test, GyroBiasRecoveryAllAxes) {
+  // z-axis gyro bias produces yaw drift — observable only through the mag
+  const Eigen::Vector3d bias(0.02, -0.015, 0.01);
+  const Eigen::Quaterniond q_true = Eigen::Quaterniond::Identity();
+
+  Mekf9 mekf;
+  mekf.Initialize(DefaultParams());
+
+  for (int i = 0; i < 20000; ++i) {
+    ASSERT_TRUE(mekf.Update(bias, GravityReading(q_true), MagReading(q_true),
+                            0.01));
+  }
+
+  for (int a = 0; a < 3; ++a) {
+    EXPECT_NEAR(mekf.GetGyroBias()(a), bias(a), 0.2 * std::abs(bias(a)))
+        << "axis " << a;
+  }
+  EXPECT_LT(FullAngleError(mekf.GetQuaternion(), q_true), 1.0 * M_PI / 180.0);
+}
+
+TEST(Mekf9Test, MagGateRejectsInterference) {
+  const Eigen::Quaterniond q_true = Eigen::Quaterniond::Identity();
+  Mekf9 mekf;
+  mekf.Initialize(DefaultParams());
+  for (int i = 0; i < 1000; ++i) {
+    mekf.Update(Eigen::Vector3d::Zero(), GravityReading(q_true),
+                MagReading(q_true), 0.01);
+  }
+  const Eigen::Quaterniond q_before = mekf.GetQuaternion();
+
+  // hard-iron style disturbance: field magnitude far off the reference
+  const Eigen::Vector3d disturbed = MagReading(q_true) * 2.0;
+  for (int i = 0; i < 500; ++i) {
+    ASSERT_TRUE(mekf.Update(Eigen::Vector3d::Zero(), GravityReading(q_true),
+                            disturbed, 0.01));
+    EXPECT_FALSE(mekf.LastUpdateUsedMag());
+    EXPECT_TRUE(mekf.LastUpdateUsedAccel());
+  }
+  EXPECT_LT(FullAngleError(mekf.GetQuaternion(), q_before),
+            0.1 * M_PI / 180.0);
+}
+
+TEST(Mekf9Test, CovarianceStaysSymmetricPositive) {
+  const Eigen::Quaterniond q_true = Eigen::Quaterniond::Identity();
+  Mekf9 mekf;
+  mekf.Initialize(DefaultParams());
+  for (int i = 0; i < 5000; ++i) {
+    ASSERT_TRUE(mekf.Update(Eigen::Vector3d::Zero(), GravityReading(q_true),
+                            MagReading(q_true), 0.01));
+  }
+  const auto& P = mekf.GetCovariance();
+  ASSERT_TRUE(P.allFinite());
+  EXPECT_LT((P - P.transpose()).norm(), 1e-12);
+  Eigen::SelfAdjointEigenSolver<Mekf9::StateCovariance> es(P);
+  EXPECT_GT(es.eigenvalues().minCoeff(), -1e-12);
+}
+
+TEST(Mekf9Test, RejectsInvalidInput) {
+  Mekf9 mekf;
+  mekf.Initialize(DefaultParams());
+  const Eigen::Quaterniond before = mekf.GetQuaternion();
+  const Eigen::Quaterniond id = Eigen::Quaterniond::Identity();
+
+  EXPECT_FALSE(mekf.Update(Eigen::Vector3d::Zero(), GravityReading(id),
+                           MagReading(id), 0.0));
+  EXPECT_FALSE(mekf.Update(Eigen::Vector3d::Zero(), GravityReading(id),
+                           Eigen::Vector3d(NAN, 0, 0), 0.01));
+  EXPECT_TRUE(before.coeffs().isApprox(mekf.GetQuaternion().coeffs()));
+}


### PR DESCRIPTION
Stacked on #50 (implements against the *corrected* derivation; also shares the test CMakeLists — merge #50 first, this retargets automatically).

Fills the empty `Mekf9` stub with the paper's full 18-error-state model: gravity + magnetic-field vector observations processed **sequentially** (fold + reset between them, so the mag update linearizes about the accel-updated attitude). What the magnetometer buys over Mekf6, and what the tests assert:

- **Heading is observable** — full-attitude convergence including a 30° initial yaw error (gravity alone cannot see yaw)
- **All three gyro-bias axes recover** — z-bias drift is yaw drift, visible only to the mag
- **Hard-iron interference is gated**: mag readings with the wrong field magnitude are rejected without dragging the heading

Same production regime as the corrected Mekf6: symmetric Q_d, Joseph form, gating, validation, bias accumulators, documented conventions (`mag_reference` is the local field in the inertial frame; its magnitude sets the expected sensor units).

## Verification (WERROR on)
Full suite **33/33** · ASan+UBSan **24/24** · all 5 new tests pass.

Follow-up candidates: mag-declination handling helpers, and initial-attitude bootstrap (TRIAD from the first accel+mag pair) — currently the filter converges from identity instead.