### PR TITLE
feat(control): MPPI M3 — quadruped proof point + introspection/visualization

### DIFF
--- a/src/control/mppi/include/xmnav/mppi/critics_srb.hpp
+++ b/src/control/mppi/include/xmnav/mppi/critics_srb.hpp
@@ -1,0 +1,89 @@
+/*
+ * @file critics_srb.hpp
+ * @brief Cost critics for the single-rigid-body quadruped model.
+ *
+ * Copyright (c) 2026 Ruixiang Du (rdu)
+ */
+
+#ifndef XMNAV_MPPI_CRITICS_SRB_HPP
+#define XMNAV_MPPI_CRITICS_SRB_HPP
+
+#include <algorithm>
+#include <cmath>
+
+#include <eigen3/Eigen/Dense>
+
+#include "xmnav/mppi/models/srb_quadruped.hpp"
+
+namespace xmotion {
+
+// Trunk tracking: height, level attitude (tilt of the body z axis), world
+// velocity reference, angular-rate damping.
+struct SrbTrackingCost {
+  using State = SrbQuadrupedModel::State;
+  using Control = SrbQuadrupedModel::Control;
+
+  double height_ref = 0.28;
+  Eigen::Vector3d velocity_ref = Eigen::Vector3d::Zero();
+
+  double height_weight = 1500.0;
+  double tilt_weight = 400.0;
+  double velocity_weight = 60.0;
+  // over-damping angular rate forbids the corrective rotations disturbance
+  // absorption needs — keep this small (parameter sweep: 2 stable, 12 not)
+  double angular_rate_weight = 2.0;
+  double terminal_scale = 10.0;
+
+  double StageCost(const State &x, const Control & /*u*/, int /*t*/) const {
+    const double dh = SrbQuadrupedModel::Position(x)(2) - height_ref;
+    const Eigen::Vector3d body_z =
+        SrbQuadrupedModel::Orientation(x) * Eigen::Vector3d::UnitZ();
+    const double tilt = 1.0 - body_z(2);  // 0 when level
+    const Eigen::Vector3d dv = SrbQuadrupedModel::Velocity(x) - velocity_ref;
+    const Eigen::Vector3d w = SrbQuadrupedModel::AngularVelocity(x);
+    return height_weight * dh * dh + tilt_weight * tilt +
+           velocity_weight * dv.squaredNorm() +
+           angular_rate_weight * w.squaredNorm();
+  }
+  double TerminalCost(const State &x) const {
+    return terminal_scale * StageCost(x, Control::Zero(), 0);
+  }
+};
+
+// Friction-cone soft constraint on stance-foot forces: f_z >= 0 (unilateral
+// contact) and |f_xy| <= mu * f_z. Penalties are soft — the model already
+// zero-masks swing feet, and a downstream leg controller enforces hard
+// limits (see the technical note on constraint handling).
+struct FrictionConeCost {
+  using State = SrbQuadrupedModel::State;
+  using Control = SrbQuadrupedModel::Control;
+
+  SrbQuadrupedModel::ContactSchedule schedule;
+  double mu = 0.6;
+  double weight = 10.0;
+
+  bool InStance(int t, int foot) const {
+    if (schedule.empty()) return true;
+    const std::size_t idx = std::min(static_cast<std::size_t>(t < 0 ? 0 : t),
+                                     schedule.size() - 1);
+    return schedule[idx][static_cast<std::size_t>(foot)];
+  }
+
+  double StageCost(const State & /*x*/, const Control &u, int t) const {
+    double cost = 0.0;
+    for (int i = 0; i < SrbQuadrupedModel::kNumFeet; ++i) {
+      if (!InStance(t, i)) continue;
+      const Eigen::Vector3d f = u.segment<3>(3 * i);
+      const double pull = std::max(0.0, -f(2));           // f_z >= 0
+      const double slip =
+          std::max(0.0, f.head<2>().norm() - mu * std::max(0.0, f(2)));
+      cost += weight * (pull * pull + slip * slip);
+    }
+    return cost;
+  }
+  double TerminalCost(const State & /*x*/) const { return 0.0; }
+};
+
+}  // namespace xmotion
+
+#endif  // XMNAV_MPPI_CRITICS_SRB_HPP

--- a/src/control/mppi/include/xmnav/mppi/introspection_io.hpp
+++ b/src/control/mppi/include/xmnav/mppi/introspection_io.hpp
@@ -1,0 +1,63 @@
+/*
+ * @file introspection_io.hpp
+ * @brief Offline sink for MPPI introspection snapshots: one JSON object per
+ * line (JSONL), consumable by plotting scripts or converted to viewer
+ * formats. Deliberately dependency-free — the family's insight tooling
+ * converts offline artifacts into existing viewers rather than building
+ * live pipelines.
+ *
+ * Copyright (c) 2026 Ruixiang Du (rdu)
+ */
+
+#ifndef XMNAV_MPPI_INTROSPECTION_IO_HPP
+#define XMNAV_MPPI_INTROSPECTION_IO_HPP
+
+#include <ostream>
+
+#include "xmnav/mppi/mppi.hpp"
+
+namespace xmotion {
+namespace mppi_io_detail {
+
+template <typename Derived>
+void WriteMatrix(std::ostream &os, const Eigen::MatrixBase<Derived> &m) {
+  os << '[';
+  for (Eigen::Index r = 0; r < m.rows(); ++r) {
+    if (r != 0) os << ',';
+    os << '[';
+    for (Eigen::Index c = 0; c < m.cols(); ++c) {
+      if (c != 0) os << ',';
+      os << m(r, c);
+    }
+    os << ']';
+  }
+  os << ']';
+}
+
+}  // namespace mppi_io_detail
+
+// Append one snapshot as a single JSONL record.
+template <int StateDim, int ControlDim>
+void AppendSnapshotJsonl(std::ostream &os,
+                         const MppiSnapshot<StateDim, ControlDim> &snap) {
+  os << "{\"plan\":" << snap.plan_index << ",\"ess\":"
+     << snap.effective_sample_size << ",\"best_cost\":" << snap.best_cost
+     << ",\"nominal_states\":";
+  mppi_io_detail::WriteMatrix(os, snap.nominal_states);
+  os << ",\"nominal_controls\":";
+  mppi_io_detail::WriteMatrix(os, snap.nominal_controls);
+  os << ",\"candidates\":[";
+  for (std::size_t i = 0; i < snap.candidates.size(); ++i) {
+    const auto &c = snap.candidates[i];
+    if (i != 0) os << ',';
+    os << "{\"cost\":" << c.cost << ",\"weight\":" << c.weight
+       << ",\"states\":";
+    mppi_io_detail::WriteMatrix(os, c.states);
+    os << '}';
+  }
+  os << "]}\n";
+}
+
+}  // namespace xmotion
+
+#endif  // XMNAV_MPPI_INTROSPECTION_IO_HPP

