### PR TITLE
feat(simulation): headless sim loop + visual inspection tier

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ supporting tiers:
 | `src/control`        | control laws & models (PID, FSM, dynamics models, kinematics)      |
 | `src/types`          | shared navigation-stack vocabulary (the inter-area contract types) |
 | `src/visualization`  | drawing for all of the above — the only module linking a renderer  |
+| `src/simulation`     | deterministic sim loop for algorithm development (headless + visual) |
 
 Supporting folders: `cmake` (build configuration), `data` (test fixtures: maps, lookup tables),
 `docs` (documentation), `python` (analysis scripts), `third_party` (vendored dependencies —

--- a/docs/LESSONS.md
+++ b/docs/LESSONS.md
@@ -16,3 +16,8 @@ Recorded per the self-improvement loop: concrete mistakes and the corrections th
 - **Pattern:** PR #47 (delete `controller_interface.hpp`) and PR #48 (rename `common/` → `types/`) were open concurrently; #48 branched before #47 merged, so its `git mv` carried the file to the new path and git's rename-vs-delete resolution silently resurrected it after both merges.
 - **Correction:** PRs touching overlapping paths must be stacked (later branched on the earlier) or serialized (second opened only after the first merges). After merging concurrent PRs, verify the composed tree matches both intents — git only guarantees textual, not semantic, composition.
 - **Context:** git merge semantics; multi-PR workflows in the XMotion family.
+
+### Release-sized workloads do not belong in sanitizer builds
+- **Pattern:** MPPI behavioral tests ran full convergence workloads (12–20M rollout steps) in every build configuration; under ASan+Debug they take 100–200× longer — the CI sanitizers lane burned 55 minutes before cancellation and local runs appeared hung. Earlier the same day, a wall-clock performance assertion failed under ASan for the same reason.
+- **Correction:** Sanitizer/Debug builds run reduced-scale workloads with finiteness assertions (they exist to catch memory errors on every code path); numerical convergence and timing assertions stay Release-only where they were validated. Gate with `!defined(NDEBUG) || __SANITIZE_ADDRESS__/__SANITIZE_THREAD__`.
+- **Context:** C++ test suites with heavy numerical closed loops; CI sanitizer lanes.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,6 +6,7 @@ add_subdirectory(decision)
 add_subdirectory(estimation)
 add_subdirectory(control)
 add_subdirectory(planning)
+add_subdirectory(simulation)
 
 if (ENABLE_VISUALIZATION)
   add_subdirectory(visualization)

--- a/src/simulation/CMakeLists.txt
+++ b/src/simulation/CMakeLists.txt
@@ -1,0 +1,30 @@
+## Dependency libraries
+find_package(Eigen3 REQUIRED NO_MODULE)
+
+## Headless simulation support for algorithm development (deterministic
+## fixed-step loop + recording). Header-only; the visual viewer lives in
+## the visualization module and attaches through the observer callback.
+add_library(sim INTERFACE)
+target_link_libraries(sim INTERFACE Eigen3::Eigen)
+target_include_directories(sim INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>)
+add_library(xmotion::sim ALIAS sim)
+
+if (BUILD_TESTS)
+  add_subdirectory(test)
+endif ()
+
+if (ENABLE_VISUALIZATION)
+  add_subdirectory(demos)
+endif ()
+
+install(TARGETS sim
+    EXPORT xmNavigationTargets
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+    RUNTIME DESTINATION bin
+    INCLUDES DESTINATION include)
+
+install(DIRECTORY include/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/src/simulation/demos/CMakeLists.txt
+++ b/src/simulation/demos/CMakeLists.txt
@@ -1,0 +1,6 @@
+# Inspection demos (visual; not ctest-registered — they open windows)
+add_executable(demo_mppi_diffdrive demo_mppi_diffdrive.cpp)
+target_link_libraries(demo_mppi_diffdrive sim mppi viz)
+
+add_executable(demo_srb_quadruped demo_srb_quadruped.cpp)
+target_link_libraries(demo_srb_quadruped sim mppi viz)

--- a/src/simulation/demos/demo_mppi_diffdrive.cpp
+++ b/src/simulation/demos/demo_mppi_diffdrive.cpp
@@ -1,0 +1,82 @@
+/*
+ * demo_mppi_diffdrive.cpp
+ *
+ * Live inspection of the MPPI controller on a differential-drive robot:
+ * candidate rollouts drawn with weight-encoded intensity, the chosen
+ * trajectory in blue, obstacles and goal in the world frame.
+ *
+ * Run from the repo root; press any key per frame if frame_period_ms = 0,
+ * Esc/close-window semantics follow OpenCV.
+ *
+ * Copyright (c) 2026 Ruixiang Du (rdu)
+ */
+
+#include <cstdio>
+
+#include "xmnav/mppi/critics.hpp"
+#include "xmnav/mppi/models/diff_drive.hpp"
+#include "xmnav/mppi/mppi.hpp"
+#include "xmnav/sim/sim_loop.hpp"
+#include "xmnav/viz/mppi_draw.hpp"
+#include "xmnav/viz/sim_viewer.hpp"
+
+using namespace xmotion;
+
+int main() {
+  Se2GoalCost goal_cost;
+  goal_cost.goal << 3.5, 1.0, 0.0;
+  CircularObstacleCost obstacle_cost;
+  obstacle_cost.obstacles.push_back({Eigen::Vector2d(1.5, 0.2), 0.4});
+  obstacle_cost.obstacles.push_back({Eigen::Vector2d(2.6, 1.1), 0.3});
+
+  auto cost = MakeCompositeCost(goal_cost, obstacle_cost);
+  using Controller = Mppi<DiffDriveModel, decltype(cost)>;
+  Controller::Params p;
+  p.num_samples = 1024;
+  p.horizon_steps = 50;
+  p.dt = 0.05;
+  p.lambda = 0.3;
+  p.sigma << 0.3, 0.8;
+  p.u_min << -0.8, -2.0;
+  p.u_max << 0.8, 2.0;
+  p.normalize_cost_spread = true;
+  Controller mppi(DiffDriveModel{}, cost, p);
+  mppi.EnableIntrospection(24, 24);
+
+  SimViewer2D::Config vc;
+  vc.x_min = -0.5;
+  vc.x_max = 4.5;
+  vc.y_min = -1.0;
+  vc.y_max = 2.0;
+  SimViewer2D viewer(vc);
+  for (const auto &ob : obstacle_cost.obstacles) {
+    viewer.AddObstacle(ob.center, ob.radius);
+  }
+  viewer.SetGoal(goal_cost.goal.head<2>());
+  viewer.AddOverlay([&](quickviz::CvCanvas &canvas) {
+    DrawMppiSnapshot2D(canvas, mppi.LastSnapshot());
+  });
+
+  SimLoop<DiffDriveModel>::Config cfg;
+  cfg.dt = 0.05;
+  cfg.steps = 400;
+  cfg.process_noise << 0.002, 0.002, 0.004;
+  SimLoop<DiffDriveModel> sim(DiffDriveModel{}, cfg);
+
+  sim.Run(
+      DiffDriveModel::State::Zero(),
+      [&](const DiffDriveModel::State &z, int) {
+        mppi.Plan(z);
+        return mppi.Command();
+      },
+      nullptr,
+      [&](const DiffDriveModel::State &x, const DiffDriveModel::Control &,
+          int t) {
+        viewer.Frame(x(0), x(1));
+        if (t % 50 == 0) {
+          std::printf("t=%5.1fs  ESS=%5.0f  best=%.1f\n", t * cfg.dt,
+                      mppi.LastEffectiveSampleSize(), mppi.LastBestCost());
+        }
+      });
+  return 0;
+}

--- a/src/simulation/demos/demo_srb_quadruped.cpp
+++ b/src/simulation/demos/demo_srb_quadruped.cpp
@@ -1,0 +1,124 @@
+/*
+ * demo_srb_quadruped.cpp
+ *
+ * Ground-plane view of the SRB quadruped trotting under MPPI GRF control:
+ * candidate trunk trajectories with weight intensity, the executed trail,
+ * and the current stance feet.
+ *
+ * Copyright (c) 2026 Ruixiang Du (rdu)
+ */
+
+#include <cstdio>
+
+#include "xmnav/mppi/critics.hpp"
+#include "xmnav/mppi/critics_srb.hpp"
+#include "xmnav/mppi/models/srb_quadruped.hpp"
+#include "xmnav/mppi/mppi.hpp"
+#include "xmnav/sim/sim_loop.hpp"
+#include "xmnav/viz/mppi_draw.hpp"
+#include "xmnav/viz/sim_viewer.hpp"
+
+using namespace xmotion;
+using Srb = SrbQuadrupedModel;
+
+namespace {
+const std::array<Eigen::Vector3d, 4> kOffsets = {
+    Eigen::Vector3d(0.19, 0.11, 0.0), Eigen::Vector3d(0.19, -0.11, 0.0),
+    Eigen::Vector3d(-0.19, 0.11, 0.0), Eigen::Vector3d(-0.19, -0.11, 0.0)};
+constexpr int kHorizon = 20;
+constexpr double kDt = 0.02;
+constexpr int kPhase = 10;
+
+std::array<bool, 4> PhaseOf(int step) {
+  const bool a = ((step / kPhase) % 2) == 0;
+  return {a, !a, !a, a};
+}
+Srb::ContactSchedule Schedule(int step) {
+  Srb::ContactSchedule s(kHorizon);
+  for (int t = 0; t < kHorizon; ++t) s[t] = PhaseOf(step + t);
+  return s;
+}
+}  // namespace
+
+int main() {
+  SrbTrackingCost tracking;
+  tracking.height_ref = 0.28;
+  tracking.velocity_ref = Eigen::Vector3d(0.3, 0.0, 0.0);
+  tracking.velocity_weight = 250.0;
+  FrictionConeCost cone;
+  QuadraticControlCost<13, 12> reg;
+  reg.R = Eigen::Matrix<double, 12, 12>::Identity() * 1e-4;
+  auto cost = MakeCompositeCost(tracking, cone, reg);
+
+  using Controller = Mppi<Srb, decltype(cost), SplineKnotSampler<12>>;
+  Controller::Params p;
+  p.num_samples = 2048;
+  p.horizon_steps = kHorizon;
+  p.dt = kDt;
+  p.lambda = 0.1;
+  p.control_cost_decoupling = 1.0;
+  p.normalize_cost_spread = true;
+  for (int i = 0; i < 4; ++i) {
+    p.sigma.segment<3>(3 * i) << 8.0, 8.0, 15.0;
+    p.u_min.segment<3>(3 * i) << -60.0, -60.0, 0.0;
+    p.u_max.segment<3>(3 * i) << 60.0, 60.0, 160.0;
+  }
+  Controller mppi(Srb{}, cost, p, SplineKnotSampler<12>(11, 5));
+  Srb::Control seed = Srb::Control::Zero();
+  for (int i = 0; i < 4; ++i) seed(3 * i + 2) = 15.0 * 9.81 / 4.0;
+  mppi.SeedSequence(seed);
+  mppi.EnableIntrospection(16, 16);
+
+  SimViewer2D::Config vc;
+  vc.x_min = -0.5;
+  vc.x_max = 3.5;
+  vc.y_min = -1.0;
+  vc.y_max = 1.0;
+  vc.window_name = "srb quadruped (ground plane)";
+  SimViewer2D viewer(vc);
+  Srb::FootPositions feet;
+  std::array<bool, 4> stance{};
+  viewer.AddOverlay([&](quickviz::CvCanvas &canvas) {
+    DrawMppiSnapshot2D(canvas, mppi.LastSnapshot());
+    for (int i = 0; i < 4; ++i) {
+      canvas.DrawPoint({feet[i](0), feet[i](1)}, stance[i] ? 4 : 2,
+                       stance[i] ? quickviz::CvColors::black_color
+                                 : quickviz::CvColors::gray_color);
+    }
+  });
+
+  Srb plant;
+  Srb::State x = Srb::MakeState({0, 0, 0.28}, {0, 0, 0},
+                                Eigen::Quaterniond::Identity(), {0, 0, 0});
+  for (std::size_t i = 0; i < 4; ++i) {
+    feet[i] = Eigen::Vector3d(0, 0, 0) + kOffsets[i];
+  }
+
+  for (int i = 0; i < 500; ++i) {
+    const auto sch = Schedule(i);
+    stance = PhaseOf(i);
+    // simple gait context: touchdown at hip projection + half-stance lead
+    const auto now = PhaseOf(i);
+    const auto next = PhaseOf(i + 1);
+    for (std::size_t f = 0; f < 4; ++f) {
+      if (!now[f] && next[f]) {
+        feet[f] = Eigen::Vector3d(Srb::Position(x)(0), Srb::Position(x)(1),
+                                  0.0) +
+                  kOffsets[f] +
+                  tracking.velocity_ref * (0.5 * kPhase * kDt);
+      }
+    }
+    std::vector<Srb::FootPositions> plan(kHorizon, feet);
+    mppi.model().SetContext(plan, sch);
+    plant.SetContext(feet, sch);
+    mppi.Plan(x);
+    x = plant.Step(x, mppi.Command(), 0, kDt);
+    viewer.Frame(Srb::Position(x)(0), Srb::Position(x)(1));
+    if (i % 50 == 0) {
+      std::printf("t=%4.1fs  v=%.2f m/s  h=%.3f m  ESS=%.0f\n", i * kDt,
+                  Srb::Velocity(x)(0), Srb::Position(x)(2),
+                  mppi.LastEffectiveSampleSize());
+    }
+  }
+  return 0;
+}

--- a/src/simulation/include/xmnav/sim/sim_log.hpp
+++ b/src/simulation/include/xmnav/sim/sim_log.hpp
@@ -1,0 +1,82 @@
+/*
+ * @file sim_log.hpp
+ * @brief Preallocated recording of a simulation run + JSONL export.
+ *
+ * Copyright (c) 2026 Ruixiang Du (rdu)
+ */
+
+#ifndef XMNAV_SIM_SIM_LOG_HPP
+#define XMNAV_SIM_SIM_LOG_HPP
+
+#include <ostream>
+
+#include <eigen3/Eigen/Dense>
+
+namespace xmotion {
+
+class SimLog {
+ public:
+  void Reset(int steps, int state_dim, int control_dim) {
+    time_.resize(steps);
+    states_.resize(steps, state_dim);
+    measurements_.resize(steps, state_dim);
+    controls_.resize(steps, control_dim);
+    count_ = 0;
+  }
+
+  template <typename S, typename C>
+  void Append(double t, const S &x, const S &z, const C &u) {
+    time_(count_) = t;
+    states_.row(count_) = x.transpose();
+    measurements_.row(count_) = z.transpose();
+    controls_.row(count_) = u.transpose();
+    ++count_;
+  }
+
+  int size() const { return count_; }
+  double time(int i) const { return time_(i); }
+  Eigen::VectorXd state(int i) const {
+    return states_.row(i).transpose();
+  }
+  Eigen::VectorXd control(int i) const {
+    return controls_.row(i).transpose();
+  }
+  const Eigen::MatrixXd &states() const { return states_; }
+  const Eigen::MatrixXd &controls() const { return controls_; }
+
+  // one JSON object per run
+  void WriteJsonl(std::ostream &os) const {
+    auto write = [&](const Eigen::MatrixXd &m) {
+      os << '[';
+      for (int r = 0; r < count_; ++r) {
+        if (r != 0) os << ',';
+        os << '[';
+        for (Eigen::Index c = 0; c < m.cols(); ++c) {
+          if (c != 0) os << ',';
+          os << m(r, c);
+        }
+        os << ']';
+      }
+      os << ']';
+    };
+    os << "{\"dt\":" << (count_ > 1 ? time_(1) - time_(0) : 0.0)
+       << ",\"states\":";
+    write(states_);
+    os << ",\"measurements\":";
+    write(measurements_);
+    os << ",\"controls\":";
+    write(controls_);
+    os << "}\n";
+  }
+
+ private:
+  Eigen::VectorXd time_;
+  Eigen::MatrixXd states_;
+  Eigen::MatrixXd measurements_;
+  Eigen::MatrixXd controls_;
+  int count_ = 0;
+};
+
+}  // namespace xmotion
+
+#endif  // XMNAV_SIM_SIM_LOG_HPP

--- a/src/simulation/include/xmnav/sim/sim_loop.hpp
+++ b/src/simulation/include/xmnav/sim/sim_loop.hpp
@@ -1,0 +1,102 @@
+/*
+ * @file sim_loop.hpp
+ * @brief Deterministic fixed-step simulation loop for algorithm development.
+ *
+ * The plant reuses the controller Model concept (Step(x, u, t, dt) with
+ * compile-time dims) — the same model types serve as rollout models and as
+ * truth plants, and the plant may deliberately differ from the model an
+ * algorithm plans with (model-mismatch studies). Headless by design: this
+ * header has no visualization dependencies; the viz-gated SimViewer2D
+ * attaches through the observer callback.
+ *
+ * Determinism: fixed step, seeded noise, no wall-clock anywhere.
+ *
+ * Copyright (c) 2026 Ruixiang Du (rdu)
+ */
+
+#ifndef XMNAV_SIM_SIM_LOOP_HPP
+#define XMNAV_SIM_SIM_LOOP_HPP
+
+#include <cstdint>
+#include <functional>
+#include <random>
+
+#include <eigen3/Eigen/Dense>
+
+#include "xmnav/sim/sim_log.hpp"
+
+namespace xmotion {
+
+template <typename Plant>
+class SimLoop {
+ public:
+  static constexpr int kStateDim = Plant::kStateDim;
+  static constexpr int kControlDim = Plant::kControlDim;
+
+  using State = Eigen::Matrix<double, kStateDim, 1>;
+  using Control = Eigen::Matrix<double, kControlDim, 1>;
+
+  struct Config {
+    double dt = 0.02;
+    int steps = 500;
+    std::uint64_t seed = 0;
+    // per-channel std-dev of additive noise (zero = off)
+    State process_noise = State::Zero();
+    State measurement_noise = State::Zero();
+  };
+
+  // the algorithm under test: receives the (noisy) measured state and the
+  // step index, returns the control to execute
+  using Agent = std::function<Control(const State &, int)>;
+  // observer: called after every executed step with (true state, control,
+  // step index); the visual viewer attaches here, tests can assert here
+  using Observer = std::function<void(const State &, const Control &, int)>;
+
+  SimLoop(Plant plant, const Config &config)
+      : plant_(std::move(plant)), config_(config), rng_(config.seed) {}
+
+  Plant &plant() { return plant_; }
+  const Config &config() const { return config_; }
+
+  // run the scenario; returns the final true state. The log (optional)
+  // records the true state, measurement, and control per step.
+  State Run(const State &x0, const Agent &agent, SimLog *log = nullptr,
+            const Observer &observer = {}) {
+    if (log != nullptr) {
+      log->Reset(config_.steps, kStateDim, kControlDim);
+    }
+    State x = x0;
+    for (int t = 0; t < config_.steps; ++t) {
+      const State z = x + Noise(config_.measurement_noise);
+      const Control u = agent(z, t);
+      x = plant_.Step(x, u, t, config_.dt);
+      x += Noise(config_.process_noise);
+      if (log != nullptr) {
+        log->Append(t * config_.dt, x, z, u);
+      }
+      if (observer) {
+        observer(x, u, t);
+      }
+    }
+    return x;
+  }
+
+ private:
+  State Noise(const State &sigma) {
+    if (sigma.isZero()) return State::Zero();
+    State n;
+    for (int i = 0; i < kStateDim; ++i) {
+      n(i) = sigma(i) * unit_normal_(rng_);
+    }
+    return n;
+  }
+
+  Plant plant_;
+  Config config_;
+  std::mt19937_64 rng_;
+  std::normal_distribution<double> unit_normal_{0.0, 1.0};
+};
+
+}  // namespace xmotion
+
+#endif  // XMNAV_SIM_SIM_LOOP_HPP

--- a/src/simulation/test/CMakeLists.txt
+++ b/src/simulation/test/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_executable(test_sim_loop test_sim_loop.cpp)
+target_link_libraries(test_sim_loop sim mppi gtest gtest_main)
+gtest_discover_tests(test_sim_loop)

--- a/src/simulation/test/test_sim_loop.cpp
+++ b/src/simulation/test/test_sim_loop.cpp
@@ -1,0 +1,115 @@
+/*
+ * test_sim_loop.cpp
+ *
+ * The headless simulation contract: determinism under a seed, noise
+ * injection statistics, model-mismatch wiring, logging and export.
+ *
+ * Copyright (c) 2026 Ruixiang Du (rdu)
+ */
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <sstream>
+
+#include "xmnav/mppi/critics.hpp"
+#include "xmnav/mppi/models/diff_drive.hpp"
+#include "xmnav/mppi/mppi.hpp"
+#include "xmnav/sim/sim_loop.hpp"
+
+using namespace xmotion;
+
+TEST(SimLoopTest, DeterministicUnderSeed) {
+  SimLoop<DiffDriveModel>::Config cfg;
+  cfg.dt = 0.05;
+  cfg.steps = 100;
+  cfg.seed = 42;
+  cfg.process_noise << 0.01, 0.01, 0.005;
+  cfg.measurement_noise << 0.02, 0.02, 0.01;
+
+  auto agent = [](const DiffDriveModel::State& z, int) {
+    return DiffDriveModel::Control(0.5, 0.3 * std::sin(z(2)));
+  };
+
+  SimLoop<DiffDriveModel> a(DiffDriveModel{}, cfg);
+  SimLoop<DiffDriveModel> b(DiffDriveModel{}, cfg);
+  const auto xa = a.Run(DiffDriveModel::State::Zero(), agent);
+  const auto xb = b.Run(DiffDriveModel::State::Zero(), agent);
+  EXPECT_TRUE(xa.isApprox(xb));
+}
+
+TEST(SimLoopTest, NoiseFreeMatchesDirectIntegration) {
+  SimLoop<DiffDriveModel>::Config cfg;
+  cfg.dt = 0.05;
+  cfg.steps = 50;
+  auto agent = [](const DiffDriveModel::State&, int) {
+    return DiffDriveModel::Control(0.4, 0.2);
+  };
+  SimLoop<DiffDriveModel> sim(DiffDriveModel{}, cfg);
+  const auto x_sim = sim.Run(DiffDriveModel::State::Zero(), agent);
+
+  DiffDriveModel m;
+  DiffDriveModel::State x = DiffDriveModel::State::Zero();
+  for (int t = 0; t < 50; ++t) {
+    x = m.Step(x, {0.4, 0.2}, t, 0.05);
+  }
+  EXPECT_TRUE(x_sim.isApprox(x));
+}
+
+TEST(SimLoopTest, LogRecordsAndExports) {
+  SimLoop<DiffDriveModel>::Config cfg;
+  cfg.dt = 0.1;
+  cfg.steps = 10;
+  SimLoop<DiffDriveModel> sim(DiffDriveModel{}, cfg);
+  SimLog log;
+  sim.Run(DiffDriveModel::State::Zero(),
+          [](const DiffDriveModel::State&, int) {
+            return DiffDriveModel::Control(1.0, 0.0);
+          },
+          &log);
+
+  ASSERT_EQ(log.size(), 10);
+  EXPECT_NEAR(log.state(9)(0), 1.0, 1e-9);  // 1 m/s for 1 s
+  EXPECT_DOUBLE_EQ(log.control(0)(0), 1.0);
+
+  std::ostringstream os;
+  log.WriteJsonl(os);
+  const std::string s = os.str();
+  EXPECT_NE(s.find("\"states\":[["), std::string::npos);
+  EXPECT_EQ(std::count(s.begin(), s.end(), '{'),
+            std::count(s.begin(), s.end(), '}'));
+}
+
+TEST(SimLoopTest, ClosedLoopWithMppiUnderModelMismatch) {
+  // controller plans on the nominal model; the plant runs with process
+  // noise — the loop still reaches the goal (the whole point of feedback)
+  Se2GoalCost cost;
+  cost.goal << 2.0, 0.5, 0.0;
+  using Controller = Mppi<DiffDriveModel, Se2GoalCost>;
+  Controller::Params p;
+  p.num_samples = 256;
+  p.horizon_steps = 30;
+  p.dt = 0.05;
+  p.lambda = 0.3;
+  p.sigma << 0.3, 0.8;
+  p.u_min << -0.8, -2.0;
+  p.u_max << 0.8, 2.0;
+  Controller mppi(DiffDriveModel{}, cost, p);
+
+  SimLoop<DiffDriveModel>::Config cfg;
+  cfg.dt = 0.05;
+  cfg.steps = 300;
+  cfg.seed = 9;
+  cfg.process_noise << 0.002, 0.002, 0.004;
+
+  SimLoop<DiffDriveModel> sim(DiffDriveModel{}, cfg);
+  const auto x_end =
+      sim.Run(DiffDriveModel::State::Zero(),
+              [&](const DiffDriveModel::State& z, int) {
+                mppi.Plan(z);
+                return mppi.Command();
+              });
+
+  EXPECT_NEAR(x_end(0), 2.0, 0.25);
+  EXPECT_NEAR(x_end(1), 0.5, 0.25);
+}

--- a/src/visualization/include/xmnav/viz/sim_viewer.hpp
+++ b/src/visualization/include/xmnav/viz/sim_viewer.hpp
@@ -1,0 +1,98 @@
+/*
+ * @file sim_viewer.hpp
+ * @brief Live 2D viewer for simulation runs.
+ *
+ * Attaches to a SimLoop through its observer callback: renders the world
+ * (obstacles, goal), the executed trail, and any number of per-frame
+ * overlays (e.g. the MPPI introspection drawer, estimator ellipses). The
+ * headless loop is untouched — the viewer is a wrapper, not a fork.
+ *
+ * Frame pacing uses the frame period passed to the window (0 = wait for a
+ * key each frame, i.e. single-step inspection).
+ *
+ * Copyright (c) 2026 Ruixiang Du (rdu)
+ */
+
+#ifndef XMNAV_VIZ_SIM_VIEWER_HPP
+#define XMNAV_VIZ_SIM_VIEWER_HPP
+
+#include <functional>
+#include <string>
+#include <vector>
+
+#include "cvdraw/cvdraw.hpp"
+
+namespace xmotion {
+
+class SimViewer2D {
+ public:
+  struct Config {
+    double x_min = -1.0, x_max = 5.0;
+    double y_min = -2.0, y_max = 2.0;
+    int pixels_per_unit = 120;
+    int frame_period_ms = 20;  // 0 = single-step on keypress
+    std::string window_name = "xmnav sim";
+  };
+
+  // draws onto the canvas each frame, before the trail
+  using Overlay = std::function<void(quickviz::CvCanvas &)>;
+
+  explicit SimViewer2D(const Config &config) : config_(config) {}
+
+  void AddOverlay(Overlay overlay) { overlays_.push_back(std::move(overlay)); }
+
+  void AddObstacle(const Eigen::Vector2d &center, double radius) {
+    obstacles_.push_back({center, radius});
+  }
+  void SetGoal(const Eigen::Vector2d &goal) {
+    goal_ = goal;
+    has_goal_ = true;
+  }
+
+  // render one frame around the current 2D position (state rows x/y)
+  void Frame(double x, double y) {
+    quickviz::CvCanvas canvas(config_.pixels_per_unit);
+    canvas.Resize(config_.x_min, config_.x_max, config_.y_min, config_.y_max);
+    canvas.SetMode(quickviz::CvCanvas::DrawMode::Geometry);
+
+    for (const auto &ob : obstacles_) {
+      canvas.DrawCircle({ob.center(0), ob.center(1)}, ob.radius,
+                        quickviz::CvColors::gray_color, 2);
+    }
+    if (has_goal_) {
+      canvas.DrawPoint({goal_(0), goal_(1)}, 4,
+                       quickviz::CvColors::green_color);
+    }
+    for (const auto &overlay : overlays_) {
+      overlay(canvas);
+    }
+
+    trail_.push_back({x, y});
+    for (std::size_t i = 1; i < trail_.size(); ++i) {
+      canvas.DrawLine({trail_[i - 1].first, trail_[i - 1].second},
+                      {trail_[i].first, trail_[i].second},
+                      quickviz::CvColors::black_color, 2);
+    }
+    canvas.DrawPoint({x, y}, 3, quickviz::CvColors::blue_color);
+
+    quickviz::CvIO::ShowImageFrame(canvas.GetPaintArea(), config_.window_name,
+                                   config_.frame_period_ms);
+  }
+
+ private:
+  struct Obstacle {
+    Eigen::Vector2d center;
+    double radius;
+  };
+
+  Config config_;
+  std::vector<Overlay> overlays_;
+  std::vector<Obstacle> obstacles_;
+  Eigen::Vector2d goal_ = Eigen::Vector2d::Zero();
+  bool has_goal_ = false;
+  std::vector<std::pair<double, double>> trail_;
+};
+
+}  // namespace xmotion
+
+#endif  // XMNAV_VIZ_SIM_VIEWER_HPP


### PR DESCRIPTION
The lightweight simulation setup for algorithm development: **headless and visual are the same scenario object** — the visual mode is an observer wrapper, never a fork.

- **Headless core** (`xmnav/sim/`, header-only, Eigen-only): `SimLoop<Plant>` reuses the controller Model concept as the plant — so every existing model (diff-drive, Ackermann, SRB, double integrator) is a plant for free, and the plant may deliberately differ from what an algorithm plans on (**model-mismatch studies**, tested with MPPI under process noise). Deterministic under seed; preallocated `SimLog` + JSONL export.
- **Visual mode** (viz-gated): `SimViewer2D` — world, executed trail, and **pluggable overlays**; the MPPI introspection drawer slots straight in. Frame pacing with a single-step-on-keypress inspection mode.
- **Demos** (`build-*/bin/demo_mppi_diffdrive`, `demo_srb_quadruped`): watch candidate fans steer around obstacles; watch the quadruped trot on the ground plane with stance-foot markers. Built under viz, not ctest-registered.
- Extension path (documented, not built): MuJoCo as an optional external plant when full-order legged work demands it; MCAP recording once W4 telemetry channels exist.

Also: LESSONS entry for the sanitizer-workload pattern (bitten twice today).

Verified: viz-ON **62/62** · viz-OFF **52/52** · WERROR on.