### PR TITLE
test(control): scale MPPI workloads for sanitizer/Debug builds

### DIFF
--- a/src/control/mppi/test/test_mppi_control.cpp
+++ b/src/control/mppi/test/test_mppi_control.cpp
@@ -20,13 +20,25 @@
 
 using namespace xmotion;
 
+namespace {
+// Reduced scale under sanitizer/Debug builds: exercise the code paths, keep
+// the numerical convergence assertions in Release where they are validated.
+#if !defined(NDEBUG) || defined(__SANITIZE_ADDRESS__) || \
+    defined(__SANITIZE_THREAD__)
+constexpr bool kReducedScale = true;
+#else
+constexpr bool kReducedScale = false;
+#endif
+}  // namespace
+
+
 TEST(MppiControlTest, DiffDriveReachesGoalPose) {
   Se2GoalCost cost;
   cost.goal << 2.0, 1.0, M_PI / 2.0;
 
   using Controller = Mppi<DiffDriveModel, Se2GoalCost>;
   Controller::Params p;
-  p.num_samples = 1024;
+  p.num_samples = kReducedScale ? 128 : 1024;
   p.horizon_steps = 40;
   p.dt = 0.05;
   p.lambda = 0.3;
@@ -37,14 +49,18 @@ TEST(MppiControlTest, DiffDriveReachesGoalPose) {
 
   DiffDriveModel model;
   Controller::State x = Controller::State::Zero();
-  for (int i = 0; i < 400; ++i) {  // 20 s
+  for (int i = 0; i < (kReducedScale ? 30 : 400); ++i) {  // 20 s in Release
     mppi.Plan(x);
     x = model.Step(x, mppi.Command(), 0, p.dt);
   }
 
-  EXPECT_NEAR(x(0), 2.0, 0.15);
-  EXPECT_NEAR(x(1), 1.0, 0.15);
-  EXPECT_LT(std::abs(std::remainder(x(2) - M_PI / 2.0, 2.0 * M_PI)), 0.3);
+  if (!kReducedScale) {
+    EXPECT_NEAR(x(0), 2.0, 0.15);
+    EXPECT_NEAR(x(1), 1.0, 0.15);
+    EXPECT_LT(std::abs(std::remainder(x(2) - M_PI / 2.0, 2.0 * M_PI)), 0.3);
+  } else {
+    EXPECT_TRUE(x.allFinite());
+  }
 }
 
 TEST(MppiControlTest, DiffDriveAvoidsObstacleEnRoute) {
@@ -57,7 +73,7 @@ TEST(MppiControlTest, DiffDriveAvoidsObstacleEnRoute) {
   auto cost = MakeCompositeCost(goal_cost, obstacle_cost);
   using Controller = Mppi<DiffDriveModel, decltype(cost)>;
   Controller::Params p;
-  p.num_samples = 1024;
+  p.num_samples = kReducedScale ? 128 : 1024;
   p.horizon_steps = 50;
   p.dt = 0.05;
   p.lambda = 0.3;
@@ -69,7 +85,7 @@ TEST(MppiControlTest, DiffDriveAvoidsObstacleEnRoute) {
   DiffDriveModel model;
   Controller::State x = Controller::State::Zero();
   double min_clearance = 1e9;
-  for (int i = 0; i < 500; ++i) {
+  for (int i = 0; i < (kReducedScale ? 30 : 500); ++i) {
     mppi.Plan(x);
     x = model.Step(x, mppi.Command(), 0, p.dt);
     min_clearance = std::min(
@@ -77,8 +93,10 @@ TEST(MppiControlTest, DiffDriveAvoidsObstacleEnRoute) {
   }
 
   EXPECT_GT(min_clearance, 0.0) << "executed path entered the obstacle";
-  EXPECT_NEAR(x(0), 3.0, 0.2);
-  EXPECT_NEAR(x(1), 0.0, 0.2);
+  if (!kReducedScale) {
+    EXPECT_NEAR(x(0), 3.0, 0.2);
+    EXPECT_NEAR(x(1), 0.0, 0.2);
+  }
 }
 
 namespace {
@@ -134,7 +152,7 @@ TEST(MppiControlTest, MatchesLqrOnDoubleIntegrator) {
 
   using Controller = Mppi<DoubleIntegratorModel, decltype(cost)>;
   Controller::Params p;
-  p.num_samples = 2048;
+  p.num_samples = kReducedScale ? 128 : 2048;
   p.horizon_steps = 40;
   p.dt = dt;
   // operating point from the parameter sweep: lambda must be scaled to the
@@ -148,7 +166,7 @@ TEST(MppiControlTest, MatchesLqrOnDoubleIntegrator) {
   double mppi_cost = 0.0;
   {
     Controller::State x = x0;
-    for (int i = 0; i < 120; ++i) {
+    for (int i = 0; i < (kReducedScale ? 20 : 120); ++i) {
       mppi.Plan(x);
       const double u = mppi.Command()(0);
       mppi_cost += x.dot(Q * x) + R * u * u;
@@ -156,8 +174,12 @@ TEST(MppiControlTest, MatchesLqrOnDoubleIntegrator) {
     }
   }
 
-  // sampling-based control approaches but cannot beat the analytic optimum
-  EXPECT_GT(mppi_cost, 0.95 * lqr_cost);
-  EXPECT_LT(mppi_cost, 1.25 * lqr_cost)
-      << "MPPI closed-loop cost " << mppi_cost << " vs LQR " << lqr_cost;
+  if (!kReducedScale) {
+    // sampling-based control approaches but cannot beat the analytic optimum
+    EXPECT_GT(mppi_cost, 0.95 * lqr_cost);
+    EXPECT_LT(mppi_cost, 1.25 * lqr_cost)
+        << "MPPI closed-loop cost " << mppi_cost << " vs LQR " << lqr_cost;
+  } else {
+    EXPECT_TRUE(std::isfinite(mppi_cost));
+  }
 }

--- a/src/control/mppi/test/test_mppi_quadruped.cpp
+++ b/src/control/mppi/test/test_mppi_quadruped.cpp
@@ -23,6 +23,18 @@ using namespace xmotion;
 
 namespace {
 
+// Sanitizer/Debug builds exercise the code paths for memory errors but run
+// the physics at reduced scale: full convergence workloads (12M rollout
+// steps) take 100-200x longer under ASan and add nothing to what the
+// Release suite already asserts numerically.
+#if !defined(NDEBUG) || defined(__SANITIZE_ADDRESS__) ||     defined(__SANITIZE_THREAD__)
+constexpr bool kReducedScale = true;
+#else
+constexpr bool kReducedScale = false;
+#endif
+constexpr int kSamples = kReducedScale ? 128 : 2048;
+inline int Cycles(int full) { return kReducedScale ? 20 : full; }
+
 constexpr double kDt = 0.02;
 constexpr int kHorizon = 20;  // 0.4 s
 constexpr double kHeight = 0.28;
@@ -137,7 +149,7 @@ struct Setup {
     // 12-dim GRF control needs coverage: 512 samples leaves 8-13 deg
     // attitude transients under disturbance; 2048 brings them under 5 deg
     // (see the sweep record in the PR). CPU cost: ~4 ms/plan.
-    p.num_samples = 2048;
+    p.num_samples = kSamples;
     p.horizon_steps = kHorizon;
     p.dt = kDt;
     p.lambda = 0.1;
@@ -175,7 +187,7 @@ TEST(MppiQuadrupedTest, StandingBalanceHoldsHeightAndAttitude) {
                                 Eigen::Quaterniond::Identity(),
                                 Eigen::Vector3d::Zero());
   double mean_fz = 0.0;
-  const int cycles = 200;  // 4 s
+  const int cycles = Cycles(200);  // 4 s in Release
   for (int i = 0; i < cycles; ++i) {
     mppi.model().SetContext(FeetUnderBody(Srb::Position(x)), AllStance());
     plant.SetContext(FeetUnderBody(Srb::Position(x)), AllStance());
@@ -185,13 +197,18 @@ TEST(MppiQuadrupedTest, StandingBalanceHoldsHeightAndAttitude) {
     x = plant.Step(x, u, 0, kDt);
   }
 
-  EXPECT_NEAR(Srb::Position(x)(2), kHeight, 0.04);
-  const Eigen::Vector3d body_z =
-      Srb::Orientation(x) * Eigen::Vector3d::UnitZ();
-  EXPECT_GT(body_z(2), std::cos(5.0 * M_PI / 180.0));  // tilt < 5 deg
-  // stance forces carry the weight: mg/4 per foot on average
-  const double mg4 = 15.0 * 9.81 / 4.0;
-  EXPECT_NEAR(mean_fz, mg4, 0.3 * mg4);
+  if (!kReducedScale) {
+    EXPECT_NEAR(Srb::Position(x)(2), kHeight, 0.04);
+    const Eigen::Vector3d body_z =
+        Srb::Orientation(x) * Eigen::Vector3d::UnitZ();
+    EXPECT_GT(body_z(2), std::cos(5.0 * M_PI / 180.0));  // tilt < 5 deg
+    // stance forces carry the weight: mg/4 per foot on average
+    const double mg4 = 15.0 * 9.81 / 4.0;
+    EXPECT_NEAR(mean_fz, mg4, 0.3 * mg4);
+  } else {
+    (void)mean_fz;
+    EXPECT_TRUE(x.allFinite());
+  }
 }
 
 TEST(MppiQuadrupedTest, RecoversFromLateralPush) {
@@ -204,14 +221,18 @@ TEST(MppiQuadrupedTest, RecoversFromLateralPush) {
   Srb::State x = Srb::MakeState(
       Eigen::Vector3d(0, 0, kHeight), Eigen::Vector3d(0.0, 0.4, 0.0),
       Eigen::Quaterniond::Identity(), Eigen::Vector3d::Zero());
-  for (int i = 0; i < 150; ++i) {  // 3 s
+  for (int i = 0; i < Cycles(150); ++i) {  // 3 s in Release
     mppi.model().SetContext(FeetUnderBody(Srb::Position(x)), AllStance());
     plant.SetContext(FeetUnderBody(Srb::Position(x)), AllStance());
     mppi.Plan(x);
     x = plant.Step(x, mppi.Command(), 0, kDt);
   }
-  EXPECT_LT(Srb::Velocity(x).norm(), 0.10);
-  EXPECT_NEAR(Srb::Position(x)(2), kHeight, 0.05);
+  if (!kReducedScale) {
+    EXPECT_LT(Srb::Velocity(x).norm(), 0.10);
+    EXPECT_NEAR(Srb::Position(x)(2), kHeight, 0.05);
+  } else {
+    EXPECT_TRUE(x.allFinite());
+  }
 }
 
 TEST(MppiQuadrupedTest, TrotTracksForwardVelocity) {
@@ -232,7 +253,7 @@ TEST(MppiQuadrupedTest, TrotTracksForwardVelocity) {
   TrotGait gait(Srb::Position(x), phase_steps);
   double mean_vx = 0.0;
   int samples = 0;
-  const int cycles = 300;  // 6 s
+  const int cycles = Cycles(300);  // 6 s in Release
   for (int i = 0; i < cycles; ++i) {
     const auto schedule = TrotSchedule(i, phase_steps);
     const auto feet_plan =
@@ -249,9 +270,14 @@ TEST(MppiQuadrupedTest, TrotTracksForwardVelocity) {
   }
   mean_vx /= samples;
 
-  EXPECT_NEAR(mean_vx, 0.3, 0.12);
-  EXPECT_NEAR(Srb::Position(x)(2), kHeight, 0.05);
-  EXPECT_GT(Srb::Position(x)(0), 0.6);  // actually moved forward
+  if (!kReducedScale) {
+    EXPECT_NEAR(mean_vx, 0.3, 0.12);
+    EXPECT_NEAR(Srb::Position(x)(2), kHeight, 0.05);
+    EXPECT_GT(Srb::Position(x)(0), 0.6);  // actually moved forward
+  } else {
+    (void)mean_vx;
+    EXPECT_TRUE(x.allFinite());
+  }
 }
 
 TEST(MppiQuadrupedTest, FrictionConeRespectedInStance) {
@@ -266,7 +292,7 @@ TEST(MppiQuadrupedTest, FrictionConeRespectedInStance) {
       Eigen::Quaterniond::Identity(), Eigen::Vector3d::Zero());
   const double mu = 0.6;
   double worst_slip = 0.0;
-  for (int i = 0; i < 100; ++i) {
+  for (int i = 0; i < Cycles(100); ++i) {
     mppi.model().SetContext(FeetUnderBody(Srb::Position(x)), AllStance());
     plant.SetContext(FeetUnderBody(Srb::Position(x)), AllStance());
     mppi.Plan(x);

--- a/src/control/mppi/test/test_mppi_samplers.cpp
+++ b/src/control/mppi/test/test_mppi_samplers.cpp
@@ -20,6 +20,18 @@
 using namespace xmotion;
 
 namespace {
+// Reduced scale under sanitizer/Debug builds: exercise the code paths, keep
+// the numerical convergence assertions in Release where they are validated.
+#if !defined(NDEBUG) || defined(__SANITIZE_ADDRESS__) || \
+    defined(__SANITIZE_THREAD__)
+constexpr bool kReducedScale = true;
+#else
+constexpr bool kReducedScale = false;
+#endif
+}  // namespace
+
+
+namespace {
 template <typename Sampler>
 std::vector<Eigen::Matrix<double, Eigen::Dynamic, 1>> Draw(Sampler& sampler,
                                                            int k, int t) {
@@ -149,7 +161,7 @@ TEST(MppiSamplerTest, CostNormalizationRestoresEffectiveSampleSize) {
     DoubleIntegratorModel m;
     C::State x(1.0, 0.0);
     double min_ess = 1e18;
-    for (int i = 0; i < 60; ++i) {
+    for (int i = 0; i < (kReducedScale ? 15 : 60); ++i) {
       mppi.Plan(x);
       x = m.Step(x, mppi.Command(), 0, dt);
       min_ess = std::min(min_ess, mppi.LastEffectiveSampleSize());
@@ -157,8 +169,12 @@ TEST(MppiSamplerTest, CostNormalizationRestoresEffectiveSampleSize) {
     return min_ess;
   };
 
-  EXPECT_LT(run(false), 3.0);    // raw: weight collapse
-  EXPECT_GT(run(true), 20.0);    // normalized: healthy sample utilization
+  if (!kReducedScale) {
+    EXPECT_LT(run(false), 3.0);  // raw: weight collapse
+    EXPECT_GT(run(true), 20.0);  // normalized: healthy sample utilization
+  } else {
+    EXPECT_GT(run(true), run(false));
+  }
 }
 
 TEST(MppiSamplerTest, SplineSamplerYieldsSmootherCommandsOnDiffDrive) {
@@ -174,7 +190,7 @@ TEST(MppiSamplerTest, SplineSamplerYieldsSmootherCommandsOnDiffDrive) {
     typename std::decay_t<decltype(mppi)>::State x =
         std::decay_t<decltype(mppi)>::State::Zero();
     double sum = 0.0;
-    for (int i = 0; i < 200; ++i) {
+    for (int i = 0; i < (kReducedScale ? 20 : 200); ++i) {
       const auto& seq = mppi.Plan(x);
       for (Eigen::Index t = 0; t + 1 < seq.rows(); ++t) {
         sum += (seq.row(t + 1) - seq.row(t)).cwiseAbs().sum();
@@ -199,7 +215,11 @@ TEST(MppiSamplerTest, SplineSamplerYieldsSmootherCommandsOnDiffDrive) {
   Gauss gauss(DiffDriveModel{}, goal, p);
   Spline spline(DiffDriveModel{}, goal, p, SplineKnotSampler<2>(21, 8));
 
-  EXPECT_LT(roughness(spline), 0.7 * roughness(gauss));
+  if (!kReducedScale) {
+    EXPECT_LT(roughness(spline), 0.7 * roughness(gauss));
+  } else {
+    EXPECT_LT(roughness(spline), roughness(gauss));
+  }
 }
 
 TEST(MppiSamplerTest, SingleCorePerformanceEnvelope) {


### PR DESCRIPTION
Fixes the stuck sanitizers lane: the MPPI behavioral suites run Release-sized convergence workloads (12–20M rollout steps) that take 100–200× longer under ASan+Debug — the lane burned 55 minutes before cancellation on #55's run and will do the same on devel's post-merge run. Sanitizer builds now run reduced scale (128 samples, short loops, finiteness assertions) — they exercise every code path for memory errors, which is their job — while numerical convergence assertions remain Release-only. Same policy as the existing performance-envelope skip. Verified: Release full suite unchanged (58/58); ASan MPPI subset 24/24.