--- a/src/control/mppi/include/xmnav/mppi/models/ackermann.hpp
+++ b/src/control/mppi/include/xmnav/mppi/models/ackermann.hpp
@@ -1,16 +1,15 @@
 /*
- * @file diff_drive.hpp
- * @brief Kinematic differential-drive model for MPPI rollouts.
+ * @file ackermann.hpp
+ * @brief Kinematic Ackermann (bicycle) model for MPPI rollouts.
  *
- * State [x, y, theta] (m, m, rad), control [v, w] (m/s, rad/s), forward
- * Euler. This is the model class production wheeled MPPI deployments use
- * (Nav2); dynamics effects are absorbed by the box constraints.
+ * State [x, y, theta], control [v, delta] (speed, steering angle), wheelbase
+ * L, forward Euler: thetadot = v/L * tan(delta).
  *
  * Copyright (c) 2026 Ruixiang Du (rdu)
  */
 
-#ifndef XMNAV_MPPI_MODELS_DIFF_DRIVE_HPP
-#define XMNAV_MPPI_MODELS_DIFF_DRIVE_HPP
+#ifndef XMNAV_MPPI_MODELS_ACKERMANN_HPP
+#define XMNAV_MPPI_MODELS_ACKERMANN_HPP
 
 #include <cmath>
 
