### PR TITLE
refactor(viz): draw/present split, viewer hygiene, xmViewer relabeling

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,12 @@ was previously spread across several repositories (notably `librav` and `imtoolk
 recently, lived in `libxmotion`. At the moment it is used mainly for study, research and
 experimentation — not yet production-hardened.
 
-> **Algorithm-centric.** `xmNavigation` is a pure algorithms library: it depends only on
-> **[xmBase](https://github.com/rxdu/xmBase)** (foundation/common) and math libraries — no hardware
-> dependencies. Composing algorithms with drivers into runnable robot applications happens in
-> external application repos. See the umbrella's
+> **Algorithm-centric.** `xmNavigation` is a pure algorithms library: its **runtime** dependency
+> set is **[xmBase](https://github.com/rxdu/xmBase)** (foundation/common) and math libraries — no
+> hardware dependencies. For **development only**, the visualization-gated modules and demos use
+> **[xmViewer](https://github.com/rxdu/quickviz)** (the family's viewer component); deployment
+> builds carry none of it. Composing algorithms with drivers into runnable robot applications
+> happens in external application repos. See the umbrella's
 > [transition ADR](https://github.com/rxdu/xmotion/blob/main/docs/adr/0002-repo-transition-plan.md).
 
 ## Repository structure

--- a/src/decision/reachability/tests/test_tstate_sim.cpp
+++ b/src/decision/reachability/tests/test_tstate_sim.cpp
@@ -38,9 +38,9 @@ int main()
 
 #ifdef ENABLE_VIZ
     LightViz::ShowTStateSpace(*sim.state_space_.get());
-    // LightViz::ShowMatrixAsColorMap(Psi, "Psi_matrix", false);
-    // LightViz::ShowMatrixAsImage(Psi);
-    // LightViz::ShowMatrixAsColorMap(Psi_T, "Psi_T_matrix", false);
+    // LightViz::quickviz::CvIO::ShowImage(MatrixToColorMap(Psi, "Psi_matrix", false);
+    // LightViz::quickviz::CvIO::ShowImage(MatrixToImage(Psi);
+    // LightViz::quickviz::CvIO::ShowImage(MatrixToColorMap(Psi_T, "Psi_T_matrix", false);
 #endif
 
     return 0;

--- a/src/planning/decomp/test/devel/test_dense_grid.cpp
+++ b/src/planning/decomp/test/devel/test_dense_grid.cpp
@@ -37,8 +37,8 @@ int main() {
   // grid.ResizeGrid(3, 3);
   // grid.PrintGrid();
 
-  // ShowDenseGridAsImage(grid);
-  ShowDenseGridAsColorMap(grid);
+  // quickviz::CvIO::ShowImage(DenseGridToImage(grid);
+  quickviz::CvIO::ShowImage(DenseGridToColorMap(grid));
 
   return 0;
 }

--- a/src/visualization/include/xmnav/viz/dense_grid_visual.hpp
+++ b/src/visualization/include/xmnav/viz/dense_grid_visual.hpp
@@ -1,18 +1,22 @@
 /*
  * dense_grid_visual.hpp
  *
- * Created on: Mar 28, 2018 21:02
- * Description:
+ * Pure image converters for dense grids and Eigen matrices. Module rule:
+ * Draw/To functions render onto canvases or return images and NEVER
+ * present (no imshow/waitKey) — presentation belongs to SimViewer2D or
+ * explicit CvIO calls at the application edge, which keeps every converter
+ * usable headless (tests, file export, CI artifacts).
  *
  * Reference:
- * [1]
- * https://www.learnopencv.com/applycolormap-for-pseudocoloring-in-opencv-c-python/
+ * [1] https://www.learnopencv.com/applycolormap-for-pseudocoloring-in-opencv-c-python/
  *
  * Copyright (c) 2018 Ruixiang Du (rdu)
  */
 
 #ifndef DENSE_GRID_VISUAL_HPP
 #define DENSE_GRID_VISUAL_HPP
+
+#include <vector>
 
 #include <Eigen/Dense>
 #include <opencv2/core/eigen.hpp>
@@ -21,11 +25,18 @@
 #include "cvdraw/cvdraw.hpp"
 
 #include "xmnav/decomp/dense_grid.hpp"
-#include "cvdraw/cvdraw.hpp"
 
 namespace xmotion {
-cv::Mat CreateColorMapFromEigenMatrix(const Eigen::MatrixXd &matrix,
-                                      bool invert_y = false) {
+
+inline cv::Mat MatrixToImage(const Eigen::MatrixXd &matrix) {
+  cv::Mat img;
+  cv::eigen2cv(matrix, img);
+  img.convertTo(img, CV_8UC3);
+  return img;
+}
+
+inline cv::Mat MatrixToColorMap(const Eigen::MatrixXd &matrix,
+                                bool invert_y = false) {
   cv::Mat grey_img, color_img;
 
   // scale matrix to 0-255
@@ -51,27 +62,16 @@ cv::Mat CreateColorMapFromEigenMatrix(const Eigen::MatrixXd &matrix,
   return color_img;
 }
 
-void ShowMatrixAsImage(const Eigen::MatrixXd &matrix, std::string window_name,
-                       bool save_img) {
-  cv::Mat img;
-  cv::eigen2cv(matrix, img);
-  img.convertTo(img, CV_8UC3);
-  quickviz::CvIO::ShowImage(img, window_name, save_img);
+// kept under its historical name for existing call sites
+inline cv::Mat CreateColorMapFromEigenMatrix(const Eigen::MatrixXd &matrix,
+                                             bool invert_y = false) {
+  return MatrixToColorMap(matrix, invert_y);
 }
 
-void ShowMatrixAsColorMap(const Eigen::MatrixXd &matrix,
-                          std::string window_name, bool save_img) {
-  cv::Mat color_img = CreateColorMapFromEigenMatrix(matrix);
-  quickviz::CvIO::ShowImage(color_img, window_name, save_img);
-}
-
-void ShowPathOnMatrixAsColorMap(const Eigen::MatrixXd &matrix,
-                                std::vector<RectGridIndex> waypoints,
-                                std::string window_name, bool save_img) {
-  cv::Mat color_img = CreateColorMapFromEigenMatrix(matrix);
-
+inline cv::Mat PathOnColorMap(const Eigen::MatrixXd &matrix,
+                              const std::vector<RectGridIndex> &waypoints) {
+  cv::Mat color_img = MatrixToColorMap(matrix);
   quickviz::CvCanvas canvas(color_img);
-
   for (int i = 0; i < static_cast<int>(waypoints.size()) - 1; ++i) {
     canvas.DrawLine({static_cast<double>(waypoints[i].GetX()),
                      static_cast<double>(waypoints[i].GetY())},
@@ -79,32 +79,22 @@ void ShowPathOnMatrixAsColorMap(const Eigen::MatrixXd &matrix,
                      static_cast<double>(waypoints[i + 1].GetY())},
                     cv::Scalar(244, 92, 66));
   }
-
-  quickviz::CvIO::ShowImage(color_img, window_name, save_img);
-}
-}  // namespace xmotion
-
-
-#include "xmnav/decomp/dense_grid.hpp"
-
-namespace xmotion {
-inline void ShowDenseGridAsImage(const DenseGrid &grid, bool save_img = false,
-                          std::string img_name = "DenseGrid") {
-  ShowMatrixAsImage(grid.GetGridMatrix(true) * 128, img_name, save_img);
+  return color_img;
 }
 
-inline void ShowDenseGridAsColorMap(const DenseGrid &grid, bool save_img = false,
-                             std::string img_name = "DenseGrid") {
-  ShowMatrixAsColorMap(grid.GetGridMatrix(true), img_name, save_img);
+inline cv::Mat DenseGridToImage(const DenseGrid &grid) {
+  return MatrixToImage(grid.GetGridMatrix(true) * 128);
 }
 
-inline void ShowPathOnDenseGrid(const DenseGrid &grid,
-                         std::vector<RectGridIndex> waypoints,
-                         bool save_img = false,
-                         std::string img_name = "DenseGrid") {
-  ShowPathOnMatrixAsColorMap(grid.GetGridMatrix(true), waypoints, img_name,
-                             save_img);
+inline cv::Mat DenseGridToColorMap(const DenseGrid &grid) {
+  return MatrixToColorMap(grid.GetGridMatrix(true));
 }
+
+inline cv::Mat PathOnDenseGrid(const DenseGrid &grid,
+                               const std::vector<RectGridIndex> &waypoints) {
+  return PathOnColorMap(grid.GetGridMatrix(true), waypoints);
+}
+
 }  // namespace xmotion
 
 #endif /* DENSE_GRID_VISUAL_HPP */

--- a/src/visualization/include/xmnav/viz/mppi_draw.hpp
+++ b/src/visualization/include/xmnav/viz/mppi_draw.hpp
@@ -19,6 +19,7 @@
 #include "cvdraw/cvdraw.hpp"
 
 #include "xmnav/mppi/mppi.hpp"
+#include "xmnav/viz/style.hpp"
 
 namespace xmotion {
 
@@ -31,9 +32,7 @@ void DrawMppiSnapshot2D(quickviz::CvCanvas &canvas,
 
   for (const auto &c : snap.candidates) {
     // weight -> intensity: influential candidates draw bright
-    const double a = std::min(1.0, c.weight / w_max);
-    const int shade = 230 - static_cast<int>(190.0 * a);
-    const cv::Scalar color(shade, shade, 255);  // faint red -> strong red
+    const cv::Scalar color = viz_style::WeightColor(c.weight / w_max);
     for (Eigen::Index t = 0; t + 1 < c.states.rows(); ++t) {
       canvas.DrawLine({c.states(t, x_col), c.states(t, y_col)},
                       {c.states(t + 1, x_col), c.states(t + 1, y_col)}, color,
@@ -46,7 +45,7 @@ void DrawMppiSnapshot2D(quickviz::CvCanvas &canvas,
     canvas.DrawLine(
         {snap.nominal_states(t, x_col), snap.nominal_states(t, y_col)},
         {snap.nominal_states(t + 1, x_col), snap.nominal_states(t + 1, y_col)},
-        quickviz::CvColors::blue_color, 2);
+        viz_style::kChosenTrajectory, 2);
   }
 }
 

--- a/src/visualization/include/xmnav/viz/sim_viewer.hpp
+++ b/src/visualization/include/xmnav/viz/sim_viewer.hpp
@@ -7,8 +7,13 @@
  * overlays (e.g. the MPPI introspection drawer, estimator ellipses). The
  * headless loop is untouched — the viewer is a wrapper, not a fork.
  *
- * Frame pacing uses the frame period passed to the window (0 = wait for a
- * key each frame, i.e. single-step inspection).
+ * Presentation modes (combinable):
+ *  - window: frame pacing via frame_period_ms (0 = single-step per key)
+ *  - recording: numbered PNGs into record_dir — works fully headless, so
+ *    demo runs can produce CI artifacts / videos (ffmpeg over the frames)
+ *
+ * Module rule: Draw/To functions in this module never present; this
+ * class is where presentation lives.
  *
  * Copyright (c) 2026 Ruixiang Du (rdu)
  */
@@ -16,11 +21,17 @@
 #ifndef XMNAV_VIZ_SIM_VIEWER_HPP
 #define XMNAV_VIZ_SIM_VIEWER_HPP
 
+#include <cstdio>
+#include <deque>
 #include <functional>
 #include <string>
 #include <vector>
 
+#include <opencv2/imgcodecs.hpp>
+
 #include "cvdraw/cvdraw.hpp"
+
+#include "xmnav/viz/style.hpp"
 
 namespace xmotion {
 
@@ -31,13 +42,21 @@ class SimViewer2D {
     double y_min = -2.0, y_max = 2.0;
     int pixels_per_unit = 120;
     int frame_period_ms = 20;  // 0 = single-step on keypress
+    bool show_window = true;
     std::string window_name = "xmnav sim";
+    // when non-empty, every frame is written as <record_dir>/frame_N.png
+    std::string record_dir;
+    // executed-trail history bound (decimated by 2 when exceeded)
+    std::size_t max_trail_points = 4096;
   };
 
-  // draws onto the canvas each frame, before the trail
   using Overlay = std::function<void(quickviz::CvCanvas &)>;
 
-  explicit SimViewer2D(const Config &config) : config_(config) {}
+  explicit SimViewer2D(const Config &config)
+      : config_(config), canvas_(config.pixels_per_unit) {
+    canvas_.Resize(config_.x_min, config_.x_max, config_.y_min, config_.y_max);
+    canvas_.SetMode(quickviz::CvCanvas::DrawMode::Geometry);
+  }
 
   void AddOverlay(Overlay overlay) { overlays_.push_back(std::move(overlay)); }
 
@@ -51,46 +70,70 @@ class SimViewer2D {
 
   // render one frame around the current 2D position (state rows x/y)
   void Frame(double x, double y) {
-    quickviz::CvCanvas canvas(config_.pixels_per_unit);
-    canvas.Resize(config_.x_min, config_.x_max, config_.y_min, config_.y_max);
-    canvas.SetMode(quickviz::CvCanvas::DrawMode::Geometry);
+    canvas_.Clear();
 
     for (const auto &ob : obstacles_) {
-      canvas.DrawCircle({ob.center(0), ob.center(1)}, ob.radius,
-                        quickviz::CvColors::gray_color, 2);
+      canvas_.DrawCircle({ob.center(0), ob.center(1)}, ob.radius,
+                         viz_style::kObstacle, 2);
     }
     if (has_goal_) {
-      canvas.DrawPoint({goal_(0), goal_(1)}, 4,
-                       quickviz::CvColors::green_color);
+      canvas_.DrawPoint({goal_(0), goal_(1)}, 4, viz_style::kGoal);
     }
     for (const auto &overlay : overlays_) {
-      overlay(canvas);
+      overlay(canvas_);
     }
 
     trail_.push_back({x, y});
-    for (std::size_t i = 1; i < trail_.size(); ++i) {
-      canvas.DrawLine({trail_[i - 1].first, trail_[i - 1].second},
-                      {trail_[i].first, trail_[i].second},
-                      quickviz::CvColors::black_color, 2);
+    if (trail_.size() > config_.max_trail_points) {
+      Decimate();
     }
-    canvas.DrawPoint({x, y}, 3, quickviz::CvColors::blue_color);
+    for (std::size_t i = 1; i < trail_.size(); ++i) {
+      canvas_.DrawLine({trail_[i - 1].first, trail_[i - 1].second},
+                       {trail_[i].first, trail_[i].second},
+                       viz_style::kExecutedTrail, 2);
+    }
+    canvas_.DrawPoint({x, y}, 3, viz_style::kChosenTrajectory);
 
-    quickviz::CvIO::ShowImageFrame(canvas.GetPaintArea(), config_.window_name,
-                                   config_.frame_period_ms);
+    Present();
   }
 
  private:
+  void Decimate() {
+    std::deque<std::pair<double, double>> kept;
+    for (std::size_t i = 0; i < trail_.size(); i += 2) {
+      kept.push_back(trail_[i]);
+    }
+    trail_.swap(kept);
+  }
+
+  void Present() {
+    if (!config_.record_dir.empty()) {
+      char name[512];
+      std::snprintf(name, sizeof(name), "%s/frame_%06d.png",
+                    config_.record_dir.c_str(), frame_index_);
+      cv::imwrite(name, canvas_.GetPaintArea());
+    }
+    if (config_.show_window) {
+      quickviz::CvIO::ShowImageFrame(canvas_.GetPaintArea(),
+                                     config_.window_name,
+                                     config_.frame_period_ms);
+    }
+    ++frame_index_;
+  }
+
   struct Obstacle {
     Eigen::Vector2d center;
     double radius;
   };
 
   Config config_;
+  quickviz::CvCanvas canvas_;
   std::vector<Overlay> overlays_;
   std::vector<Obstacle> obstacles_;
   Eigen::Vector2d goal_ = Eigen::Vector2d::Zero();
   bool has_goal_ = false;
-  std::vector<std::pair<double, double>> trail_;
+  std::deque<std::pair<double, double>> trail_;
+  int frame_index_ = 0;
 };
 
 }  // namespace xmotion

--- a/src/visualization/include/xmnav/viz/style.hpp
+++ b/src/visualization/include/xmnav/viz/style.hpp
@@ -1,0 +1,35 @@
+/*
+ * @file style.hpp
+ * @brief Shared palette and value->color mappings for the visualization
+ * module, so drawers stop inventing colors independently.
+ *
+ * Copyright (c) 2026 Ruixiang Du (rdu)
+ */
+
+#ifndef XMNAV_VIZ_STYLE_HPP
+#define XMNAV_VIZ_STYLE_HPP
+
+#include <algorithm>
+
+#include "cvdraw/cvdraw.hpp"
+
+namespace xmotion {
+namespace viz_style {
+
+// primary roles
+inline const cv::Scalar kChosenTrajectory = quickviz::CvColors::blue_color;
+inline const cv::Scalar kExecutedTrail = quickviz::CvColors::black_color;
+inline const cv::Scalar kGoal = quickviz::CvColors::green_color;
+inline const cv::Scalar kObstacle = quickviz::CvColors::gray_color;
+
+// normalized weight [0,1] -> candidate color (dim gray-red -> strong red)
+inline cv::Scalar WeightColor(double w) {
+  const double a = std::min(1.0, std::max(0.0, w));
+  const int shade = 230 - static_cast<int>(190.0 * a);
+  return cv::Scalar(shade, shade, 255);
+}
+
+}  // namespace viz_style
+}  // namespace xmotion
+
+#endif  // XMNAV_VIZ_STYLE_HPP

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -15,7 +15,9 @@ add_subdirectory(stopwatch)
 add_subdirectory(spatial)
 add_subdirectory(quadprog++)
 
-# Visualization engine (vendored; used by viz-gated targets only)
+# xmViewer (quickviz): a FAMILY development-support component, not
+# third-party code — consumed by the visualization-gated modules and demos
+# only, never part of the deployment closure (ADR 0005 dependency classes).
 if (ENABLE_VISUALIZATION)
   option(QUICKVIZ_DEV_MODE "Build quickviz in dev mode" ON)
   option(BUILD_QUICKVIZ_APP "Build quickviz application" ON)


### PR DESCRIPTION
The visualization review follow-through, paired with umbrella PR #21 (ADR 0005 dependency classes):

- **Draw/present split enforced as the module rule**: the 2018-era `Show*` grid helpers (blocking `imshow`/`waitKey` inside draw calls) become pure converters; presentation happens only in `SimViewer2D` or explicit `CvIO` calls at the application edge. Every converter is now usable headless.
- **`SimViewer2D` hygiene**: persistent canvas + `Clear()` instead of per-frame reallocation; bounded (decimating) trail instead of unbounded growth; **`record_dir` PNG recording that works fully headless** — demo runs can produce CI artifacts and ffmpeg videos with `show_window=false`.
- **Shared style** (`xmnav/viz/style.hpp`): palette + weight colormap; `mppi_draw` adopts it.
- **Honest labeling**: quickviz is **xmViewer**, the family's development-support component — comments and README now state the runtime (xmBase-only) vs development (xmViewer, gated) dependency split per the ADR 0005 clarification.

Verified: viz-ON 62/62 (WERROR).