### PR TITLE
feat: W4 — telemetry instrumentation across the navigation stack

### DIFF
--- a/src/decision/reachability/CMakeLists.txt
+++ b/src/decision/reachability/CMakeLists.txt
@@ -23,7 +23,7 @@ set(REACHABILITY_LIB_SRC
     src/car_longitudinal_model.cpp
 )
 add_library(reachability STATIC ${REACHABILITY_LIB_SRC})
-target_link_libraries(reachability markov model stopwatch Eigen3::Eigen)
+target_link_libraries(reachability xmotion::xmBase markov model stopwatch Eigen3::Eigen)
 # target_compile_definitions(reachability PUBLIC "-DEIGEN_STACK_ALLOCATION_LIMIT=0")
 target_include_directories(reachability PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/src/decision/reachability/src/monte_carlo_sim.cpp
+++ b/src/decision/reachability/src/monte_carlo_sim.cpp
@@ -9,10 +9,13 @@
 
 #include "xmnav/reachability/monte_carlo_sim.hpp"
 
+#include "xmbase/telemetry/telemetry.hpp"
+
 using namespace xmotion;
 
 void MonteCarloSim::RunSim(double t0, double tf, double step, int32_t iter_num)
 {
+    XM_SPAN("decision.monte_carlo.run_sim");
     double x = 0, y = 0;
     double acc = -1, phi = 0;
 

--- a/src/estimation/include/xmnav/estimation/mekf6.hpp
+++ b/src/estimation/include/xmnav/estimation/mekf6.hpp
@@ -27,6 +27,8 @@
 
 #include <eigen3/Eigen/Geometry>
 
+#include "xmbase/telemetry/telemetry.hpp"
+
 namespace xmotion {
 class Mekf6 {
  public:
@@ -98,6 +100,18 @@ class Mekf6 {
   Eigen::Vector3d b_f_ = Eigen::Vector3d::Zero();
 
   bool last_obs_used_ = false;
+
+  // pre-acquired wait-free telemetry handles (no-ops when unbound)
+  telemetry::Gauge innovation_gauge_ =
+      telemetry::GetGauge("estimation.mekf6.innovation_norm");
+  telemetry::Gauge gyro_bias_gauge_ =
+      telemetry::GetGauge("estimation.mekf6.gyro_bias_norm");
+  telemetry::Counter gate_reject_counter_ =
+      telemetry::GetCounter("estimation.mekf6.gate_rejections");
+  telemetry::Counter invalid_input_counter_ =
+      telemetry::GetCounter("estimation.mekf6.invalid_inputs");
+
+  friend class Mekf6TelemetryAccess;
 };
 }  // namespace xmotion
 

--- a/src/estimation/include/xmnav/estimation/mekf9.hpp
+++ b/src/estimation/include/xmnav/estimation/mekf9.hpp
@@ -26,6 +26,8 @@
 
 #include <eigen3/Eigen/Geometry>
 
+#include "xmbase/telemetry/telemetry.hpp"
+
 namespace xmotion {
 class Mekf9 {
  public:
@@ -110,6 +112,16 @@ class Mekf9 {
 
   bool last_accel_used_ = false;
   bool last_mag_used_ = false;
+
+  // pre-acquired wait-free telemetry handles (no-ops when unbound)
+  telemetry::Gauge gyro_bias_gauge_ =
+      telemetry::GetGauge("estimation.mekf9.gyro_bias_norm");
+  telemetry::Counter accel_reject_counter_ =
+      telemetry::GetCounter("estimation.mekf9.accel_gate_rejections");
+  telemetry::Counter mag_reject_counter_ =
+      telemetry::GetCounter("estimation.mekf9.mag_gate_rejections");
+  telemetry::Counter invalid_input_counter_ =
+      telemetry::GetCounter("estimation.mekf9.invalid_inputs");
 };
 }  // namespace xmotion
 

--- a/src/estimation/src/mekf6.cpp
+++ b/src/estimation/src/mekf6.cpp
@@ -73,7 +73,9 @@ Mekf6::ProcessNoiseCovariance Mekf6::GetQMatrix(double dt) const {
 
 bool Mekf6::Update(const ControlInput &gyro_tilde,
                    const Observation &accel_tilde, double dt) {
+  XM_SPAN("estimation.mekf6.update");
   if (!(dt > 0.0) || !gyro_tilde.allFinite() || !accel_tilde.allFinite()) {
+    invalid_input_counter_.Add();
     return false;
   }
 
@@ -109,6 +111,7 @@ bool Mekf6::Update(const ControlInput &gyro_tilde,
       std::abs(accel.norm() - params_.gravity_constant) <=
           params_.accel_gate_threshold;
   if (!last_obs_used_) {
+    gate_reject_counter_.Add();
     P_ = 0.5 * (P_ + P_.transpose());
     return true;  // prediction-only cycle
   }
@@ -127,6 +130,7 @@ bool Mekf6::Update(const ControlInput &gyro_tilde,
 
   // innovation and error-state estimate (prior error mean is zero)
   const Eigen::Vector3d delta_y = accel - h;
+  innovation_gauge_.Set(delta_y.norm());
   const State x = K * delta_y;
 
   // Joseph-form covariance update, then re-symmetrize
@@ -139,6 +143,7 @@ bool Mekf6::Update(const ControlInput &gyro_tilde,
   q_hat_.normalize();
   b_omega_ += x.segment<3>(9);
   b_f_ += x.segment<3>(12);
+  gyro_bias_gauge_.Set(b_omega_.norm());
   // (delta v / delta r fold when nominal velocity/position tracking lands)
 
   return true;

--- a/src/estimation/src/mekf9.cpp
+++ b/src/estimation/src/mekf9.cpp
@@ -104,8 +104,10 @@ void Mekf9::ApplyVectorObservation(const Eigen::Vector3d &delta_y,
 bool Mekf9::Update(const ControlInput &gyro_tilde,
                    const Observation &accel_tilde, const Observation &mag_tilde,
                    double dt) {
+  XM_SPAN("estimation.mekf9.update");
   if (!(dt > 0.0) || !gyro_tilde.allFinite() || !accel_tilde.allFinite() ||
       !mag_tilde.allFinite()) {
+    invalid_input_counter_.Add();
     return false;
   }
 
@@ -143,6 +145,8 @@ bool Mekf9::Update(const ControlInput &gyro_tilde,
   if (last_accel_used_) {
     const Eigen::Vector3d h_a = q_hat_.conjugate() * g_i;
     ApplyVectorObservation(accel - h_a, h_a, 12, params_.accel_noise_cov);
+  } else {
+    accel_reject_counter_.Add();
   }
 
   // --- magnetometer observation (gated) ---
@@ -152,7 +156,10 @@ bool Mekf9::Update(const ControlInput &gyro_tilde,
   if (last_mag_used_) {
     const Eigen::Vector3d h_m = q_hat_.conjugate() * params_.mag_reference;
     ApplyVectorObservation(mag - h_m, h_m, 15, params_.mag_noise_cov);
+  } else {
+    mag_reject_counter_.Add();
   }
+  gyro_bias_gauge_.Set(b_omega_.norm());
 
   return true;
 }

--- a/src/mapping/map_processing/src/pgm_map.cpp
+++ b/src/mapping/map_processing/src/pgm_map.cpp
@@ -48,6 +48,7 @@ bool PgmMap::LoadData() {
 }
 
 bool PgmMap::LoadFromFile(const std::string& file_path) {
+  XM_SPAN("mapping.pgm.load");
   metadata_.image = file_path;
   return LoadData();
 }

--- a/src/planning/sampling/CMakeLists.txt
+++ b/src/planning/sampling/CMakeLists.txt
@@ -7,7 +7,7 @@ set(SAMPLING_LIB_SRC
     # src/realvector_state.cpp
 )
 add_library(sampling ${SAMPLING_LIB_SRC})
-target_link_libraries(sampling PUBLIC graph geometry spatial Eigen3::Eigen)
+target_link_libraries(sampling PUBLIC xmotion::xmBase graph geometry spatial Eigen3::Eigen)
 target_include_directories(sampling PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<BUILD_INTERFACE:${EIGEN3_INCLUDE_DIR}>

--- a/src/planning/sampling/include/xmnav/sampling/rrg.hpp
+++ b/src/planning/sampling/include/xmnav/sampling/rrg.hpp
@@ -20,6 +20,7 @@
 #include <cassert>
 
 #include "xmnav/sampling/base/planner_base.hpp"
+#include "xmbase/telemetry/telemetry.hpp"
 #include "xmnav/sampling/tree/kd_graph.hpp"
 
 #include "graph/search/dijkstra.hpp"
@@ -53,6 +54,7 @@ class RRG : public PlannerBase<Space, KdGraph<Space>> {
 
   PathType Search(std::shared_ptr<StateType> start,
                   std::shared_ptr<StateType> goal, int32_t iter = -1) override {
+    XM_SPAN("planning.rrg.search");
     assert(BaseType::Steer != nullptr);
 
 #ifdef SHOW_TREE_GROWTH
@@ -160,9 +162,9 @@ class RRG : public PlannerBase<Space, KdGraph<Space>> {
       RRTViz::DrawStraightPath(canvas, path);
       quickviz::CvIO::ShowImageFrame(canvas.GetPaintArea(), "RRG", 0);
 #endif
-      for (auto &wp : path) std::cout << *wp << std::endl;
+      XM_INFO("planning.rrg: path found, {} waypoints", path.size());
     } else {
-      std::cout << "failed to find a path" << std::endl;
+      XM_WARN("planning.rrg: failed to find a path");
     }
 
     return path;

--- a/src/planning/sampling/include/xmnav/sampling/rrt.hpp
+++ b/src/planning/sampling/include/xmnav/sampling/rrt.hpp
@@ -21,6 +21,7 @@
 #include <cassert>
 
 #include "xmnav/sampling/base/planner_base.hpp"
+#include "xmbase/telemetry/telemetry.hpp"
 #include "xmnav/sampling/tree/basic_tree.hpp"
 #include "xmnav/sampling/tree/kd_tree.hpp"
 
@@ -45,6 +46,7 @@ class RRT : public PlannerBase<Space, Tree> {
  public:
   PathType Search(std::shared_ptr<StateType> start,
                   std::shared_ptr<StateType> goal, int32_t iter = -1) override {
+    XM_SPAN("planning.rrt.search");
     assert(BaseType::Steer != nullptr);
 
 #ifdef SHOW_TREE_GROWTH
@@ -95,8 +97,8 @@ class RRT : public PlannerBase<Space, Tree> {
               BaseType::space_->EvaluateDistance(new_state, goal));
           path = BaseType::tree_.TraceBackToRoot(goal);
 
-          std::cout << "path found at iteration " << k << std::endl;
-          for (auto &wp : path) std::cout << *wp << std::endl;
+          XM_INFO("planning.rrt: path found after {} iterations, {} waypoints",
+                  k, path.size());
 
 #ifdef SHOW_TREE_GROWTH
           RRTViz::DrawStraightBranch(canvas, new_state, goal);

--- a/src/planning/sampling/include/xmnav/sampling/rrt_star.hpp
+++ b/src/planning/sampling/include/xmnav/sampling/rrt_star.hpp
@@ -21,6 +21,7 @@
 #include <cassert>
 
 #include "xmnav/sampling/base/planner_base.hpp"
+#include "xmbase/telemetry/telemetry.hpp"
 #include "xmnav/sampling/tree/kd_tree_motion.hpp"
 
 // #define SHOW_TREE_GROWTH
@@ -51,6 +52,7 @@ class RRTStar : public PlannerBase<Space, Tree> {
 
   PathType Search(std::shared_ptr<StateType> start,
                   std::shared_ptr<StateType> goal, int32_t iter = -1) override {
+    XM_SPAN("planning.rrt_star.search");
     assert(BaseType::Steer != nullptr);
 
 #ifdef SHOW_TREE_GROWTH
@@ -134,8 +136,8 @@ class RRTStar : public PlannerBase<Space, Tree> {
     }
 
     if (!state_to_goal_candidates.empty()) {
-      std::cout << "number of candidates: " << state_to_goal_candidates.size()
-                << std::endl;
+      XM_INFO("planning.rrt_star: {} goal candidates",
+              state_to_goal_candidates.size());
 
       std::map<double, std::shared_ptr<StateType>> candidate_map;
 
@@ -152,7 +154,7 @@ class RRTStar : public PlannerBase<Space, Tree> {
           BaseType::space_->EvaluateDistance(best_candidate, goal));
       path = BaseType::tree_.TraceBackToRoot(goal);
 
-      for (auto &wp : path) std::cout << *wp << std::endl;
+      XM_INFO("planning.rrt_star: path found, {} waypoints", path.size());
     }
 
 #ifdef SHOW_TREE_GROWTH


### PR DESCRIPTION
The final content wave of the migration plan: every built area of the stack now reports through one telemetry spine, following the conventions the MPPI/control exemplar established (pre-acquired wait-free handles on high-rate paths, call-site events on episodic ones).

| Area | Instrumentation |
|---|---|
| **estimation** | MEKF6/9 `Update()` spans; innovation-norm + gyro-bias gauges; per-observation gate-rejection counters (accel/mag); invalid-input counters |
| **planning** | RRT/RRG/RRT* `Search()` spans; result events (`XM_INFO`/`XM_WARN` with iteration + path counts) replacing 2018-era `std::cout` dumps — including a per-waypoint console print in the hot success path |
| **decision** | monte-carlo `RunSim` span |
| **mapping** | PGM load span |
| **control** | already done (MPPI: plan span, ESS/best-cost gauges) |

The estimation gauges are the field divergence-watch surface; the planner events give per-search cost/latency in the trace timeline.

Verified: 62/62 Release, **52/52 ASan+UBSan**, WERROR on.

Remaining in the migration arc after this: **W5** — xmBase v0.4.0 cut, umbrella re-pin with `XMOTION_WITH_NAVIGATION=ON`, full assembly proof.