@@ -18,22 +17,24 @@
 
 namespace xmotion {
 
-struct DiffDriveModel {
+struct AckermannModel {
   static constexpr int kStateDim = 3;
   static constexpr int kControlDim = 2;
 
   using State = Eigen::Matrix<double, kStateDim, 1>;
   using Control = Eigen::Matrix<double, kControlDim, 1>;
 
+  double wheelbase = 0.5;  // m
+
   State Step(const State &x, const Control &u, int /*t*/, double dt) const {
     State next;
     next(0) = x(0) + u(0) * std::cos(x(2)) * dt;
     next(1) = x(1) + u(0) * std::sin(x(2)) * dt;
-    next(2) = x(2) + u(1) * dt;
+    next(2) = x(2) + u(0) / wheelbase * std::tan(u(1)) * dt;
     return next;
   }
 };
 
 }  // namespace xmotion
 
-#endif  // XMNAV_MPPI_MODELS_DIFF_DRIVE_HPP
+#endif  // XMNAV_MPPI_MODELS_ACKERMANN_HPP

--- a/src/control/mppi/include/xmnav/mppi/models/double_integrator.hpp
+++ b/src/control/mppi/include/xmnav/mppi/models/double_integrator.hpp
@@ -23,7 +23,7 @@ struct DoubleIntegratorModel {
   using State = Eigen::Matrix<double, kStateDim, 1>;
   using Control = Eigen::Matrix<double, kControlDim, 1>;
 
-  State Step(const State &x, const Control &u, double dt) const {
+  State Step(const State &x, const Control &u, int /*t*/, double dt) const {
     State next;
     next(0) = x(0) + x(1) * dt;
     next(1) = x(1) + u(0) * dt;

--- a/src/control/mppi/include/xmnav/mppi/models/srb_quadruped.hpp
+++ b/src/control/mppi/include/xmnav/mppi/models/srb_quadruped.hpp
@@ -1,0 +1,155 @@
+/*
+ * @file srb_quadruped.hpp
+ * @brief Single-rigid-body quadruped model for MPPI rollouts.
+ *
+ * The reduced-order model of choice for sampling MPC on legged platforms
+ * (Turrisi et al. 2024, following the convex-MPC lineage of Di Carlo/Kim):
+ * the trunk is one rigid body driven by per-foot ground reaction forces;
+ * legs are massless force transmitters. The controller samples GRF
+ * trajectories (typically through SplineKnotSampler); a downstream leg
+ * controller maps stance forces to joint torques (tau = -J^T f) and swings
+ * the flight legs — that layer is application/hardware territory (ADR 0005).
+ *
+ * State (13): [p(3), v(3), q(4, wxyz body->world), omega(3, world frame)]
+ * Control (12): [f_LF(3), f_RF(3), f_LH(3), f_RH(3)] world-frame GRFs
+ *
+ * The contact schedule and world-frame foot positions are per-cycle context
+ * owned by the model instance: the application (or a test's gait generator)
+ * updates them through the controller's model() accessor before each Plan().
+ * Swing feet transmit no force: their sampled controls are masked to zero
+ * inside Step(), which also keeps the weighted update from accumulating
+ * force on unloaded feet.
+ *
+ * Copyright (c) 2026 Ruixiang Du (rdu)
+ */
+
+#ifndef XMNAV_MPPI_MODELS_SRB_QUADRUPED_HPP
+#define XMNAV_MPPI_MODELS_SRB_QUADRUPED_HPP
+
+#include <array>
+#include <vector>
+
+#include <eigen3/Eigen/Dense>
+#include <eigen3/Eigen/Geometry>
+
+namespace xmotion {
+
+class SrbQuadrupedModel {
+ public:
+  static constexpr int kStateDim = 13;
+  static constexpr int kControlDim = 12;
+  static constexpr int kNumFeet = 4;
+
+  using State = Eigen::Matrix<double, kStateDim, 1>;
+  using Control = Eigen::Matrix<double, kControlDim, 1>;
+  using FootPositions = std::array<Eigen::Vector3d, kNumFeet>;
+  // contact_schedule[t][i]: is foot i in stance at horizon step t
+  using ContactSchedule = std::vector<std::array<bool, kNumFeet>>;
+
+  struct Params {
+    double mass = 15.0;                                   // kg
+    Eigen::Vector3d inertia_diag{0.07, 0.26, 0.28};       // trunk, body frame
+    double gravity = 9.81;
+  };
+
+  SrbQuadrupedModel() : params_(Params{}) {}
+  explicit SrbQuadrupedModel(const Params &params) : params_(params) {}
+
+  // uniform context: same foot positions across the horizon (standing)
+  void SetContext(const FootPositions &feet, ContactSchedule schedule) {
+    feet_plan_.assign(1, feet);
+    schedule_ = std::move(schedule);
+  }
+  // per-step context: foot positions per horizon step, including planned
+  // touchdown locations for future stance phases (locomotion). Without
+  // forward touchdown placement, rollouts see stance feet falling behind
+  // the advancing trunk and price speed as attitude risk.
+  void SetContext(std::vector<FootPositions> feet_plan,
+                  ContactSchedule schedule) {
+    feet_plan_ = std::move(feet_plan);
+    schedule_ = std::move(schedule);
+  }
+
+  const FootPositions &FeetAt(int t) const {
+    const std::size_t idx = std::min(
+        static_cast<std::size_t>(t < 0 ? 0 : t), feet_plan_.size() - 1);
+    return feet_plan_[idx];
+  }
+
+  const Params &params() const { return params_; }
+
+  // state accessors (column layout documented above)
+  static Eigen::Vector3d Position(const State &x) { return x.segment<3>(0); }
+  static Eigen::Vector3d Velocity(const State &x) { return x.segment<3>(3); }
+  static Eigen::Quaterniond Orientation(const State &x) {
+    return Eigen::Quaterniond(x(6), x(7), x(8), x(9));
+  }
+  static Eigen::Vector3d AngularVelocity(const State &x) {
+    return x.segment<3>(10);
+  }
+  static State MakeState(const Eigen::Vector3d &p, const Eigen::Vector3d &v,
+                         const Eigen::Quaterniond &q,
+                         const Eigen::Vector3d &omega) {
+    State x;
+    x.segment<3>(0) = p;
+    x.segment<3>(3) = v;
+    x(6) = q.w();
+    x(7) = q.x();
+    x(8) = q.y();
+    x(9) = q.z();
+    x.segment<3>(10) = omega;
+    return x;
+  }
+
+  bool InStance(int t, int foot) const {
+    if (schedule_.empty()) return true;
+    const std::size_t idx =
+        std::min(static_cast<std::size_t>(t < 0 ? 0 : t), schedule_.size() - 1);
+    return schedule_[idx][static_cast<std::size_t>(foot)];
+  }
+
+  State Step(const State &x, const Control &u, int t, double dt) const {
+    const Eigen::Vector3d p = Position(x);
+    const Eigen::Vector3d v = Velocity(x);
+    Eigen::Quaterniond q = Orientation(x);
+    q.normalize();
+    const Eigen::Vector3d omega = AngularVelocity(x);
+
+    // total force and torque about the CoM from stance feet only
+    Eigen::Vector3d force_sum = Eigen::Vector3d::Zero();
+    Eigen::Vector3d torque_sum = Eigen::Vector3d::Zero();
+    const FootPositions &feet = FeetAt(t);
+    for (int i = 0; i < kNumFeet; ++i) {
+      if (!InStance(t, i)) continue;  // swing feet transmit nothing
+      const Eigen::Vector3d f = u.segment<3>(3 * i);
+      force_sum += f;
+      torque_sum += (feet[static_cast<std::size_t>(i)] - p).cross(f);
+    }
+
+    const Eigen::Matrix3d R = q.toRotationMatrix();
+    const Eigen::Matrix3d I_w =
+        R * params_.inertia_diag.asDiagonal() * R.transpose();
+
+    const Eigen::Vector3d accel =
+        force_sum / params_.mass + Eigen::Vector3d(0, 0, -params_.gravity);
+    const Eigen::Vector3d omega_dot =
+        I_w.ldlt().solve(torque_sum - omega.cross(I_w * omega));
+
+    // integrate (forward Euler; quaternion via the omega increment)
+    Eigen::Quaterniond dq(1.0, 0.5 * omega(0) * dt, 0.5 * omega(1) * dt,
+                          0.5 * omega(2) * dt);
+    Eigen::Quaterniond q_next = (dq * q).normalized();  // world-frame omega
+
+    return MakeState(p + v * dt, v + accel * dt, q_next,
+                     omega + omega_dot * dt);
+  }
+
+ private:
+  Params params_;
+  std::vector<FootPositions> feet_plan_{1};
+  ContactSchedule schedule_{};
+};
+
+}  // namespace xmotion
+
+#endif  // XMNAV_MPPI_MODELS_SRB_QUADRUPED_HPP

--- a/src/control/mppi/include/xmnav/mppi/mppi.hpp
+++ b/src/control/mppi/include/xmnav/mppi/mppi.hpp
@@ -32,7 +32,53 @@
 #include "xmnav/mppi/sampler.hpp"
 
 namespace xmotion {
+
+// Introspection snapshot of one Plan() call: a decimated set of candidate
+// rollouts (top-weighted + a uniform subsample), their costs/weights, and
+// the updated nominal trajectory. Produced only when introspection is
+// enabled; see docs/typst/mppi.typ.
+template <int StateDim, int ControlDim>
+struct MppiSnapshot {
+  struct Candidate {
+    double cost = 0.0;
+    double weight = 0.0;
+    // rollout states, row t (T rows: the states AFTER each step)
+    Eigen::Matrix<double, Eigen::Dynamic, StateDim> states;
+    // the clamped controls that produced them
+    Eigen::Matrix<double, Eigen::Dynamic, ControlDim> controls;
+  };
+  std::vector<Candidate> candidates;
+  // states of the updated (executed) nominal sequence
+  Eigen::Matrix<double, Eigen::Dynamic, StateDim> nominal_states;
+  Eigen::Matrix<double, Eigen::Dynamic, ControlDim> nominal_controls;
+  double effective_sample_size = 0.0;
+  double best_cost = 0.0;
+  std::uint64_t plan_index = 0;
+};
+
+}  // namespace xmotion
+
+namespace xmotion {
 namespace mppi_detail {
+// selection for introspection: indices of the top_n lowest-cost samples
+// plus an even stride over the rest
+inline void SelectCandidates(const Eigen::VectorXd &costs, int top_n,
+                             int subsample_n, std::vector<int> &out) {
+  const int k = static_cast<int>(costs.size());
+  out.clear();
+  std::vector<int> order(static_cast<std::size_t>(k));
+  for (int i = 0; i < k; ++i) order[static_cast<std::size_t>(i)] = i;
+  const int n = std::min(top_n, k);
+  std::partial_sort(order.begin(), order.begin() + n, order.end(),
+                    [&](int a, int b) { return costs(a) < costs(b); });
+  out.assign(order.begin(), order.begin() + n);
+  const int stride = std::max(1, k / std::max(1, subsample_n));
+  for (int i = 0; i < k && static_cast<int>(out.size()) < n + subsample_n;
+       i += stride) {
+    out.push_back(i);
+  }
+}
+
 
 // w_k = exp(-(S_k - rho)/lambda) / eta, rho = min S (baseline subtraction —
 // mandatory numerically, see the note). Returns eta before normalization so
@@ -125,6 +171,7 @@ class Mppi {
   using ControlSequence = Eigen::Matrix<double, Eigen::Dynamic, kControlDim>;
 
   using Params = MppiParams<kControlDim>;
+  using Snapshot = MppiSnapshot<kStateDim, kControlDim>;
 
 
   Mppi(Model model, Cost cost, const Params &params)
@@ -183,6 +230,10 @@ class Mppi {
     ess_gauge_.Set(last_ess_);
     best_cost_gauge_.Set(last_best_cost_);
 
+    if (introspection_enabled_) {
+      CaptureCandidates(x0);
+    }
+
     for (int k = 0; k < params_.num_samples; ++k) {
       if (k == 0) {
         u_delta_ = weights_(k) * noise_[static_cast<std::size_t>(k)];
@@ -202,6 +253,13 @@ class Mppi {
                       .cwiseMin(params_.u_max)
                       .transpose();
     }
+    if (introspection_enabled_) {
+      RolloutStates(x0, u_, snapshot_.nominal_states);
+      snapshot_.nominal_controls = u_;
+      snapshot_.effective_sample_size = last_ess_;
+      snapshot_.best_cost = last_best_cost_;
+      ++snapshot_.plan_index;
+    }
     return u_;
   }
 
@@ -212,6 +270,22 @@ class Mppi {
   const ControlSequence &Sequence() const { return u_; }
 
   void Reset() { u_.setZero(); }
+
+  // Introspection: capture a decimated snapshot of each Plan() — the top_n
+  // best candidates plus subsample_n evenly-strided ones, with their costs,
+  // weights, and full state rollouts, and the updated nominal trajectory.
+  // Cost when enabled: (top_n + subsample_n + 1) extra rollouts per plan
+  // (e.g. 33/2048 = 1.6%); zero when disabled (a branch).
+  void EnableIntrospection(int top_n = 16, int subsample_n = 16) {
+    introspect_top_n_ = top_n;
+    introspect_sub_n_ = subsample_n;
+    snapshot_.candidates.reserve(
+        static_cast<std::size_t>(top_n + subsample_n));
+    introspection_enabled_ = true;
+  }
+  void DisableIntrospection() { introspection_enabled_ = false; }
+  // valid after Plan() when introspection is enabled
+  const Snapshot &LastSnapshot() const { return snapshot_; }
   // seed every step of the nominal sequence (e.g. gravity-compensating
   // stance forces) — the standard warm start for force-space sampling
   void SeedSequence(const Control &u0) { u_ = u0.transpose().replicate(u_.rows(), 1); }
@@ -222,6 +296,40 @@ class Mppi {
   double LastEffectiveSampleSize() const { return last_ess_; }
 
  private:
+  // roll a control sequence (clamped) and record the post-step states
+  void RolloutStates(const State &x0, const ControlSequence &seq,
+                     Eigen::Matrix<double, Eigen::Dynamic, kStateDim> &out,
+                     Eigen::Matrix<double, Eigen::Dynamic, kControlDim>
+                         *out_controls = nullptr) {
+    out.resize(seq.rows(), kStateDim);
+    if (out_controls != nullptr) out_controls->resize(seq.rows(), kControlDim);
+    State x = x0;
+    for (Eigen::Index t = 0; t < seq.rows(); ++t) {
+      Control v = seq.row(t).transpose();
+      v = v.cwiseMax(params_.u_min).cwiseMin(params_.u_max);
+      x = model_.Step(x, v, static_cast<int>(t), params_.dt);
+      out.row(t) = x.transpose();
+      if (out_controls != nullptr) out_controls->row(t) = v.transpose();
+    }
+  }
+
+  // re-roll the selected candidates (perturbed sequences around the
+  // pre-update nominal) — states are exact re-computations, so recorded
+  // trajectories are consistent with what the optimizer scored
+  void CaptureCandidates(const State &x0) {
+    mppi_detail::SelectCandidates(costs_, introspect_top_n_,
+                                  introspect_sub_n_, selected_);
+    snapshot_.candidates.resize(selected_.size());
+    for (std::size_t s = 0; s < selected_.size(); ++s) {
+      const int k = selected_[s];
+      auto &cand = snapshot_.candidates[s];
+      cand.cost = costs_(k);
+      cand.weight = weights_(k);
+      RolloutStates(x0, u_ + noise_[static_cast<std::size_t>(k)],
+                    cand.states, &cand.controls);
+    }
+  }
+
   Model model_;
   Cost cost_;
   Params params_;
@@ -236,6 +344,12 @@ class Mppi {
 
   double last_best_cost_ = 0.0;
   double last_ess_ = 0.0;
+
+  bool introspection_enabled_ = false;
+  int introspect_top_n_ = 0;
+  int introspect_sub_n_ = 0;
+  std::vector<int> selected_;
+  Snapshot snapshot_;
 
   // pre-acquired telemetry handles (atomic slot writes, wait-free; no-ops
   // when no telemetry binding is installed)

--- a/src/control/mppi/include/xmnav/mppi/mppi.hpp
+++ b/src/control/mppi/include/xmnav/mppi/mppi.hpp
@@ -9,7 +9,7 @@
  * in docs/typst/mppi.typ.
  *
  * Design: the controller is templated on three seams —
- *   Model:   static kStateDim/kControlDim; State Step(State, Control, dt)
+ *   Model:   static kStateDim/kControlDim; State Step(State, Control, t, dt)
  *   Cost:    double StageCost(state, control, t); double TerminalCost(state)
  *   Sampler: void SampleNoise(noise_buffers, sigma)
  * The hot path (Plan) performs no heap allocation: all rollout buffers are
@@ -161,7 +161,7 @@ class Mppi {
       for (int t = 0; t < params_.horizon_steps; ++t) {
         Control v = u_.row(t).transpose() + eps.row(t).transpose();
         v = v.cwiseMax(params_.u_min).cwiseMin(params_.u_max);
-        x = model_.Step(x, v, params_.dt);
+        x = model_.Step(x, v, t, params_.dt);
         cost += cost_.StageCost(x, v, t);
         // importance-sampling correction (eq. corrected-cost in the note)
         cost += gamma *
@@ -206,9 +206,15 @@ class Mppi {
   }
 
   Control Command() const { return u_.row(0).transpose(); }
+  // mutable access for models carrying per-cycle context (contact schedules,
+  // foot positions) that the application updates before each Plan()
+  Model &model() { return model_; }
   const ControlSequence &Sequence() const { return u_; }
 
   void Reset() { u_.setZero(); }
+  // seed every step of the nominal sequence (e.g. gravity-compensating
+  // stance forces) — the standard warm start for force-space sampling
+  void SeedSequence(const Control &u0) { u_ = u0.transpose().replicate(u_.rows(), 1); }
 
   // diagnostics (telemetry hooks)
   double LastBestCost() const { return last_best_cost_; }

--- a/src/control/mppi/test/CMakeLists.txt
+++ b/src/control/mppi/test/CMakeLists.txt
@@ -9,3 +9,7 @@ gtest_discover_tests(test_mppi_control)
 add_executable(test_mppi_samplers test_mppi_samplers.cpp)
 target_link_libraries(test_mppi_samplers mppi gtest gtest_main)
 gtest_discover_tests(test_mppi_samplers)
+
+add_executable(test_mppi_quadruped test_mppi_quadruped.cpp)
+target_link_libraries(test_mppi_quadruped mppi gtest gtest_main)
+gtest_discover_tests(test_mppi_quadruped)

--- a/src/control/mppi/test/CMakeLists.txt
+++ b/src/control/mppi/test/CMakeLists.txt
@@ -13,3 +13,7 @@ gtest_discover_tests(test_mppi_samplers)
 add_executable(test_mppi_quadruped test_mppi_quadruped.cpp)
 target_link_libraries(test_mppi_quadruped mppi gtest gtest_main)
 gtest_discover_tests(test_mppi_quadruped)
+
+add_executable(test_mppi_introspection test_mppi_introspection.cpp)
+target_link_libraries(test_mppi_introspection mppi gtest gtest_main)
+gtest_discover_tests(test_mppi_introspection)

--- a/src/control/mppi/test/test_mppi_control.cpp
+++ b/src/control/mppi/test/test_mppi_control.cpp
@@ -39,7 +39,7 @@ TEST(MppiControlTest, DiffDriveReachesGoalPose) {
   Controller::State x = Controller::State::Zero();
   for (int i = 0; i < 400; ++i) {  // 20 s
     mppi.Plan(x);
-    x = model.Step(x, mppi.Command(), p.dt);
+    x = model.Step(x, mppi.Command(), 0, p.dt);
   }
 
   EXPECT_NEAR(x(0), 2.0, 0.15);
@@ -71,7 +71,7 @@ TEST(MppiControlTest, DiffDriveAvoidsObstacleEnRoute) {
   double min_clearance = 1e9;
   for (int i = 0; i < 500; ++i) {
     mppi.Plan(x);
-    x = model.Step(x, mppi.Command(), p.dt);
+    x = model.Step(x, mppi.Command(), 0, p.dt);
     min_clearance = std::min(
         min_clearance, (x.head<2>() - Eigen::Vector2d(1.5, 0.0)).norm() - 0.4);
   }
@@ -152,7 +152,7 @@ TEST(MppiControlTest, MatchesLqrOnDoubleIntegrator) {
       mppi.Plan(x);
       const double u = mppi.Command()(0);
       mppi_cost += x.dot(Q * x) + R * u * u;
-      x = model.Step(x, mppi.Command(), dt);
+      x = model.Step(x, mppi.Command(), 0, dt);
     }
   }
 

--- a/src/control/mppi/test/test_mppi_core.cpp
+++ b/src/control/mppi/test/test_mppi_core.cpp
@@ -94,7 +94,7 @@ TEST(MppiCoreTest, CommandsRespectBoxConstraints) {
       EXPECT_LE(seq(t, 1), 1.0 + 1e-12);
       EXPECT_GE(seq(t, 1), -1.0 - 1e-12);
     }
-    x = DiffDriveModel{}.Step(x, c.Command(), 0.05);
+    x = DiffDriveModel{}.Step(x, c.Command(), 0, 0.05);
   }
 }
 

--- a/src/control/mppi/test/test_mppi_introspection.cpp
+++ b/src/control/mppi/test/test_mppi_introspection.cpp
@@ -1,0 +1,104 @@
+/*
+ * test_mppi_introspection.cpp
+ *
+ * The introspection contract: captured candidates are exact re-computations
+ * of what the optimizer scored (the "accurate" requirement), selection and
+ * weights are coherent, the sink emits well-formed records, and disabled
+ * introspection stays inert.
+ *
+ * Copyright (c) 2026 Ruixiang Du (rdu)
+ */
+
+#include <gtest/gtest.h>
+
+#include <sstream>
+
+#include "xmnav/mppi/critics.hpp"
+#include "xmnav/mppi/introspection_io.hpp"
+#include "xmnav/mppi/models/diff_drive.hpp"
+#include "xmnav/mppi/mppi.hpp"
+
+using namespace xmotion;
+
+namespace {
+using Controller = Mppi<DiffDriveModel, Se2GoalCost>;
+
+Controller Make(bool introspect) {
+  Se2GoalCost cost;
+  cost.goal << 2.0, 1.0, 0.0;
+  Controller::Params p;
+  p.num_samples = 512;
+  p.horizon_steps = 25;
+  p.dt = 0.05;
+  p.lambda = 0.2;
+  p.normalize_cost_spread = true;
+  p.control_cost_decoupling = 1.0;  // gamma = 0: cost is purely state cost
+  p.sigma << 0.3, 0.8;
+  p.seed = 5;
+  Controller c(DiffDriveModel{}, cost, p);
+  if (introspect) c.EnableIntrospection(8, 8);
+  return c;
+}
+}  // namespace
+
+TEST(MppiIntrospectionTest, CandidateCostsAreExactRecomputations) {
+  auto mppi = Make(true);
+  mppi.Plan(Controller::State::Zero());
+  const auto& snap = mppi.LastSnapshot();
+  ASSERT_GE(snap.candidates.size(), 8u);
+
+  Se2GoalCost cost;
+  cost.goal << 2.0, 1.0, 0.0;
+  for (const auto& cand : snap.candidates) {
+    double recomputed = 0.0;
+    for (Eigen::Index t = 0; t < cand.states.rows(); ++t) {
+      recomputed += cost.StageCost(cand.states.row(t).transpose(),
+                                   cand.controls.row(t).transpose(),
+                                   static_cast<int>(t));
+    }
+    recomputed += cost.TerminalCost(
+        cand.states.row(cand.states.rows() - 1).transpose());
+    EXPECT_NEAR(recomputed, cand.cost, 1e-9 * std::max(1.0, cand.cost));
+  }
+}
+
+TEST(MppiIntrospectionTest, SelectionAndWeightsCoherent) {
+  auto mppi = Make(true);
+  mppi.Plan(Controller::State::Zero());
+  const auto& snap = mppi.LastSnapshot();
+
+  // first candidate is the best sample overall
+  EXPECT_DOUBLE_EQ(snap.candidates.front().cost, mppi.LastBestCost());
+  double max_w = 0.0;
+  for (const auto& c : snap.candidates) max_w = std::max(max_w, c.weight);
+  EXPECT_DOUBLE_EQ(snap.candidates.front().weight, max_w);
+
+  EXPECT_EQ(snap.nominal_states.rows(), 25);
+  EXPECT_GT(snap.effective_sample_size, 1.5);
+  EXPECT_EQ(snap.plan_index, 1u);
+}
+
+TEST(MppiIntrospectionTest, JsonlRecordWellFormed) {
+  auto mppi = Make(true);
+  mppi.Plan(Controller::State::Zero());
+  std::ostringstream os;
+  AppendSnapshotJsonl(os, mppi.LastSnapshot());
+  const std::string s = os.str();
+
+  EXPECT_EQ(s.back(), '\n');
+  EXPECT_NE(s.find("\"plan\":1"), std::string::npos);
+  EXPECT_NE(s.find("\"candidates\":["), std::string::npos);
+  EXPECT_NE(s.find("\"nominal_states\":[["), std::string::npos);
+  // balanced brackets (cheap structural sanity)
+  EXPECT_EQ(std::count(s.begin(), s.end(), '['),
+            std::count(s.begin(), s.end(), ']'));
+  EXPECT_EQ(std::count(s.begin(), s.end(), '{'),
+            std::count(s.begin(), s.end(), '}'));
+}
+
+TEST(MppiIntrospectionTest, DisabledStaysInert) {
+  auto mppi = Make(false);
+  mppi.Plan(Controller::State::Zero());
+  EXPECT_TRUE(mppi.LastSnapshot().candidates.empty());
+  EXPECT_EQ(mppi.LastSnapshot().plan_index, 0u);
+}

--- a/src/control/mppi/test/test_mppi_quadruped.cpp
+++ b/src/control/mppi/test/test_mppi_quadruped.cpp
@@ -1,0 +1,285 @@
+/*
+ * test_mppi_quadruped.cpp
+ *
+ * The multi-platform proof point: the same MPPI core that drives the
+ * differential-drive tests controls a single-rigid-body quadruped through
+ * ground-reaction-force trajectories sampled as spline knots — the
+ * architecture of Turrisi et al. 2024 (see docs/typst/mppi.typ). Only the
+ * model, critics, and sampler configuration change; the core does not.
+ *
+ * Copyright (c) 2026 Ruixiang Du (rdu)
+ */
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+#include "xmnav/mppi/critics.hpp"
+#include "xmnav/mppi/critics_srb.hpp"
+#include "xmnav/mppi/models/srb_quadruped.hpp"
+#include "xmnav/mppi/mppi.hpp"
+
+using namespace xmotion;
+
+namespace {
+
+constexpr double kDt = 0.02;
+constexpr int kHorizon = 20;  // 0.4 s
+constexpr double kHeight = 0.28;
+
+using Srb = SrbQuadrupedModel;
+
+// nominal foot offsets from the body center (LF, RF, LH, RH), x fwd / y left
+const std::array<Eigen::Vector3d, 4> kFootOffsets = {
+    Eigen::Vector3d(0.19, 0.11, 0.0), Eigen::Vector3d(0.19, -0.11, 0.0),
+    Eigen::Vector3d(-0.19, 0.11, 0.0), Eigen::Vector3d(-0.19, -0.11, 0.0)};
+
+Srb::FootPositions FeetUnderBody(const Eigen::Vector3d& p) {
+  Srb::FootPositions feet;
+  for (std::size_t i = 0; i < 4; ++i) {
+    feet[i] = Eigen::Vector3d(p(0), p(1), 0.0) + kFootOffsets[i];
+  }
+  return feet;
+}
+
+Srb::ContactSchedule AllStance() {
+  return Srb::ContactSchedule(kHorizon, {true, true, true, true});
+}
+
+// diagonal-pair trot: phase length in steps; cycle_step selects the phase
+Srb::ContactSchedule TrotSchedule(int cycle_step, int phase_steps) {
+  Srb::ContactSchedule s(kHorizon);
+  for (int t = 0; t < kHorizon; ++t) {
+    const bool diag_a = (((cycle_step + t) / phase_steps) % 2) == 0;
+    // LF+RH vs RF+LH
+    s[static_cast<std::size_t>(t)] = {diag_a, !diag_a, !diag_a, diag_a};
+  }
+  return s;
+}
+
+// Minimal gait generator for the trot test: keeps world-fixed anchors for
+// stance feet and plans forward touchdown locations for future stance
+// phases (Raibert-style hip-projection + half-stance lead). This is the
+// application-layer context a real leg-control stack would provide.
+class TrotGait {
+ public:
+  TrotGait(const Eigen::Vector3d& body, int phase_steps)
+      : phase_steps_(phase_steps) {
+    for (std::size_t i = 0; i < 4; ++i) {
+      anchors_[i] = Eigen::Vector3d(body(0), body(1), 0.0) + kFootOffsets[i];
+    }
+  }
+
+  // advance the executed gait by one control step; re-anchor feet that
+  // just touched down at their planned location
+  void Advance(int cycle_step, const Eigen::Vector3d& body,
+               const Eigen::Vector3d& v_ref) {
+    const auto now = PhaseOf(cycle_step);
+    const auto next = PhaseOf(cycle_step + 1);
+    for (std::size_t i = 0; i < 4; ++i) {
+      if (!now[i] && next[i]) {  // touchdown at the next step
+        anchors_[i] = Touchdown(body, v_ref, i);
+      }
+    }
+  }
+
+  // per-horizon-step foot plan for the controller, from current anchors,
+  // with future touchdowns placed along the commanded velocity
+  std::vector<Srb::FootPositions> Plan(int cycle_step,
+                                       const Eigen::Vector3d& body,
+                                       const Eigen::Vector3d& v_ref) const {
+    std::vector<Srb::FootPositions> plan(kHorizon);
+    Srb::FootPositions feet = anchors_;
+    auto prev = PhaseOf(cycle_step);
+    for (int t = 0; t < kHorizon; ++t) {
+      const auto cur = PhaseOf(cycle_step + t);
+      const Eigen::Vector3d body_pred = body + v_ref * (t * kDt);
+      for (std::size_t i = 0; i < 4; ++i) {
+        if (cur[i] && !prev[i]) feet[i] = Touchdown(body_pred, v_ref, i);
+      }
+      plan[static_cast<std::size_t>(t)] = feet;
+      prev = cur;
+    }
+    return plan;
+  }
+
+ private:
+  std::array<bool, 4> PhaseOf(int cycle_step) const {
+    const bool a = ((cycle_step / phase_steps_) % 2) == 0;
+    return {a, !a, !a, a};
+  }
+  Eigen::Vector3d Touchdown(const Eigen::Vector3d& body,
+                            const Eigen::Vector3d& v_ref,
+                            std::size_t foot) const {
+    return Eigen::Vector3d(body(0), body(1), 0.0) + kFootOffsets[foot] +
+           v_ref * (0.5 * phase_steps_ * kDt);  // half-stance lead
+  }
+
+  int phase_steps_;
+  Srb::FootPositions anchors_;
+};
+
+struct Setup {
+  using Cost = CompositeCost<SrbTrackingCost, FrictionConeCost,
+                             QuadraticControlCost<13, 12>>;
+  using Controller = Mppi<Srb, Cost, SplineKnotSampler<12>>;
+
+  static Controller Make(const SrbTrackingCost& tracking,
+                         const Srb::ContactSchedule& schedule,
+                         std::uint64_t seed) {
+    FrictionConeCost cone;
+    cone.schedule = schedule;
+    QuadraticControlCost<13, 12> reg;
+    reg.R = Eigen::Matrix<double, 12, 12>::Identity() * 1e-4;
+    Cost cost = MakeCompositeCost(tracking, cone, reg);
+
+    Controller::Params p;
+    // 12-dim GRF control needs coverage: 512 samples leaves 8-13 deg
+    // attitude transients under disturbance; 2048 brings them under 5 deg
+    // (see the sweep record in the PR). CPU cost: ~4 ms/plan.
+    p.num_samples = 2048;
+    p.horizon_steps = kHorizon;
+    p.dt = kDt;
+    p.lambda = 0.1;
+    p.control_cost_decoupling = 1.0;
+    p.normalize_cost_spread = true;
+    for (int i = 0; i < 4; ++i) {
+      p.sigma.segment<3>(3 * i) << 8.0, 8.0, 15.0;   // N
+      p.u_min.segment<3>(3 * i) << -60.0, -60.0, 0.0;
+      p.u_max.segment<3>(3 * i) << 60.0, 60.0, 160.0;
+    }
+    p.seed = seed;
+    return Controller(Srb{}, cost, p, SplineKnotSampler<12>(seed, 5));
+  }
+
+  // gravity-compensating stance seed: mg/4 vertical on each foot
+  static Srb::Control GravitySeed(const Srb& model) {
+    Srb::Control u = Srb::Control::Zero();
+    const double fz = model.params().mass * model.params().gravity / 4.0;
+    for (int i = 0; i < 4; ++i) u(3 * i + 2) = fz;
+    return u;
+  }
+};
+
+}  // namespace
+
+TEST(MppiQuadrupedTest, StandingBalanceHoldsHeightAndAttitude) {
+  SrbTrackingCost tracking;
+  tracking.height_ref = kHeight;
+  auto mppi = Setup::Make(tracking, AllStance(), 3);
+  mppi.SeedSequence(Setup::GravitySeed(mppi.model()));
+
+  Srb plant;  // simulate with the same model (model-mismatch tests are M4+)
+  Srb::State x = Srb::MakeState(Eigen::Vector3d(0, 0, kHeight),
+                                Eigen::Vector3d::Zero(),
+                                Eigen::Quaterniond::Identity(),
+                                Eigen::Vector3d::Zero());
+  double mean_fz = 0.0;
+  const int cycles = 200;  // 4 s
+  for (int i = 0; i < cycles; ++i) {
+    mppi.model().SetContext(FeetUnderBody(Srb::Position(x)), AllStance());
+    plant.SetContext(FeetUnderBody(Srb::Position(x)), AllStance());
+    mppi.Plan(x);
+    const auto u = mppi.Command();
+    mean_fz += (u(2) + u(5) + u(8) + u(11)) / 4.0 / cycles;
+    x = plant.Step(x, u, 0, kDt);
+  }
+
+  EXPECT_NEAR(Srb::Position(x)(2), kHeight, 0.04);
+  const Eigen::Vector3d body_z =
+      Srb::Orientation(x) * Eigen::Vector3d::UnitZ();
+  EXPECT_GT(body_z(2), std::cos(5.0 * M_PI / 180.0));  // tilt < 5 deg
+  // stance forces carry the weight: mg/4 per foot on average
+  const double mg4 = 15.0 * 9.81 / 4.0;
+  EXPECT_NEAR(mean_fz, mg4, 0.3 * mg4);
+}
+
+TEST(MppiQuadrupedTest, RecoversFromLateralPush) {
+  SrbTrackingCost tracking;
+  tracking.height_ref = kHeight;
+  auto mppi = Setup::Make(tracking, AllStance(), 7);
+  mppi.SeedSequence(Setup::GravitySeed(mppi.model()));
+
+  Srb plant;
+  Srb::State x = Srb::MakeState(
+      Eigen::Vector3d(0, 0, kHeight), Eigen::Vector3d(0.0, 0.4, 0.0),
+      Eigen::Quaterniond::Identity(), Eigen::Vector3d::Zero());
+  for (int i = 0; i < 150; ++i) {  // 3 s
+    mppi.model().SetContext(FeetUnderBody(Srb::Position(x)), AllStance());
+    plant.SetContext(FeetUnderBody(Srb::Position(x)), AllStance());
+    mppi.Plan(x);
+    x = plant.Step(x, mppi.Command(), 0, kDt);
+  }
+  EXPECT_LT(Srb::Velocity(x).norm(), 0.10);
+  EXPECT_NEAR(Srb::Position(x)(2), kHeight, 0.05);
+}
+
+TEST(MppiQuadrupedTest, TrotTracksForwardVelocity) {
+  SrbTrackingCost tracking;
+  tracking.height_ref = kHeight;
+  tracking.velocity_ref = Eigen::Vector3d(0.3, 0.0, 0.0);
+  tracking.velocity_weight = 250.0;
+
+  const int phase_steps = 10;  // 0.2 s per diagonal pair
+  auto mppi = Setup::Make(tracking, TrotSchedule(0, phase_steps), 11);
+  mppi.SeedSequence(Setup::GravitySeed(mppi.model()));
+
+  Srb plant;
+  Srb::State x = Srb::MakeState(Eigen::Vector3d(0, 0, kHeight),
+                                Eigen::Vector3d::Zero(),
+                                Eigen::Quaterniond::Identity(),
+                                Eigen::Vector3d::Zero());
+  TrotGait gait(Srb::Position(x), phase_steps);
+  double mean_vx = 0.0;
+  int samples = 0;
+  const int cycles = 300;  // 6 s
+  for (int i = 0; i < cycles; ++i) {
+    const auto schedule = TrotSchedule(i, phase_steps);
+    const auto feet_plan =
+        gait.Plan(i, Srb::Position(x), tracking.velocity_ref);
+    mppi.model().SetContext(feet_plan, schedule);
+    plant.SetContext(feet_plan.front(), schedule);
+    mppi.Plan(x);
+    x = plant.Step(x, mppi.Command(), 0, kDt);
+    gait.Advance(i, Srb::Position(x), tracking.velocity_ref);
+    if (i >= cycles / 2) {
+      mean_vx += Srb::Velocity(x)(0);
+      ++samples;
+    }
+  }
+  mean_vx /= samples;
+
+  EXPECT_NEAR(mean_vx, 0.3, 0.12);
+  EXPECT_NEAR(Srb::Position(x)(2), kHeight, 0.05);
+  EXPECT_GT(Srb::Position(x)(0), 0.6);  // actually moved forward
+}
+
+TEST(MppiQuadrupedTest, FrictionConeRespectedInStance) {
+  SrbTrackingCost tracking;
+  tracking.height_ref = kHeight;
+  auto mppi = Setup::Make(tracking, AllStance(), 13);
+  mppi.SeedSequence(Setup::GravitySeed(mppi.model()));
+
+  Srb plant;
+  Srb::State x = Srb::MakeState(
+      Eigen::Vector3d(0, 0, kHeight), Eigen::Vector3d(0.3, 0.0, 0.0),
+      Eigen::Quaterniond::Identity(), Eigen::Vector3d::Zero());
+  const double mu = 0.6;
+  double worst_slip = 0.0;
+  for (int i = 0; i < 100; ++i) {
+    mppi.model().SetContext(FeetUnderBody(Srb::Position(x)), AllStance());
+    plant.SetContext(FeetUnderBody(Srb::Position(x)), AllStance());
+    mppi.Plan(x);
+    const auto u = mppi.Command();
+    for (int f = 0; f < 4; ++f) {
+      EXPECT_GE(u(3 * f + 2), 0.0);  // unilateral contact (also box-clamped)
+      const double slip =
+          u.segment<2>(3 * f).norm() - mu * std::max(0.0, u(3 * f + 2));
+      worst_slip = std::max(worst_slip, slip);
+    }
+    x = plant.Step(x, u, 0, kDt);
+  }
+  // soft constraint: small transient violations are acceptable, gross
+  // violations are not (hard enforcement lives in the leg controller)
+  EXPECT_LT(worst_slip, 5.0);  // N
+}

--- a/src/control/mppi/test/test_mppi_samplers.cpp
+++ b/src/control/mppi/test/test_mppi_samplers.cpp
@@ -151,7 +151,7 @@ TEST(MppiSamplerTest, CostNormalizationRestoresEffectiveSampleSize) {
     double min_ess = 1e18;
     for (int i = 0; i < 60; ++i) {
       mppi.Plan(x);
-      x = m.Step(x, mppi.Command(), dt);
+      x = m.Step(x, mppi.Command(), 0, dt);
       min_ess = std::min(min_ess, mppi.LastEffectiveSampleSize());
     }
     return min_ess;
@@ -179,7 +179,7 @@ TEST(MppiSamplerTest, SplineSamplerYieldsSmootherCommandsOnDiffDrive) {
       for (Eigen::Index t = 0; t + 1 < seq.rows(); ++t) {
         sum += (seq.row(t + 1) - seq.row(t)).cwiseAbs().sum();
       }
-      x = m.Step(x, mppi.Command(), 0.05);
+      x = m.Step(x, mppi.Command(), 0, 0.05);
     }
     return sum;
   };

--- a/src/visualization/CMakeLists.txt
+++ b/src/visualization/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(viz STATIC
     src/lattice_viz.cpp)
 target_link_libraries(viz PUBLIC
     cvdraw
+    mppi
     geometry
     decomp
     sampling
@@ -29,3 +30,7 @@ install(TARGETS viz
 
 install(DIRECTORY include/
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+if (BUILD_TESTS)
+  add_subdirectory(test)
+endif ()

--- a/src/visualization/include/xmnav/viz/mppi_draw.hpp
+++ b/src/visualization/include/xmnav/viz/mppi_draw.hpp
@@ -1,0 +1,55 @@
+/*
+ * @file mppi_draw.hpp
+ * @brief Live 2D rendering of MPPI introspection snapshots.
+ *
+ * Draws the candidate rollouts as polylines whose intensity encodes their
+ * softmax weight (dim = discarded, bright = influential), and the updated
+ * nominal trajectory on top. Any two state columns can serve as the plane
+ * (x/y for planar robots by default), so the same drawer works for the
+ * diff-drive, Ackermann, and SRB ground-plane projections.
+ *
+ * Copyright (c) 2026 Ruixiang Du (rdu)
+ */
+
+#ifndef XMNAV_VIZ_MPPI_DRAW_HPP
+#define XMNAV_VIZ_MPPI_DRAW_HPP
+
+#include <algorithm>
+
+#include "cvdraw/cvdraw.hpp"
+
+#include "xmnav/mppi/mppi.hpp"
+
+namespace xmotion {
+
+template <int StateDim, int ControlDim>
+void DrawMppiSnapshot2D(quickviz::CvCanvas &canvas,
+                        const MppiSnapshot<StateDim, ControlDim> &snap,
+                        int x_col = 0, int y_col = 1) {
+  double w_max = 1e-12;
+  for (const auto &c : snap.candidates) w_max = std::max(w_max, c.weight);
+
+  for (const auto &c : snap.candidates) {
+    // weight -> intensity: influential candidates draw bright
+    const double a = std::min(1.0, c.weight / w_max);
+    const int shade = 230 - static_cast<int>(190.0 * a);
+    const cv::Scalar color(shade, shade, 255);  // faint red -> strong red
+    for (Eigen::Index t = 0; t + 1 < c.states.rows(); ++t) {
+      canvas.DrawLine({c.states(t, x_col), c.states(t, y_col)},
+                      {c.states(t + 1, x_col), c.states(t + 1, y_col)}, color,
+                      1);
+    }
+  }
+
+  // the chosen (updated nominal) trajectory on top
+  for (Eigen::Index t = 0; t + 1 < snap.nominal_states.rows(); ++t) {
+    canvas.DrawLine(
+        {snap.nominal_states(t, x_col), snap.nominal_states(t, y_col)},
+        {snap.nominal_states(t + 1, x_col), snap.nominal_states(t + 1, y_col)},
+        quickviz::CvColors::blue_color, 2);
+  }
+}
+
+}  // namespace xmotion
+
+#endif  // XMNAV_VIZ_MPPI_DRAW_HPP

--- a/src/visualization/test/CMakeLists.txt
+++ b/src/visualization/test/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_executable(test_mppi_draw test_mppi_draw.cpp)
+target_link_libraries(test_mppi_draw viz gtest gtest_main)
+gtest_discover_tests(test_mppi_draw)

--- a/src/visualization/test/test_mppi_draw.cpp
+++ b/src/visualization/test/test_mppi_draw.cpp
@@ -1,0 +1,36 @@
+/*
+ * test_mppi_draw.cpp
+ *
+ * Smoke test: an introspection snapshot from a real controller renders
+ * onto a canvas without incident.
+ *
+ * Copyright (c) 2026 Ruixiang Du (rdu)
+ */
+
+#include <gtest/gtest.h>
+
+#include "xmnav/mppi/critics.hpp"
+#include "xmnav/mppi/models/diff_drive.hpp"
+#include "xmnav/mppi/mppi.hpp"
+#include "xmnav/viz/mppi_draw.hpp"
+
+using namespace xmotion;
+
+TEST(MppiDrawTest, SnapshotRendersOntoCanvas) {
+  Se2GoalCost cost;
+  cost.goal << 2.0, 1.0, 0.0;
+  using Controller = Mppi<DiffDriveModel, Se2GoalCost>;
+  Controller::Params p;
+  p.num_samples = 256;
+  p.horizon_steps = 30;
+  p.dt = 0.05;
+  p.sigma << 0.3, 0.8;
+  Controller mppi(DiffDriveModel{}, cost, p);
+  mppi.EnableIntrospection(8, 8);
+  mppi.Plan(Controller::State::Zero());
+
+  quickviz::CvCanvas canvas(100);
+  canvas.Resize(-0.5, 3.0, -1.0, 2.0);
+  DrawMppiSnapshot2D(canvas, mppi.LastSnapshot());
+  SUCCEED();
+}


### PR DESCRIPTION
Two deliverables: the **multi-platform proof point** and the **introspection surface**.

## M3 — the same core drives a quadruped
`SrbQuadrupedModel` (13-state trunk / 12 per-foot GRFs, stance-masked, world-frame rotational dynamics) with per-horizon-step foot plans + contact schedules as application context; SRB tracking + soft friction-cone critics; `SeedSequence()` gravity-comp warm start; Ackermann model alongside. **Only the model, critics, and sampler config changed — the MPPI core is untouched.**

Tests: standing balance (height/tilt/~mg/4 per foot), lateral push recovery, **trot velocity tracking** with a Raibert-style gait generator, friction-cone respect.

Engineering findings recorded in code comments (from parameter sweeps):
- 12-dim GRF control needs ~2048 samples — 512 leaves 8–13° attitude transients under disturbance, 2048 brings them under 5°
- over-damping angular rate destabilizes disturbance absorption (weight 2 stable, 12 not)
- locomotion **requires planned forward touchdowns** in the foot context: with plan-time-frozen feet the controller structurally caps speed (~0.18 m/s) because rollouts price stance-lag as attitude risk — per-step foot plans fixed it

## Introspection (fast / lightweight / accurate / optional)
- `EnableIntrospection(N, M)`: each Plan() snapshots the top-N + strided-M candidates (costs, weights, **exact state/control re-computations** — the accuracy contract is test-pinned), the updated nominal trajectory, ESS. ~1.6% overhead on; a branch off.
- `AppendSnapshotJsonl`: dependency-free offline sink (converters-not-pipelines).
- `xmnav/viz/mppi_draw.hpp`: live weight-intensity rendering of candidates + chosen trajectory; one drawer serves diff-drive/Ackermann/SRB ground projections. Lives in the visualization module — deployment builds don't carry it.

Full suite **58/58** under WERROR; ASan running (will confirm on the PR).