### PR TITLE
build: pin xmBase v0.4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,7 +107,7 @@ add_subdirectory(third_party)
 
 ## Foundation (external). A parent superbuild may already provide it.
 if (NOT TARGET xmotion::xmBase)
-  find_package(xmBase 0.3.0 QUIET)
+  find_package(xmBase 0.4.0 QUIET)
   if (NOT xmBase_FOUND)
     if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/third_party/xmBase/CMakeLists.txt)
       add_subdirectory(third_party/xmBase)


### PR DESCRIPTION
Replaces the interim branch-head pin with the released v0.4.0 tag (event/math promotion now released); find_package minimum rises to 0.4.0. Verified: 62/62 (WERROR). Part of W5.