### PR TITLE
feat(viz): Viz v2 — quickviz migration + interactive MPPI tuner

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,7 +134,9 @@ if (XMOTION_WERROR)
   add_compile_options(-Wall -Wextra -Werror -Wno-error=maybe-uninitialized)
   # Vendored header-only libraries are consumed from first-party TUs; mark
   # their include directories SYSTEM so their headers never gate our build.
-  foreach (_vendored stb rapidcsv pnm)
+  # (quickviz modules included: its headers reach first-party TUs the same
+  # way, and quickviz builds with its own flags, not ours)
+  foreach (_vendored stb rapidcsv pnm core viewer canvas plot image imcore)
     if (TARGET ${_vendored})
       get_target_property(_inc ${_vendored} INTERFACE_INCLUDE_DIRECTORIES)
       set_target_properties(${_vendored} PROPERTIES

--- a/src/control/mppi/include/xmnav/mppi/mppi.hpp
+++ b/src/control/mppi/include/xmnav/mppi/mppi.hpp
@@ -24,6 +24,7 @@
 #include <cmath>
 #include <cstdint>
 #include <limits>
+#include <stdexcept>
 #include <vector>
 
 #include <eigen3/Eigen/Dense>
@@ -294,6 +295,27 @@ class Mppi {
   double LastBestCost() const { return last_best_cost_; }
   // effective sample size in [1, K]: near 1 means weight collapse
   double LastEffectiveSampleSize() const { return last_ess_; }
+
+  // Live-tuning setters (interactive tuner, adaptive schemes). Both are
+  // cheap and allocation-free but must be called from the planning thread
+  // between Plan() invocations — relay values through atomics if the knobs
+  // are driven from a UI thread.
+  void SetTemperature(double lambda) {
+    if (!(lambda > 0.0)) {
+      throw std::invalid_argument("MPPI temperature lambda must be > 0");
+    }
+    params_.lambda = lambda;
+  }
+  double Temperature() const { return params_.lambda; }
+  // updates the cached Sigma^{-1} used by the control-cost term with it
+  void SetSigma(const Control &sigma) {
+    if (!(sigma.minCoeff() > 0.0)) {
+      throw std::invalid_argument("MPPI sigma must be > 0 on every channel");
+    }
+    params_.sigma = sigma;
+    sigma_inv_sq_ = sigma.cwiseProduct(sigma).cwiseInverse();
+  }
+  Control Sigma() const { return params_.sigma; }
 
  private:
   // roll a control sequence (clamped) and record the post-step states

--- a/src/mapping/map_processing/test/test_occupancy_map.cpp
+++ b/src/mapping/map_processing/test/test_occupancy_map.cpp
@@ -13,7 +13,7 @@
 #include "xmnav/map_processing/point_cloud_processor.hpp"
 #include "xmnav/map_processing/trajectory_processor.hpp"
 
-#include "cvdraw/cvdraw.hpp"
+#include "image/image.hpp"
 
 using namespace xmotion;
 using namespace std::chrono_literals;

--- a/src/mapping/map_processing/test/test_traj_processor.cpp
+++ b/src/mapping/map_processing/test/test_traj_processor.cpp
@@ -10,7 +10,7 @@
 
 #include "xmnav/map_processing/trajectory_processor.hpp"
 
-#include "cvdraw/cvdraw.hpp"
+#include "image/image.hpp"
 
 using namespace xmotion;
 

--- a/src/simulation/demos/CMakeLists.txt
+++ b/src/simulation/demos/CMakeLists.txt
@@ -4,3 +4,9 @@ target_link_libraries(demo_mppi_diffdrive sim mppi viz)
 
 add_executable(demo_srb_quadruped demo_srb_quadruped.cpp)
 target_link_libraries(demo_srb_quadruped sim mppi viz)
+
+# Interactive MPPI tuner: quickviz viewer shell (Box layout), cairo world
+# view with the alpha-blended candidate fan, live ESS/cost plots,
+# pause/step and lambda/sigma controls
+add_executable(tuner_mppi_diffdrive tuner_mppi_diffdrive.cpp)
+target_link_libraries(tuner_mppi_diffdrive sim mppi viz viewer plot)

--- a/src/simulation/demos/tuner_mppi_diffdrive.cpp
+++ b/src/simulation/demos/tuner_mppi_diffdrive.cpp
@@ -1,0 +1,320 @@
+/*
+ * tuner_mppi_diffdrive.cpp
+ *
+ * Interactive MPPI tuner (Viz v2): a differential-drive robot runs against
+ * the demo obstacle course on a background thread while the quickviz viewer
+ * shows, live:
+ *   - the world panel (CairoWidget): obstacle course, executed trail, and
+ *     the candidate-rollout fan with alpha-blended softmax weights
+ *   - ESS and best-cost strip charts (RtLinePlotWidget via BufferRegistry)
+ *   - a control panel: pause / single-step / reset and live lambda / sigma
+ *     sliders applied to the controller between Plan() calls
+ *
+ * Threading follows the quickviz contract: all GL/ImGui work stays on the
+ * main thread; the simulation publishes frames through a latest-only
+ * DataStream and plot points through registry ring buffers; tuning knobs
+ * travel UI -> sim through atomics and are applied on the planning thread.
+ *
+ * Copyright (c) 2026 Ruixiang Du (rdu)
+ */
+
+#include <atomic>
+#include <chrono>
+#include <cstdio>
+#include <deque>
+#include <memory>
+#include <thread>
+#include <utility>
+
+#include "core/buffer/buffer_registry.hpp"
+#include "core/buffer/ring_buffer.hpp"
+#include "core/data_stream.hpp"
+#include "canvas/cairo_widget.hpp"
+#include "plot/rt_line_plot_widget.hpp"
+#include "viewer/box.hpp"
+#include "viewer/viewer.hpp"
+
+#include "xmnav/mppi/critics.hpp"
+#include "xmnav/mppi/models/diff_drive.hpp"
+#include "xmnav/mppi/mppi.hpp"
+#include "xmnav/viz/mppi_draw_cairo.hpp"
+
+using namespace xmotion;
+
+namespace {
+
+using Cost = decltype(MakeCompositeCost(std::declval<Se2GoalCost>(),
+                                        std::declval<CircularObstacleCost>()));
+using Controller = Mppi<DiffDriveModel, Cost>;
+using PlotPoint = quickviz::RtLinePlotWidget::DataPoint;
+
+constexpr int kNumSamples = 1024;
+constexpr double kDt = 0.05;
+
+// UI -> sim knobs and sim -> UI gauges (all lock-free)
+struct TunerShared {
+  std::atomic<double> lambda{0.3};
+  std::atomic<double> sigma_v{0.3};
+  std::atomic<double> sigma_w{0.8};
+  std::atomic<bool> paused{false};
+  std::atomic<int> step_credits{0};
+  std::atomic<bool> reset{false};
+  std::atomic<bool> stop{false};
+  std::atomic<double> ess{0.0};
+  std::atomic<double> best_cost{0.0};
+  std::atomic<double> sim_time{0.0};
+};
+
+// one sim step as seen by the world panel
+struct WorldFrame {
+  double x = 0.0;
+  double y = 0.0;
+  double theta = 0.0;
+  double t = 0.0;
+  Controller::Snapshot snapshot;
+};
+
+void RunSim(TunerShared &shared, quickviz::DataStream<WorldFrame> &stream,
+            const Se2GoalCost &goal_cost,
+            const CircularObstacleCost &obstacle_cost) {
+  auto &registry = quickviz::BufferRegistry::GetInstance();
+  auto ess_buffer = *registry.GetBuffer<PlotPoint>("mppi.ess");
+  auto cost_buffer = *registry.GetBuffer<PlotPoint>("mppi.best_cost");
+
+  Controller::Params p;
+  p.num_samples = kNumSamples;
+  p.horizon_steps = 50;
+  p.dt = kDt;
+  p.lambda = shared.lambda.load();
+  p.sigma << shared.sigma_v.load(), shared.sigma_w.load();
+  p.u_min << -0.8, -2.0;
+  p.u_max << 0.8, 2.0;
+  p.normalize_cost_spread = true;
+  Controller mppi(DiffDriveModel{},
+                  MakeCompositeCost(goal_cost, obstacle_cost), p);
+  mppi.EnableIntrospection(24, 24);
+
+  DiffDriveModel plant;
+  DiffDriveModel::State x = DiffDriveModel::State::Zero();
+  double t = 0.0;
+
+  while (!shared.stop.load()) {
+    if (shared.reset.exchange(false)) {
+      x.setZero();
+      t = 0.0;
+      mppi.Reset();
+    }
+    if (shared.paused.load()) {
+      int credits = shared.step_credits.load();
+      if (credits <= 0 ||
+          !shared.step_credits.compare_exchange_strong(credits, credits - 1)) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        continue;
+      }
+    }
+
+    // apply UI knobs on the planning thread, between Plan() calls
+    mppi.SetTemperature(shared.lambda.load());
+    Controller::Control sigma;
+    sigma << shared.sigma_v.load(), shared.sigma_w.load();
+    mppi.SetSigma(sigma);
+
+    mppi.Plan(x);
+    x = plant.Step(x, mppi.Command(), 0, kDt);
+    t += kDt;
+
+    WorldFrame frame;
+    frame.x = x(0);
+    frame.y = x(1);
+    frame.theta = x(2);
+    frame.t = t;
+    frame.snapshot = mppi.LastSnapshot();
+    stream.Push(std::move(frame));
+
+    const float tf = static_cast<float>(t);
+    ess_buffer->Write({tf, static_cast<float>(mppi.LastEffectiveSampleSize())});
+    cost_buffer->Write({tf, static_cast<float>(mppi.LastBestCost())});
+    shared.ess.store(mppi.LastEffectiveSampleSize());
+    shared.best_cost.store(mppi.LastBestCost());
+    shared.sim_time.store(t);
+
+    // real-time pacing; while paused the single-step path above still
+    // executes exactly one iteration per credit
+    std::this_thread::sleep_for(
+        std::chrono::milliseconds(static_cast<int>(kDt * 1000)));
+  }
+}
+
+class TunerControlPanel : public quickviz::Panel {
+ public:
+  explicit TunerControlPanel(TunerShared &shared)
+      : Panel("mppi_tuner_controls"), shared_(shared) {
+    SetAutoLayout(true);
+    SetNoResize(true);
+    SetNoMove(true);
+    SetWindowNoMenuButton();
+  }
+
+  void Draw() override {
+    Begin();
+    ImGui::Text("t = %6.1f s   ESS = %5.0f / %d   best cost = %.2f",
+                shared_.sim_time.load(), shared_.ess.load(), kNumSamples,
+                shared_.best_cost.load());
+    ImGui::Separator();
+
+    float lambda = static_cast<float>(shared_.lambda.load());
+    if (ImGui::SliderFloat("lambda (temperature)", &lambda, 0.02f, 2.0f,
+                           "%.3f", ImGuiSliderFlags_Logarithmic)) {
+      shared_.lambda.store(lambda);
+    }
+    float sigma_v = static_cast<float>(shared_.sigma_v.load());
+    if (ImGui::SliderFloat("sigma v [m/s]", &sigma_v, 0.02f, 1.0f, "%.3f")) {
+      shared_.sigma_v.store(sigma_v);
+    }
+    float sigma_w = static_cast<float>(shared_.sigma_w.load());
+    if (ImGui::SliderFloat("sigma omega [rad/s]", &sigma_w, 0.05f, 3.0f,
+                           "%.3f")) {
+      shared_.sigma_w.store(sigma_w);
+    }
+    ImGui::Separator();
+
+    const bool paused = shared_.paused.load();
+    if (ImGui::Button(paused ? "Resume" : "Pause")) {
+      shared_.paused.store(!paused);
+    }
+    ImGui::SameLine();
+    ImGui::BeginDisabled(!paused);
+    if (ImGui::Button("Step")) {
+      shared_.step_credits.fetch_add(1);
+    }
+    ImGui::EndDisabled();
+    ImGui::SameLine();
+    if (ImGui::Button("Reset")) {
+      shared_.reset.store(true);
+    }
+    End();
+  }
+
+ private:
+  TunerShared &shared_;
+};
+
+}  // namespace
+
+int main() {
+  Se2GoalCost goal_cost;
+  goal_cost.goal << 3.5, 1.0, 0.0;
+  CircularObstacleCost obstacle_cost;
+  obstacle_cost.obstacles.push_back({Eigen::Vector2d(1.5, 0.2), 0.4});
+  obstacle_cost.obstacles.push_back({Eigen::Vector2d(2.6, 1.1), 0.3});
+
+  // plot buffers must exist before AddLine() resolves them by name
+  auto &registry = quickviz::BufferRegistry::GetInstance();
+  registry.AddBuffer<PlotPoint>(
+      "mppi.ess", std::make_shared<quickviz::RingBuffer<PlotPoint, 1024>>());
+  registry.AddBuffer<PlotPoint>(
+      "mppi.best_cost",
+      std::make_shared<quickviz::RingBuffer<PlotPoint, 1024>>());
+
+  TunerShared shared;
+  quickviz::DataStream<WorldFrame> stream;
+  std::thread sim(RunSim, std::ref(shared), std::ref(stream),
+                  std::cref(goal_cost), std::cref(obstacle_cost));
+
+  quickviz::Viewer viewer("xmnav MPPI tuner", 1600, 900);
+
+  // world panel: drain the stream and render the latest frame (all on the
+  // render thread; `latest`/`trail` are touched by the draw func only)
+  auto world = std::make_shared<quickviz::CairoWidget>("world", true);
+  world->OnResize(960, 640);  // initial surface; yoga resizes on first frame
+  world->SetAutoLayout(true);
+  world->SetNoResize(true);
+  world->SetNoMove(true);
+  auto latest = std::make_shared<WorldFrame>();
+  auto trail = std::make_shared<std::deque<Eigen::Vector2d>>();
+  CairoWorldFrame view;
+  view.x_min = -0.5;
+  view.x_max = 4.5;
+  view.y_min = -1.0;
+  view.y_max = 2.0;
+  world->AttachDrawFunction([&stream, latest, trail, view, goal_cost,
+                             obstacle_cost](cairo_t *cr, float aspect) {
+    WorldFrame frame;
+    if (stream.TryPull(frame)) {
+      if (frame.t < latest->t) trail->clear();  // sim was reset
+      *latest = std::move(frame);
+      trail->push_back(Eigen::Vector2d(latest->x, latest->y));
+      if (trail->size() > 2000) trail->pop_front();
+    }
+    cairo_set_source_rgba(cr, viz_style::kCairoBackground.x,
+                          viz_style::kCairoBackground.y,
+                          viz_style::kCairoBackground.z, 1.0);
+    cairo_paint(cr);
+    for (const auto &ob : obstacle_cost.obstacles) {
+      DrawDiscCairo(cr, aspect, view, ob.center, ob.radius,
+                    viz_style::kCairoObstacle);
+    }
+    DrawDiscCairo(cr, aspect, view, goal_cost.goal.head<2>(), 0.06,
+                  viz_style::kCairoGoal);
+    DrawTrailCairo(cr, aspect, view, *trail);
+    DrawMppiSnapshotCairo(cr, aspect, view, latest->snapshot);
+    DrawRobotCairo(cr, aspect, view, latest->x, latest->y, latest->theta,
+                   0.12);
+  });
+
+  auto ess_plot = std::make_shared<quickviz::RtLinePlotWidget>("ess_plot");
+  ess_plot->SetAutoLayout(true);
+  ess_plot->SetAxisLabels("t", "ESS");
+  ess_plot->SetAxisUnits("s", "");
+  ess_plot->SetFixedHistory(20.0f);
+  ess_plot->SetYAxisRange(0.0f, static_cast<float>(kNumSamples));
+  ess_plot->AddLine("ESS", "mppi.ess");
+
+  auto cost_plot = std::make_shared<quickviz::RtLinePlotWidget>("cost_plot");
+  cost_plot->SetAutoLayout(true);
+  cost_plot->SetAxisLabels("t", "best cost");
+  cost_plot->SetAxisUnits("s", "");
+  cost_plot->SetFixedHistory(20.0f);
+  cost_plot->SetYAxisRange(0.0f, 200.0f);
+  cost_plot->AddLine("best cost", "mppi.best_cost");
+
+  auto controls = std::make_shared<TunerControlPanel>(shared);
+
+  auto plots = std::make_shared<quickviz::Box>("plots");
+  plots->SetFlexDirection(quickviz::Styling::FlexDirection::kColumn);
+  plots->SetAlignItems(quickviz::Styling::AlignItems::kStretch);
+  plots->SetFlexGrow(1);
+  plots->SetFlexShrink(1);
+  ess_plot->SetFlexGrow(1);
+  ess_plot->SetFlexShrink(1);
+  cost_plot->SetFlexGrow(1);
+  cost_plot->SetFlexShrink(1);
+  plots->AddChild(ess_plot);
+  plots->AddChild(cost_plot);
+
+  auto main_row = std::make_shared<quickviz::Box>("main_row");
+  main_row->SetFlexDirection(quickviz::Styling::FlexDirection::kRow);
+  main_row->SetAlignItems(quickviz::Styling::AlignItems::kStretch);
+  main_row->SetFlexGrow(1);
+  main_row->SetFlexShrink(1);
+  world->SetFlexGrow(2);
+  world->SetFlexShrink(1);
+  main_row->AddChild(world);
+  main_row->AddChild(plots);
+
+  auto root = std::make_shared<quickviz::Box>("root");
+  root->SetFlexDirection(quickviz::Styling::FlexDirection::kColumn);
+  root->SetAlignItems(quickviz::Styling::AlignItems::kStretch);
+  controls->SetHeight(180);
+  controls->SetFlexGrow(0);
+  controls->SetFlexShrink(0);
+  root->AddChild(main_row);
+  root->AddChild(controls);
+
+  viewer.AddSceneObject(root);
+  viewer.Show();
+
+  shared.stop.store(true);
+  sim.join();
+  return 0;
+}

--- a/src/visualization/CMakeLists.txt
+++ b/src/visualization/CMakeLists.txt
@@ -9,7 +9,7 @@ add_library(viz STATIC
     src/lattice_draw.cpp
     src/lattice_viz.cpp)
 target_link_libraries(viz PUBLIC
-    cvdraw
+    image
     mppi
     geometry
     decomp

--- a/src/visualization/CMakeLists.txt
+++ b/src/visualization/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(viz STATIC
     src/lattice_viz.cpp)
 target_link_libraries(viz PUBLIC
     image
+    canvas
     mppi
     geometry
     decomp

--- a/src/visualization/include/xmnav/viz/curvilinear_grid_visual.hpp
+++ b/src/visualization/include/xmnav/viz/curvilinear_grid_visual.hpp
@@ -15,12 +15,12 @@
 
 #include <Eigen/Dense>
 
-#include "cvdraw/cvdraw.hpp"
+#include "image/image.hpp"
 
 #include "xmnav/decomp/curvilinear_grid.hpp"
 #include "xmnav/viz/geometry_draw.hpp"
 #include "xmnav/geometry/polygon.hpp"
-#include "cvdraw/cvdraw.hpp"
+#include "image/image.hpp"
 
 namespace xmotion {
 // geometric grid

--- a/src/visualization/include/xmnav/viz/dense_grid_visual.hpp
+++ b/src/visualization/include/xmnav/viz/dense_grid_visual.hpp
@@ -22,7 +22,7 @@
 #include <opencv2/core/eigen.hpp>
 #include <opencv2/imgproc/imgproc.hpp>
 
-#include "cvdraw/cvdraw.hpp"
+#include "image/image.hpp"
 
 #include "xmnav/decomp/dense_grid.hpp"
 

--- a/src/visualization/include/xmnav/viz/geometry_draw.hpp
+++ b/src/visualization/include/xmnav/viz/geometry_draw.hpp
@@ -10,7 +10,7 @@
 #ifndef XMNAV_VIZ_GEOMETRY_DRAW_HPP
 #define XMNAV_VIZ_GEOMETRY_DRAW_HPP
 
-#include "cvdraw/cvdraw.hpp"
+#include "image/image.hpp"
 
 #include "xmnav/geometry/polyline.hpp"
 #include "xmnav/geometry/cubic_spline.hpp"

--- a/src/visualization/include/xmnav/viz/lattice_draw.hpp
+++ b/src/visualization/include/xmnav/viz/lattice_draw.hpp
@@ -14,7 +14,7 @@
 #include "xmnav/state_lattice/motion_primitive.hpp"
 #include "xmnav/state_lattice/state_lattice.hpp"
 
-#include "cvdraw/cvdraw.hpp"
+#include "image/image.hpp"
 
 namespace xmotion
 {

--- a/src/visualization/include/xmnav/viz/mppi_draw.hpp
+++ b/src/visualization/include/xmnav/viz/mppi_draw.hpp
@@ -16,7 +16,7 @@
 
 #include <algorithm>
 
-#include "cvdraw/cvdraw.hpp"
+#include "image/image.hpp"
 
 #include "xmnav/mppi/mppi.hpp"
 #include "xmnav/viz/style.hpp"

--- a/src/visualization/include/xmnav/viz/mppi_draw_cairo.hpp
+++ b/src/visualization/include/xmnav/viz/mppi_draw_cairo.hpp
@@ -1,0 +1,174 @@
+/*
+ * @file mppi_draw_cairo.hpp
+ * @brief Cairo (vector) rendering of MPPI introspection snapshots.
+ *
+ * Counterpart of mppi_draw.hpp for the quickviz canvas module: candidate
+ * rollouts are drawn as anti-aliased polylines whose *alpha* encodes the
+ * softmax weight, so overlapping candidates composite into a density fan —
+ * something the raster CvCanvas drawer cannot do (it encodes weight as
+ * intensity and later strokes overwrite earlier ones).
+ *
+ * Coordinates: all drawers take a CairoWorldFrame that maps world meters
+ * into the normalized coordinates of a CairoWidget constructed with
+ * normalize_coordinate = true (x in [0, aspect_ratio], y in [0, 1],
+ * y-down). The mapping preserves aspect (meters stay square) and centers
+ * the world rect in the panel.
+ *
+ * Copyright (c) 2026 Ruixiang Du (rdu)
+ */
+
+#ifndef XMNAV_VIZ_MPPI_DRAW_CAIRO_HPP
+#define XMNAV_VIZ_MPPI_DRAW_CAIRO_HPP
+
+#include <algorithm>
+#include <cmath>
+
+#include "canvas/details/cairo_draw.hpp"
+
+#include "xmnav/mppi/mppi.hpp"
+
+namespace xmotion {
+
+// World-to-canvas mapping for a normalized-coordinate CairoWidget.
+struct CairoWorldFrame {
+  double x_min = 0.0;
+  double x_max = 1.0;
+  double y_min = 0.0;
+  double y_max = 1.0;
+
+  // meters -> canvas units (canvas unit = panel height); aspect-preserving
+  double Scale(float aspect_ratio) const {
+    const double sx = aspect_ratio / (x_max - x_min);
+    const double sy = 1.0 / (y_max - y_min);
+    return std::min(sx, sy);
+  }
+
+  ImVec2 ToCanvas(double wx, double wy, float aspect_ratio) const {
+    const double s = Scale(aspect_ratio);
+    const double ox = 0.5 * (aspect_ratio - s * (x_max - x_min));
+    const double oy = 0.5 * (1.0 - s * (y_max - y_min));
+    return ImVec2(static_cast<float>(ox + s * (wx - x_min)),
+                  static_cast<float>(1.0 - oy - s * (wy - y_min)));
+  }
+};
+
+namespace viz_style {
+// cairo colors (rgba in [0,1]); the CvScalar palette in style.hpp is BGR-byte
+inline const ImVec4 kCairoBackground = {1.0f, 1.0f, 1.0f, 1.0f};
+inline const ImVec4 kCairoCandidateFan = {0.86f, 0.20f, 0.15f, 1.0f};
+inline const ImVec4 kCairoChosenTrajectory = {0.12f, 0.35f, 0.90f, 1.0f};
+inline const ImVec4 kCairoExecutedTrail = {0.15f, 0.15f, 0.15f, 0.9f};
+inline const ImVec4 kCairoGoal = {0.10f, 0.65f, 0.25f, 0.9f};
+inline const ImVec4 kCairoObstacle = {0.55f, 0.55f, 0.55f, 0.8f};
+inline const ImVec4 kCairoRobot = {0.10f, 0.10f, 0.10f, 1.0f};
+}  // namespace viz_style
+
+namespace viz_cairo_detail {
+// stroke rows [0, rows) of a state matrix as one cairo path
+template <typename StateMatrix>
+inline void StrokeStates(cairo_t *cr, const CairoWorldFrame &frame,
+                         float aspect_ratio, const StateMatrix &states,
+                         int x_col, int y_col, double width,
+                         const ImVec4 &color, double alpha) {
+  if (states.rows() < 2) return;
+  cairo_save(cr);
+  cairo_set_source_rgba(cr, color.x, color.y, color.z, alpha);
+  cairo_set_line_width(cr, width);
+  cairo_set_line_join(cr, CAIRO_LINE_JOIN_ROUND);
+  const ImVec2 p0 =
+      frame.ToCanvas(states(0, x_col), states(0, y_col), aspect_ratio);
+  cairo_move_to(cr, p0.x, p0.y);
+  for (Eigen::Index t = 1; t < states.rows(); ++t) {
+    const ImVec2 p =
+        frame.ToCanvas(states(t, x_col), states(t, y_col), aspect_ratio);
+    cairo_line_to(cr, p.x, p.y);
+  }
+  cairo_stroke(cr);
+  cairo_restore(cr);
+}
+}  // namespace viz_cairo_detail
+
+// Candidate fan (alpha ~ softmax weight, normalized to the strongest
+// candidate) with the updated nominal trajectory on top. Any two state
+// columns can serve as the drawing plane, as in DrawMppiSnapshot2D.
+template <int StateDim, int ControlDim>
+inline void DrawMppiSnapshotCairo(cairo_t *cr, float aspect_ratio,
+                                  const CairoWorldFrame &frame,
+                                  const MppiSnapshot<StateDim, ControlDim> &snap,
+                                  int x_col = 0, int y_col = 1) {
+  double w_max = 1e-12;
+  for (const auto &c : snap.candidates) w_max = std::max(w_max, c.weight);
+
+  for (const auto &c : snap.candidates) {
+    // floor keeps discarded candidates faintly visible (sampling coverage);
+    // influential ones composite into an opaque core
+    const double alpha = 0.04 + 0.56 * (c.weight / w_max);
+    viz_cairo_detail::StrokeStates(cr, frame, aspect_ratio, c.states, x_col,
+                                   y_col, 0.0018,
+                                   viz_style::kCairoCandidateFan, alpha);
+  }
+  viz_cairo_detail::StrokeStates(cr, frame, aspect_ratio, snap.nominal_states,
+                                 x_col, y_col, 0.004,
+                                 viz_style::kCairoChosenTrajectory, 1.0);
+}
+
+inline void DrawDiscCairo(cairo_t *cr, float aspect_ratio,
+                          const CairoWorldFrame &frame,
+                          const Eigen::Vector2d &center, double radius_m,
+                          const ImVec4 &color, bool fill = true) {
+  const ImVec2 c = frame.ToCanvas(center.x(), center.y(), aspect_ratio);
+  const double r = radius_m * frame.Scale(aspect_ratio);
+  cairo_save(cr);
+  cairo_set_source_rgba(cr, color.x, color.y, color.z, color.w);
+  cairo_arc(cr, c.x, c.y, r, 0.0, 2.0 * M_PI);
+  if (fill) {
+    cairo_fill(cr);
+  } else {
+    cairo_set_line_width(cr, 0.003);
+    cairo_stroke(cr);
+  }
+  cairo_restore(cr);
+}
+
+// body disc + heading tick
+inline void DrawRobotCairo(cairo_t *cr, float aspect_ratio,
+                           const CairoWorldFrame &frame, double x, double y,
+                           double theta, double radius_m,
+                           const ImVec4 &color = viz_style::kCairoRobot) {
+  DrawDiscCairo(cr, aspect_ratio, frame, {x, y}, radius_m, color, false);
+  const ImVec2 c = frame.ToCanvas(x, y, aspect_ratio);
+  const ImVec2 h = frame.ToCanvas(x + radius_m * std::cos(theta),
+                                  y + radius_m * std::sin(theta),
+                                  aspect_ratio);
+  cairo_save(cr);
+  cairo_set_source_rgba(cr, color.x, color.y, color.z, color.w);
+  cairo_set_line_width(cr, 0.003);
+  cairo_move_to(cr, c.x, c.y);
+  cairo_line_to(cr, h.x, h.y);
+  cairo_stroke(cr);
+  cairo_restore(cr);
+}
+
+// executed path as a polyline; Trail is any container of Eigen::Vector2d
+template <typename Trail>
+inline void DrawTrailCairo(cairo_t *cr, float aspect_ratio,
+                           const CairoWorldFrame &frame, const Trail &trail,
+                           const ImVec4 &color = viz_style::kCairoExecutedTrail) {
+  if (trail.size() < 2) return;
+  cairo_save(cr);
+  cairo_set_source_rgba(cr, color.x, color.y, color.z, color.w);
+  cairo_set_line_width(cr, 0.002);
+  auto it = trail.begin();
+  ImVec2 p = frame.ToCanvas((*it).x(), (*it).y(), aspect_ratio);
+  cairo_move_to(cr, p.x, p.y);
+  for (++it; it != trail.end(); ++it) {
+    p = frame.ToCanvas((*it).x(), (*it).y(), aspect_ratio);
+    cairo_line_to(cr, p.x, p.y);
+  }
+  cairo_stroke(cr);
+  cairo_restore(cr);
+}
+
+}  // namespace xmotion
+
+#endif  // XMNAV_VIZ_MPPI_DRAW_CAIRO_HPP

--- a/src/visualization/include/xmnav/viz/rrt_draw.hpp
+++ b/src/visualization/include/xmnav/viz/rrt_draw.hpp
@@ -14,7 +14,7 @@
 #include <cstdint>
 
 #include "graph/tree.hpp"
-#include "cvdraw/cvdraw.hpp"
+#include "image/image.hpp"
 
 namespace xmotion {
 namespace RRTViz {

--- a/src/visualization/include/xmnav/viz/sim_viewer.hpp
+++ b/src/visualization/include/xmnav/viz/sim_viewer.hpp
@@ -29,7 +29,7 @@
 
 #include <opencv2/imgcodecs.hpp>
 
-#include "cvdraw/cvdraw.hpp"
+#include "image/image.hpp"
 
 #include "xmnav/viz/style.hpp"
 

--- a/src/visualization/include/xmnav/viz/square_grid_visual.hpp
+++ b/src/visualization/include/xmnav/viz/square_grid_visual.hpp
@@ -13,7 +13,7 @@
 
 #include <cstdint>
 
-#include "cvdraw/cvdraw.hpp"
+#include "image/image.hpp"
 
 #include "xmnav/decomp/square_grid.hpp"
 #include "graph/graph.hpp"

--- a/src/visualization/include/xmnav/viz/style.hpp
+++ b/src/visualization/include/xmnav/viz/style.hpp
@@ -11,7 +11,7 @@
 
 #include <algorithm>
 
-#include "cvdraw/cvdraw.hpp"
+#include "image/image.hpp"
 
 namespace xmotion {
 namespace viz_style {

--- a/src/visualization/src/lattice_viz.cpp
+++ b/src/visualization/src/lattice_viz.cpp
@@ -9,7 +9,7 @@
 
 #include "xmnav/viz/lattice_viz.hpp"
 
-#include "cvdraw/cvdraw.hpp"
+#include "image/image.hpp"
 #include "xmnav/viz/lattice_draw.hpp"
 
 using namespace xmotion;

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -19,7 +19,15 @@ add_subdirectory(quadprog++)
 # third-party code — consumed by the visualization-gated modules and demos
 # only, never part of the deployment closure (ADR 0005 dependency classes).
 if (ENABLE_VISUALIZATION)
-  option(QUICKVIZ_DEV_MODE "Build quickviz in dev mode" ON)
-  option(BUILD_QUICKVIZ_APP "Build quickviz application" ON)
+  # library modules only — upstream samples, apps, and tests are not part
+  # of this build (xmViewer has its own CI)
+  option(QUICKVIZ_DEV_MODE "Build quickviz in dev mode" OFF)
+  option(BUILD_QUICKVIZ_APP "Build quickviz application" OFF)
+  set(_xm_build_testing ${BUILD_TESTING})
+  set(BUILD_TESTING OFF)
+  # honor normal variables over option() in the subtree (CMP0077)
+  set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
   add_subdirectory(quickviz)
+  set(BUILD_TESTING ${_xm_build_testing})
+  unset(_xm_build_testing)
 endif ()


### PR DESCRIPTION
## Summary

Complete Viz v2 in one PR, in two commits:

**1. Migration to the restructured quickviz (xmViewer)** — pin moves to the new `core/viewer/scene/plot/canvas/image` architecture (318daf4 = upstream `main` + the stb target guard of quickviz#30). First-party viz code moves from the retired `cvdraw` to the `image/` module (`CvCanvas`/`CvIO`, API-compatible); upstream options are scoped out of our build (`BUILD_QUICKVIZ_APP`/`QUICKVIZ_DEV_MODE` off, `BUILD_TESTING` isolated via CMP0077).

**2. Interactive MPPI tuner** — the first consumer of the viewer shell:

- `xmnav/viz/mppi_draw_cairo.hpp`: cairo drawers for the world view. Candidate rollouts encode softmax weight as **alpha**, so overlapping samples composite into a sampling-density corridor around the chosen trajectory — the capability that motivated adding cairo to the v2 scope (raster strokes can only overwrite).
- `tuner_mppi_diffdrive` (built with `ENABLE_VISUALIZATION=ON`): quickviz `Viewer` + `Box` flexbox layout hosting the cairo world panel, live ESS / best-cost strip charts (`RtLinePlotWidget` fed through `BufferRegistry` ring buffers), and a control panel with pause / single-step / reset plus live λ / σ_v / σ_ω sliders.
- Threading follows the quickviz contract: GL/ImGui stay on the main thread; the sim runs on a background thread and publishes frames through a latest-only `DataStream`; tuning knobs travel UI → sim through atomics and are applied between `Plan()` calls.
- `Mppi::SetTemperature` / `SetSigma`: validated live-tuning setters; `SetSigma` keeps the cached Σ⁻¹ of the control-cost term consistent (the reason σ is not tunable through a raw params reference).
- WERROR: quickviz include dirs join the existing vendored SYSTEM-include list so third-party headers don't gate first-party `-Werror` builds.

## Verification

- viz-on gate: build + 53/53 tests; viz-off gate: build + 52/52 tests; WERROR viz-on build clean
- Tuner exercised under Xvfb (software GL): world panel renders obstacles/goal/trail/robot, the alpha fan and nominal trajectory update live, ESS ≈ 480/1024 and cost-decay traces plot correctly, control panel fully visible, clean shutdown (sim thread joined)

## Notes

- Precondition: quickviz PR #30 (stb target guard) — the pin already includes it; merge that first so the pinned commit is reachable from upstream `main`.
- Follow-ups (separate PRs): fix the unused-variable/parameter warnings in quickviz `core/event` + `viewer` headers upstream; scene/ 3D evaluation for the SRB quadruped.