### PR TITLE
ci: cancel superseded runs via concurrency groups

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,10 @@ on:
   schedule:
     - cron: '23 5 * * 1'   # weekly, Monday 05:23 UTC
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main, devel ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   BUILD_TYPE: Release
 

--- a/.github/workflows/ros.yml
+++ b/.github/workflows/ros.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ main, devel ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   BUILD_TYPE: Release
 


### PR DESCRIPTION
A new push to the same branch/PR now cancels the in-flight run of the same workflow (`concurrency: group workflow+ref, cancel-in-progress`). Motivation observed live today: the #50-merge devel run kept burning runners for ~9 minutes after the #53 merge had already superseded it. Applied to cpp/ros/codeql — all pure validation workflows; a future release workflow should NOT get this. Same change is worth replicating to xmBase/xmDriver on request.