### PR TITLE
feat(control): output-stage safety shield (envelope + ctfsm ladder + CBF filter)

### DIFF
--- a/docs/control/safety_shield.md
+++ b/docs/control/safety_shield.md
@@ -1,0 +1,36 @@
+# Safety Shield
+
+An output-stage command filter between a controller (`Mppi::Command()`, PID, teleop) and the actuator write. Sampling-based controllers treat constraints as soft penalties; the shield is the hard layer the technical note and the obstacle critic explicitly defer to ("safety-critical constraints need an output-stage shield on top"). It is a library stage, not a runtime node: the application calls `Filter()` once per control tick and forwards the result (ADR 0005 / algorithm-core composition).
+
+## Scenarios (acceptance set)
+
+These are the module's contract; each is implemented verbatim in `test_shield_scenarios.cpp`.
+
+- **S1 — command spike.** The controller emits a step from 0 to well beyond the platform's acceleration ability. The issued command follows at the configured rate limit, per channel; the report marks the envelope active. No mode change.
+- **S2 — invalid command.** The controller emits NaN. The shield holds the last safe command (`kHold`). If the fault clears within `hold_timeout`, operation resumes seamlessly (`kNormal`). If it persists, the shield ramps the held command to zero over `stop_ramp_time` (`kStopping`) and latches `kStopped`; only an explicit operator `Reset()` (with valid inputs) re-arms.
+- **S3 — closing obstacle.** Commanded full speed toward an obstacle. The barrier filter attenuates the command as clearance shrinks so the platform never crosses the safety distance, and leaves the command untouched while far away (minimal intervention).
+- **S4 — stale state.** The state estimate stops updating (`state_age` exceeds the configured maximum). Same ladder as S2: hold, then controlled stop. A state too old to trust is treated exactly like an invalid command.
+- **S5 — quadruped GRF outside the friction cone** *(future, with the SRB shield)*: stance-foot forces are projected onto the cone before actuation.
+- **S6 — e-stop from anywhere.** `TriggerEStop()` in any mode → `kStopped` (zero command) on the next tick, including mid-ramp. Guarded `Reset()` re-arms.
+
+## Layers
+
+1. **Command envelope** (`command_envelope.hpp`) — per-channel box clamps plus rate limits relative to the last *issued* command. Model-free, always on, exhaustively testable.
+2. **Barrier filter** (`diff_drive_barrier.hpp`) — control-barrier-function constraint for planar circular obstacles using the look-ahead-point formulation for the unicycle (the CBF is relative-degree-1 in both `v` and `omega` at a point offset `l` ahead of the axle). Minimal command modification via a small QP (vendored QuadProg++, Goldfarb–Idnani): `min ||u − u_des||²` subject to `ḣ_i ≥ −α·h_i` per active obstacle plus the actuator box. A QP failure (e.g. started inside an obstacle) is reported and treated by the ladder as a fault — never silently passed through.
+3. **Fallback ladder** (`fallback_ladder.hpp`) — `Normal → Hold → Stopping → Stopped` with an e-stop wildcard, built on the vendored `ctfsm` engine (its first in-tree consumer): the transition table is compile-time-verified, dispatch is allocation-free, and illegal events are refused rather than acted on.
+
+`WheeledShield` (`wheeled_shield.hpp`) composes the three for a diff-drive platform and owns the per-tick sequencing.
+
+## Semantics and assumptions
+
+- **Units/frames:** commands are `[v (m/s), omega (rad/s)]`; state is `[x, y, theta]` in the world frame, `state_age` in seconds. All documented per header.
+- **Validation at the boundary:** non-finite command or state, or `state_age > state_staleness_max`, is a fault. The hot path never throws; faults degrade through the ladder and are visible in the `ShieldReport` and telemetry.
+- **Timing:** `Filter()` is deterministic and O(active obstacles); the QP solves a 2-variable problem with a bounded constraint set (`kMaxActiveObstacles` + box). Known limitation: QuadProg++ allocates internally per solve — acceptable at control rates (µs-scale, small problem), and the barrier only engages within its influence radius; replace with a preallocated solver if it ever shows in traces.
+- **The shield reports everything it does:** `ShieldReport` per tick (mode, which layer engaged, minimum clearance) and telemetry (`control.shield.mode` gauge, `control.shield.faults` / `control.shield.barrier_active` counters). A shield that silently edits commands is an observability hole.
+- **E-stop:** `TriggerEStop()` takes effect on the next `Filter()` call. It complements, never replaces, the hardware e-stop chain.
+- **Recovery policy:** deliberately conservative — no automatic recovery from `kStopping`/`kStopped`; a human (or supervisor with equivalent authority) calls `Reset()`, which is guarded on inputs being valid again.
+
+## References
+
+- Ames et al., "Control Barrier Functions: Theory and Applications", ECC 2019 (the CBF-QP filter pattern).
+- The look-ahead-point unicycle formulation is standard in CBF practice for differential-drive robots (relative-degree fix by output point offset).

--- a/src/control/CMakeLists.txt
+++ b/src/control/CMakeLists.txt
@@ -1,7 +1,11 @@
 # fsm (ctfsm) is a vendored family submodule, like planning/graph (libgraph):
-# compile-time-verified FSM engine; tests/examples/install are upstream-gated
+# compile-time-verified FSM engine; tests/examples are upstream-gated.
+# Install/export stays ON: exported consumers (shield) link ctfsm::ctfsm,
+# so the target must belong to an installed export set.
+set(CTFSM_INSTALL ON)
 add_subdirectory(fsm)
 add_subdirectory(model)
 add_subdirectory(pid)
 add_subdirectory(kinematics)
 add_subdirectory(mppi)
+add_subdirectory(shield)

--- a/src/control/shield/CMakeLists.txt
+++ b/src/control/shield/CMakeLists.txt
@@ -1,0 +1,30 @@
+## Dependency libraries
+find_package(Eigen3 REQUIRED NO_MODULE)
+
+## Output-stage safety shield (docs/control/safety_shield.md): command
+## envelope + CBF barrier filter (QuadProg++) + ctfsm fallback ladder.
+## Header-only; algorithm-core composition (no runtime tier).
+add_library(shield INTERFACE)
+target_link_libraries(shield INTERFACE
+    xmotion::xmBase
+    ctfsm::ctfsm
+    quadprogpp
+    Eigen3::Eigen)
+target_include_directories(shield INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>)
+add_library(xmotion::shield ALIAS shield)
+
+if (BUILD_TESTS)
+  add_subdirectory(test)
+endif ()
+
+install(TARGETS shield
+    EXPORT xmNavigationTargets
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+    RUNTIME DESTINATION bin
+    INCLUDES DESTINATION include)
+
+install(DIRECTORY include/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/src/control/shield/include/xmnav/shield/command_envelope.hpp
+++ b/src/control/shield/include/xmnav/shield/command_envelope.hpp
@@ -1,0 +1,58 @@
+/*
+ * @file command_envelope.hpp
+ * @brief Per-channel box + rate limits on controller commands.
+ *
+ * The model-free, always-on first layer of the safety shield: absolute
+ * box clamps plus a slew-rate limit relative to the last *issued* command
+ * (not the last requested one, so a runaway request cannot drag the
+ * reference). Scenario S1 of docs/control/safety_shield.md.
+ *
+ * Copyright (c) 2026 Ruixiang Du (rdu)
+ */
+
+#ifndef XMNAV_SHIELD_COMMAND_ENVELOPE_HPP
+#define XMNAV_SHIELD_COMMAND_ENVELOPE_HPP
+
+#include <limits>
+
+#include <eigen3/Eigen/Dense>
+
+namespace xmotion {
+
+template <int ControlDim>
+struct CommandEnvelope {
+  using Control = Eigen::Matrix<double, ControlDim, 1>;
+
+  // absolute per-channel bounds
+  Control u_min =
+      Control::Constant(-std::numeric_limits<double>::infinity());
+  Control u_max = Control::Constant(std::numeric_limits<double>::infinity());
+  // per-channel |du/dt| cap (infinity disables)
+  Control rate_limit =
+      Control::Constant(std::numeric_limits<double>::infinity());
+
+  // box first, then slew toward the box-clamped target from u_prev;
+  // u_prev is the last issued command and must be finite (the facade
+  // guarantees it). Sets *clamped when any limit engaged.
+  Control Apply(const Control &u, const Control &u_prev, double dt,
+                bool *clamped = nullptr) const {
+    Control out = u.cwiseMax(u_min).cwiseMin(u_max);
+    for (int j = 0; j < ControlDim; ++j) {
+      const double max_step = rate_limit(j) * dt;
+      const double step = out(j) - u_prev(j);
+      if (step > max_step) {
+        out(j) = u_prev(j) + max_step;
+      } else if (step < -max_step) {
+        out(j) = u_prev(j) - max_step;
+      }
+    }
+    if (clamped != nullptr) {
+      *clamped = (out.array() != u.array()).any();
+    }
+    return out;
+  }
+};
+
+}  // namespace xmotion
+
+#endif  // XMNAV_SHIELD_COMMAND_ENVELOPE_HPP

--- a/src/control/shield/include/xmnav/shield/diff_drive_barrier.hpp
+++ b/src/control/shield/include/xmnav/shield/diff_drive_barrier.hpp
@@ -1,0 +1,160 @@
+/*
+ * @file diff_drive_barrier.hpp
+ * @brief Control-barrier-function command filter for a diff-drive robot
+ *        among circular obstacles.
+ *
+ * The hard counterpart of the soft CircularObstacleCost: minimally modify
+ * the commanded [v, omega] so that h_i(x) = ||p_l - o_i||^2 - D_i^2 obeys
+ * dh_i/dt >= -alpha h_i for every obstacle, where p_l is the look-ahead
+ * point l ahead of the axle (the standard relative-degree fix that makes
+ * the constraint linear in BOTH v and omega for a unicycle). Guaranteeing
+ * the look-ahead point keeps distance D + l guarantees the axle keeps D,
+ * so D_i = r_i + robot_radius + margin + look_ahead.
+ *
+ * The filter is a 2-variable QP (min ||u - u_des||^2 s.t. the active
+ * barrier rows + the actuator box), solved with the vendored QuadProg++
+ * (Goldfarb-Idnani, MIT). Fast path: when u_des already satisfies every
+ * row, no QP runs and the command passes through untouched (minimal
+ * intervention, scenario S3). Known limitation: QuadProg++ allocates
+ * internally per solve — µs-scale at this size; replace with a
+ * preallocated solver if it ever shows in traces.
+ *
+ * A QP with no feasible command (e.g. already inside an obstacle) is
+ * reported via ShieldReport::barrier_infeasible and must be treated as a
+ * fault by the caller — it is never silently passed through.
+ *
+ * Units: state [x m, y m, theta rad] world frame; command [v m/s,
+ * omega rad/s].
+ *
+ * Copyright (c) 2026 Ruixiang Du (rdu)
+ */
+
+#ifndef XMNAV_SHIELD_DIFF_DRIVE_BARRIER_HPP
+#define XMNAV_SHIELD_DIFF_DRIVE_BARRIER_HPP
+
+#include <cmath>
+#include <limits>
+#include <vector>
+
+#include <eigen3/Eigen/Dense>
+
+#include "quadprog++/QuadProg++.hh"
+
+#include "xmnav/shield/report.hpp"
+
+namespace xmotion {
+
+class DiffDriveBarrierFilter {
+ public:
+  struct Obstacle {
+    Eigen::Vector2d center;
+    double radius;
+  };
+
+  struct Config {
+    double look_ahead = 0.15;  // l > 0 [m]
+    double alpha = 2.0;        // class-K gain [1/s]
+    double margin = 0.10;      // extra clearance beyond the radii [m]
+    double robot_radius = 0.0;
+    // obstacles farther than this clearance are skipped entirely
+    double influence_distance = 2.0;  // [m]
+    // actuator box (mirror the controller's params.u_min/u_max)
+    Eigen::Vector2d u_min{-std::numeric_limits<double>::infinity(),
+                          -std::numeric_limits<double>::infinity()};
+    Eigen::Vector2d u_max{std::numeric_limits<double>::infinity(),
+                          std::numeric_limits<double>::infinity()};
+    std::vector<Obstacle> obstacles;
+  };
+
+  explicit DiffDriveBarrierFilter(Config config)
+      : config_(std::move(config)) {}
+
+  const Config &config() const { return config_; }
+  Config &config() { return config_; }
+
+  // Minimally modified command; fills the barrier fields of *report.
+  Eigen::Vector2d Filter(const Eigen::Vector3d &state,
+                         const Eigen::Vector2d &u_des,
+                         ShieldReport *report) const {
+    const double c = std::cos(state(2));
+    const double s = std::sin(state(2));
+    const double l = config_.look_ahead;
+    const Eigen::Vector2d p(state(0), state(1));
+    const Eigen::Vector2d p_l = p + l * Eigen::Vector2d(c, s);
+    // dp_l/dt = M(theta) [v, omega]
+    Eigen::Matrix2d M;
+    M << c, -l * s, s, l * c;
+
+    // collect active rows a^T u >= -alpha h
+    std::vector<Eigen::Vector2d> rows;
+    std::vector<double> offsets;  // ci0 = alpha h
+    rows.reserve(config_.obstacles.size());
+    offsets.reserve(config_.obstacles.size());
+    double min_clearance = std::numeric_limits<double>::infinity();
+    bool all_satisfied = true;
+    for (const auto &ob : config_.obstacles) {
+      const double clearance =
+          (p - ob.center).norm() - ob.radius - config_.robot_radius;
+      min_clearance = std::min(min_clearance, clearance);
+      if (clearance > config_.influence_distance) continue;
+      const double safe_dist =
+          ob.radius + config_.robot_radius + config_.margin + l;
+      const Eigen::Vector2d d = p_l - ob.center;
+      const double h = d.squaredNorm() - safe_dist * safe_dist;
+      const Eigen::Vector2d a = 2.0 * M.transpose() * d;
+      rows.push_back(a);
+      offsets.push_back(config_.alpha * h);
+      if (a.dot(u_des) + config_.alpha * h < 0.0) all_satisfied = false;
+    }
+    if (report != nullptr) {
+      report->min_clearance = min_clearance;
+      report->barrier_active = false;
+      report->barrier_infeasible = false;
+    }
+    if (rows.empty() || all_satisfied) {
+      return u_des;  // minimal intervention: nothing to do
+    }
+
+    // QP: min 1/2 u^T I u - u_des^T u  s.t.  CI^T u + ci0 >= 0
+    const int n = 2;
+    const int m = static_cast<int>(rows.size()) + 4;  // rows + box
+    quadprogpp::Matrix<double> G(n, n), CE(n, 0), CI(n, m);
+    quadprogpp::Vector<double> g0(n), ce0(0), ci0(m), x(n);
+    G[0][0] = 1.0; G[0][1] = 0.0; G[1][0] = 0.0; G[1][1] = 1.0;
+    g0[0] = -u_des(0);
+    g0[1] = -u_des(1);
+    int col = 0;
+    for (std::size_t i = 0; i < rows.size(); ++i, ++col) {
+      CI[0][col] = rows[i](0);
+      CI[1][col] = rows[i](1);
+      ci0[col] = offsets[i];
+    }
+    for (int j = 0; j < 2; ++j) {
+      // u_j >= u_min_j and -u_j >= -u_max_j (skip infinities via huge ci0)
+      CI[0][col] = (j == 0) ? 1.0 : 0.0;
+      CI[1][col] = (j == 1) ? 1.0 : 0.0;
+      ci0[col] = std::isfinite(config_.u_min(j)) ? -config_.u_min(j) : 1e30;
+      ++col;
+      CI[0][col] = (j == 0) ? -1.0 : 0.0;
+      CI[1][col] = (j == 1) ? -1.0 : 0.0;
+      ci0[col] = std::isfinite(config_.u_max(j)) ? config_.u_max(j) : 1e30;
+      ++col;
+    }
+    const double cost =
+        quadprogpp::solve_quadprog(G, g0, CE, ce0, CI, ci0, x);
+    if (!std::isfinite(cost) || !std::isfinite(x[0]) ||
+        !std::isfinite(x[1])) {
+      if (report != nullptr) report->barrier_infeasible = true;
+      return u_des;  // caller must treat this tick as a fault
+    }
+    if (report != nullptr) report->barrier_active = true;
+    return Eigen::Vector2d(x[0], x[1]);
+  }
+
+ private:
+  Config config_;
+};
+
+}  // namespace xmotion
+
+#endif  // XMNAV_SHIELD_DIFF_DRIVE_BARRIER_HPP

--- a/src/control/shield/include/xmnav/shield/fallback_ladder.hpp
+++ b/src/control/shield/include/xmnav/shield/fallback_ladder.hpp
@@ -1,0 +1,149 @@
+/*
+ * @file fallback_ladder.hpp
+ * @brief Degradation ladder of the safety shield: Normal -> Hold ->
+ *        Stopping -> Stopped, with an e-stop wildcard.
+ *
+ * Built on the vendored ctfsm engine (its first in-tree consumer): the
+ * transition table below is the complete legal graph, verified at compile
+ * time; dispatch is allocation-free and an event with no row in the
+ * current state is refused, which is exactly the policy encoding — e.g.
+ * InputRecovered is dispatched every healthy tick and only does something
+ * in kHold (no automatic recovery from kStopping/kStopped; a guarded
+ * operator Reset() re-arms). Scenarios S2/S4/S6 of
+ * docs/control/safety_shield.md.
+ *
+ * Copyright (c) 2026 Ruixiang Du (rdu)
+ */
+
+#ifndef XMNAV_SHIELD_FALLBACK_LADDER_HPP
+#define XMNAV_SHIELD_FALLBACK_LADDER_HPP
+
+#include <algorithm>
+
+#include "ctfsm/fsm.hpp"
+
+#include "xmnav/shield/report.hpp"
+
+namespace xmotion {
+
+namespace shield_detail {
+
+struct LadderContext {
+  ShieldMode mode = ShieldMode::kNormal;
+  double hold_timeout = 0.3;    // s in kHold before the controlled stop
+  double stop_ramp_time = 0.5;  // s to ramp the held command to zero
+  double dt = 0.0;              // set by Tick() before the FSM update
+  double hold_elapsed = 0.0;
+  double ramp_elapsed = 0.0;
+  bool reset_allowed = false;   // set by the facade before Reset dispatch
+};
+
+struct Normal {
+  void OnEnter(LadderContext &c) { c.mode = ShieldMode::kNormal; }
+};
+struct Hold {
+  void OnEnter(LadderContext &c) {
+    c.mode = ShieldMode::kHold;
+    c.hold_elapsed = 0.0;
+  }
+  void Update(LadderContext &c) { c.hold_elapsed += c.dt; }
+};
+struct Stopping {
+  void OnEnter(LadderContext &c) {
+    c.mode = ShieldMode::kStopping;
+    c.ramp_elapsed = 0.0;
+  }
+  void Update(LadderContext &c) { c.ramp_elapsed += c.dt; }
+};
+struct Stopped {
+  void OnEnter(LadderContext &c) { c.mode = ShieldMode::kStopped; }
+};
+
+// events
+struct FaultDetected {};
+struct InputRecovered {};
+struct HoldExpired {};
+struct RampComplete {};
+struct EStopEvent {};
+struct ResetEvent {};
+
+struct ResetAllowed {
+  bool operator()(const LadderContext &c) const noexcept {
+    return c.reset_allowed;
+  }
+};
+
+// clang-format off
+using LadderMachine = ctfsm::StateMachine<LadderContext,
+    ctfsm::StateList<Normal, Hold, Stopping, Stopped>,
+    ctfsm::Table<
+      //          From             Event           To        Guard
+      ctfsm::Row< Normal,          FaultDetected,  Hold                    >,
+      ctfsm::Row< Hold,            InputRecovered, Normal                  >,
+      ctfsm::Row< Hold,            HoldExpired,    Stopping                >,
+      ctfsm::Row< Stopping,        RampComplete,   Stopped                 >,
+      ctfsm::Row< ctfsm::AnyState, EStopEvent,     Stopped                 >,
+      ctfsm::Row< Stopped,         ResetEvent,     Normal,   ResetAllowed  >>>;
+// clang-format on
+
+}  // namespace shield_detail
+
+class FallbackLadder {
+ public:
+  struct Config {
+    double hold_timeout = 0.3;    // s
+    double stop_ramp_time = 0.5;  // s
+  };
+
+  explicit FallbackLadder(const Config &config) {
+    ctx_.hold_timeout = config.hold_timeout;
+    ctx_.stop_ramp_time = config.stop_ramp_time;
+    fsm_.Start(ctx_);
+  }
+
+  void OnFault() { fsm_.Dispatch(shield_detail::FaultDetected{}, ctx_); }
+  void OnRecovered() {
+    fsm_.Dispatch(shield_detail::InputRecovered{}, ctx_);
+  }
+  void TriggerEStop() { fsm_.Dispatch(shield_detail::EStopEvent{}, ctx_); }
+
+  // guarded re-arm; the caller states whether inputs are currently valid
+  bool Reset(bool inputs_valid) {
+    ctx_.reset_allowed = inputs_valid;
+    const bool accepted = fsm_.Dispatch(shield_detail::ResetEvent{}, ctx_);
+    ctx_.reset_allowed = false;
+    return accepted;
+  }
+
+  // advance timers and fire the timeout transitions
+  void Tick(double dt) {
+    ctx_.dt = dt;
+    fsm_.Update(ctx_);
+    if (ctx_.mode == ShieldMode::kHold &&
+        ctx_.hold_elapsed >= ctx_.hold_timeout) {
+      fsm_.Dispatch(shield_detail::HoldExpired{}, ctx_);
+    }
+    if (ctx_.mode == ShieldMode::kStopping &&
+        ctx_.ramp_elapsed >= ctx_.stop_ramp_time) {
+      fsm_.Dispatch(shield_detail::RampComplete{}, ctx_);
+    }
+  }
+
+  ShieldMode mode() const { return ctx_.mode; }
+
+  // scale in [0, 1] to apply to the held command while stopping
+  double RampScale() const {
+    if (ctx_.mode != ShieldMode::kStopping) {
+      return ctx_.mode == ShieldMode::kHold ? 1.0 : 0.0;
+    }
+    return std::max(0.0, 1.0 - ctx_.ramp_elapsed / ctx_.stop_ramp_time);
+  }
+
+ private:
+  shield_detail::LadderContext ctx_;
+  shield_detail::LadderMachine fsm_;
+};
+
+}  // namespace xmotion
+
+#endif  // XMNAV_SHIELD_FALLBACK_LADDER_HPP

--- a/src/control/shield/include/xmnav/shield/report.hpp
+++ b/src/control/shield/include/xmnav/shield/report.hpp
@@ -1,0 +1,45 @@
+/*
+ * @file report.hpp
+ * @brief Per-tick report of what the safety shield did.
+ *
+ * A shield that silently edits commands is an observability hole: every
+ * Filter() call fills one of these, and the facade mirrors the highlights
+ * into telemetry (docs/control/safety_shield.md).
+ *
+ * Copyright (c) 2026 Ruixiang Du (rdu)
+ */
+
+#ifndef XMNAV_SHIELD_REPORT_HPP
+#define XMNAV_SHIELD_REPORT_HPP
+
+#include <limits>
+
+namespace xmotion {
+
+enum class ShieldMode {
+  kNormal = 0,   // passing (filtered) controller commands through
+  kHold = 1,     // fault: issuing the last safe command
+  kStopping = 2, // fault persisted: ramping the held command to zero
+  kStopped = 3,  // latched at zero; explicit Reset() required
+};
+
+struct ShieldReport {
+  ShieldMode mode = ShieldMode::kNormal;
+  // the issued command differs from the raw controller command
+  bool modified = false;
+  // raw command + state were finite and fresh this tick
+  bool input_valid = true;
+  // box/rate envelope engaged
+  bool envelope_active = false;
+  // barrier constraint modified the command
+  bool barrier_active = false;
+  // barrier QP had no feasible command (treated as a fault)
+  bool barrier_infeasible = false;
+  // smallest obstacle clearance seen by the barrier this tick [m];
+  // +inf when no obstacle is inside the influence radius
+  double min_clearance = std::numeric_limits<double>::infinity();
+};
+
+}  // namespace xmotion
+
+#endif  // XMNAV_SHIELD_REPORT_HPP

--- a/src/control/shield/include/xmnav/shield/wheeled_shield.hpp
+++ b/src/control/shield/include/xmnav/shield/wheeled_shield.hpp
@@ -1,0 +1,142 @@
+/*
+ * @file wheeled_shield.hpp
+ * @brief Output-stage safety shield for a diff-drive platform.
+ *
+ * Composes the three shield layers (docs/control/safety_shield.md) into
+ * the object a robot application puts between the controller and the
+ * actuator write:
+ *
+ *   auto u = shield.Filter(mppi.Command(), state, state_age, dt);
+ *
+ * Per tick: validate inputs at the boundary (finite command/state, fresh
+ * state) -> barrier-filter the command (hard obstacle constraint) ->
+ * degradation ladder -> envelope (box + rate limits) on the passthrough
+ * path. Faults never throw on this path; they degrade through
+ * Hold -> Stopping -> Stopped and are visible in LastReport() and in
+ * telemetry (control.shield.*).
+ *
+ * TriggerEStop() takes effect on the next Filter() call; it complements,
+ * never replaces, the hardware e-stop chain. Reset() re-arms from
+ * kStopped only if the last tick's inputs were valid.
+ *
+ * Copyright (c) 2026 Ruixiang Du (rdu)
+ */
+
+#ifndef XMNAV_SHIELD_WHEELED_SHIELD_HPP
+#define XMNAV_SHIELD_WHEELED_SHIELD_HPP
+
+#include <eigen3/Eigen/Dense>
+
+#include "xmbase/telemetry/telemetry.hpp"
+#include "xmnav/shield/command_envelope.hpp"
+#include "xmnav/shield/diff_drive_barrier.hpp"
+#include "xmnav/shield/fallback_ladder.hpp"
+#include "xmnav/shield/report.hpp"
+
+namespace xmotion {
+
+class WheeledShield {
+ public:
+  static constexpr int kControlDim = 2;
+  using Control = Eigen::Vector2d;  // [v m/s, omega rad/s]
+  using State = Eigen::Vector3d;    // [x m, y m, theta rad] world frame
+
+  struct Config {
+    CommandEnvelope<kControlDim> envelope;
+    DiffDriveBarrierFilter::Config barrier;
+    bool enable_barrier = true;
+    FallbackLadder::Config ladder;
+    // state estimates older than this are faults (S4)
+    double state_staleness_max = 0.2;  // s
+  };
+
+  explicit WheeledShield(const Config &config)
+      : config_(config), ladder_(config.ladder), barrier_(config.barrier) {}
+
+  // One control tick: returns the command to actuate. Never throws.
+  Control Filter(const Control &u_raw, const State &state, double state_age,
+                 double dt) {
+    report_ = ShieldReport{};
+    const bool inputs_valid = u_raw.allFinite() && state.allFinite() &&
+                              state_age >= 0.0 &&
+                              state_age <= config_.state_staleness_max &&
+                              dt > 0.0;
+    report_.input_valid = inputs_valid;
+
+    Control candidate = Control::Zero();
+    if (inputs_valid) {
+      candidate = config_.enable_barrier
+                      ? barrier_.Filter(state, u_raw, &report_)
+                      : u_raw;
+    }
+    const bool fault = !inputs_valid || report_.barrier_infeasible;
+    if (fault) {
+      ladder_.OnFault();
+      faults_.Add(1.0);
+    } else {
+      ladder_.OnRecovered();  // no-op unless the ladder is in kHold
+    }
+    ladder_.Tick(dt);
+
+    Control out = Control::Zero();
+    switch (ladder_.mode()) {
+      case ShieldMode::kNormal: {
+        bool clamped = false;
+        out = config_.envelope.Apply(candidate, last_issued_, dt, &clamped);
+        report_.envelope_active = clamped;
+        held_ = out;  // the command Hold falls back to
+        break;
+      }
+      case ShieldMode::kHold:
+        out = held_;
+        break;
+      case ShieldMode::kStopping:
+        out = held_ * ladder_.RampScale();
+        break;
+      case ShieldMode::kStopped:
+        out = Control::Zero();
+        break;
+    }
+
+    last_inputs_valid_ = inputs_valid && !report_.barrier_infeasible;
+    report_.mode = ladder_.mode();
+    report_.modified =
+        !inputs_valid || (out - u_raw).cwiseAbs().maxCoeff() > 1e-12;
+    last_issued_ = out;
+
+    mode_gauge_.Set(static_cast<double>(report_.mode));
+    if (report_.barrier_active) barrier_engaged_.Add(1.0);
+    return out;
+  }
+
+  void TriggerEStop() { ladder_.TriggerEStop(); }
+
+  // re-arm from kStopped; accepted only if the last tick's inputs were
+  // valid (guarded in the ladder's transition table)
+  bool Reset() { return ladder_.Reset(last_inputs_valid_); }
+
+  ShieldMode mode() const { return ladder_.mode(); }
+  const ShieldReport &LastReport() const { return report_; }
+
+  // live access (e.g. obstacle updates from the mapping layer)
+  DiffDriveBarrierFilter &barrier() { return barrier_; }
+
+ private:
+  Config config_;
+  FallbackLadder ladder_;
+  DiffDriveBarrierFilter barrier_;
+  Control last_issued_ = Control::Zero();
+  Control held_ = Control::Zero();
+  bool last_inputs_valid_ = false;
+  ShieldReport report_;
+
+  telemetry::Gauge mode_gauge_ = telemetry::GetGauge("control.shield.mode");
+  telemetry::Counter faults_ =
+      telemetry::GetCounter("control.shield.faults");
+  telemetry::Counter barrier_engaged_ =
+      telemetry::GetCounter("control.shield.barrier_active");
+};
+
+}  // namespace xmotion
+
+#endif  // XMNAV_SHIELD_WHEELED_SHIELD_HPP

--- a/src/control/shield/test/CMakeLists.txt
+++ b/src/control/shield/test/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_executable(test_shield_scenarios test_shield_scenarios.cpp)
+target_link_libraries(test_shield_scenarios shield gtest gtest_main)
+gtest_discover_tests(test_shield_scenarios)

--- a/src/control/shield/test/test_shield_scenarios.cpp
+++ b/src/control/shield/test/test_shield_scenarios.cpp
@@ -1,0 +1,234 @@
+/*
+ * test_shield_scenarios.cpp
+ *
+ * The acceptance scenarios of docs/control/safety_shield.md (S1-S4, S6 —
+ * S5 arrives with the SRB shield), plus unit checks of the individual
+ * layers: envelope math, ladder legality (refused events), barrier
+ * minimality/constraint satisfaction.
+ *
+ * Copyright (c) 2026 Ruixiang Du (rdu)
+ */
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <limits>
+
+#include "xmnav/shield/wheeled_shield.hpp"
+
+using namespace xmotion;
+
+namespace {
+
+constexpr double kDt = 0.02;
+
+WheeledShield::Config MakeConfig(bool with_obstacle = false) {
+  WheeledShield::Config cfg;
+  cfg.envelope.u_min << -0.8, -2.0;
+  cfg.envelope.u_max << 0.8, 2.0;
+  cfg.envelope.rate_limit << 2.0, 8.0;  // [m/s^2, rad/s^2]
+  cfg.ladder.hold_timeout = 0.1;        // 5 ticks at 50 Hz
+  cfg.ladder.stop_ramp_time = 0.2;      // 10 ticks
+  cfg.state_staleness_max = 0.1;
+  cfg.barrier.u_min = cfg.envelope.u_min;
+  cfg.barrier.u_max = cfg.envelope.u_max;
+  cfg.barrier.look_ahead = 0.15;
+  cfg.barrier.alpha = 2.0;
+  cfg.barrier.margin = 0.05;
+  if (with_obstacle) {
+    cfg.barrier.obstacles.push_back({Eigen::Vector2d(2.0, 0.0), 0.3});
+  } else {
+    cfg.enable_barrier = false;
+  }
+  return cfg;
+}
+
+const WheeledShield::State kOrigin = WheeledShield::State::Zero();
+
+}  // namespace
+
+// S1: a command spike is followed at the configured rate limit
+TEST(ShieldScenarioTest, S1SpikeIsRateLimited) {
+  WheeledShield shield(MakeConfig());
+  const WheeledShield::Control spike(10.0, 0.0);  // beyond box and rate
+  const auto u1 = shield.Filter(spike, kOrigin, 0.0, kDt);
+  EXPECT_NEAR(u1(0), 2.0 * kDt, 1e-12);  // one rate step from zero
+  EXPECT_TRUE(shield.LastReport().envelope_active);
+  EXPECT_TRUE(shield.LastReport().modified);
+  EXPECT_EQ(shield.mode(), ShieldMode::kNormal);
+  // keeps ramping, then saturates at the box limit
+  WheeledShield::Control u = u1;
+  for (int i = 0; i < 100; ++i) u = shield.Filter(spike, kOrigin, 0.0, kDt);
+  EXPECT_NEAR(u(0), 0.8, 1e-12);
+}
+
+// S2: NaN command -> hold, then controlled stop; early recovery resumes
+TEST(ShieldScenarioTest, S2InvalidCommandDegradesThroughLadder) {
+  WheeledShield shield(MakeConfig());
+  const WheeledShield::Control cruise(0.5, 0.0);
+  WheeledShield::Control u = WheeledShield::Control::Zero();
+  for (int i = 0; i < 50; ++i) u = shield.Filter(cruise, kOrigin, 0.0, kDt);
+  EXPECT_NEAR(u(0), 0.5, 1e-12);
+
+  const WheeledShield::Control bad(std::nan(""), 0.0);
+  // fault: holds the last safe command
+  u = shield.Filter(bad, kOrigin, 0.0, kDt);
+  EXPECT_EQ(shield.mode(), ShieldMode::kHold);
+  EXPECT_NEAR(u(0), 0.5, 1e-12);
+  EXPECT_FALSE(shield.LastReport().input_valid);
+  // recovery within the timeout resumes normal operation
+  u = shield.Filter(cruise, kOrigin, 0.0, kDt);
+  EXPECT_EQ(shield.mode(), ShieldMode::kNormal);
+  EXPECT_NEAR(u(0), 0.5, 1e-12);
+
+  // persistent fault: hold expires -> ramp to zero -> latched stop
+  double last_v = 0.5;
+  bool saw_stopping = false;
+  for (int i = 0; i < 30; ++i) {
+    u = shield.Filter(bad, kOrigin, 0.0, kDt);
+    if (shield.mode() == ShieldMode::kStopping) {
+      saw_stopping = true;
+      EXPECT_LE(u(0), last_v + 1e-12) << "ramp must be non-increasing";
+      last_v = u(0);
+    }
+  }
+  EXPECT_TRUE(saw_stopping);
+  EXPECT_EQ(shield.mode(), ShieldMode::kStopped);
+  EXPECT_DOUBLE_EQ(u(0), 0.0);
+  // recovery alone does NOT re-arm; a guarded Reset does
+  u = shield.Filter(cruise, kOrigin, 0.0, kDt);
+  EXPECT_EQ(shield.mode(), ShieldMode::kStopped);
+  EXPECT_TRUE(shield.Reset());
+  u = shield.Filter(cruise, kOrigin, 0.0, kDt);
+  EXPECT_EQ(shield.mode(), ShieldMode::kNormal);
+}
+
+// S3: the barrier attenuates the command approaching an obstacle and the
+// closed loop never crosses the safety distance; far away it is untouched
+TEST(ShieldScenarioTest, S3BarrierPreventsPenetration) {
+  auto cfg = MakeConfig(/*with_obstacle=*/true);
+  WheeledShield shield(cfg);
+  const WheeledShield::Control full_speed(0.8, 0.0);
+
+  // far away: minimal intervention (envelope ramp-up aside)
+  WheeledShield::State x = kOrigin;  // obstacle 2 m ahead
+  auto u = shield.Filter(full_speed, x, 0.0, kDt);
+  EXPECT_FALSE(shield.LastReport().barrier_active);
+
+  // drive at the obstacle with the shield in the loop
+  double min_clearance = std::numeric_limits<double>::infinity();
+  bool barrier_engaged = false;
+  for (int i = 0; i < 600; ++i) {
+    u = shield.Filter(full_speed, x, 0.0, kDt);
+    x(0) += u(0) * std::cos(x(2)) * kDt;
+    x(1) += u(0) * std::sin(x(2)) * kDt;
+    x(2) += u(1) * kDt;
+    const double clearance =
+        (x.head<2>() - Eigen::Vector2d(2.0, 0.0)).norm() - 0.3;
+    min_clearance = std::min(min_clearance, clearance);
+    barrier_engaged |= shield.LastReport().barrier_active;
+    ASSERT_EQ(shield.mode(), ShieldMode::kNormal) << "tick " << i;
+  }
+  EXPECT_TRUE(barrier_engaged);
+  // never penetrates the margin band (allow the discrete-time epsilon)
+  EXPECT_GT(min_clearance, 0.5 * cfg.barrier.margin);
+}
+
+// S4: a stale state estimate walks the same ladder as an invalid command
+TEST(ShieldScenarioTest, S4StaleStateDegrades) {
+  WheeledShield shield(MakeConfig());
+  const WheeledShield::Control cruise(0.4, 0.0);
+  for (int i = 0; i < 30; ++i) shield.Filter(cruise, kOrigin, 0.0, kDt);
+  auto u = shield.Filter(cruise, kOrigin, /*state_age=*/0.5, kDt);
+  EXPECT_EQ(shield.mode(), ShieldMode::kHold);
+  EXPECT_GT(u(0), 0.0);  // holding, not dropping to zero instantly
+  for (int i = 0; i < 30; ++i) u = shield.Filter(cruise, kOrigin, 0.5, kDt);
+  EXPECT_EQ(shield.mode(), ShieldMode::kStopped);
+  EXPECT_DOUBLE_EQ(u(0), 0.0);
+}
+
+// S6: e-stop from any mode; guarded reset re-arms
+TEST(ShieldScenarioTest, S6EStopFromAnywhere) {
+  WheeledShield shield(MakeConfig());
+  const WheeledShield::Control cruise(0.5, 0.0);
+  for (int i = 0; i < 30; ++i) shield.Filter(cruise, kOrigin, 0.0, kDt);
+  EXPECT_EQ(shield.mode(), ShieldMode::kNormal);
+  shield.TriggerEStop();
+  auto u = shield.Filter(cruise, kOrigin, 0.0, kDt);
+  EXPECT_EQ(shield.mode(), ShieldMode::kStopped);
+  EXPECT_DOUBLE_EQ(u.norm(), 0.0);
+  // reset with valid inputs -> normal
+  EXPECT_TRUE(shield.Reset());
+  shield.Filter(cruise, kOrigin, 0.0, kDt);
+  EXPECT_EQ(shield.mode(), ShieldMode::kNormal);
+  // e-stop mid-ramp too
+  const WheeledShield::Control bad(std::nan(""), 0.0);
+  for (int i = 0; i < 8; ++i) shield.Filter(bad, kOrigin, 0.0, kDt);
+  shield.TriggerEStop();
+  u = shield.Filter(bad, kOrigin, 0.0, kDt);
+  EXPECT_EQ(shield.mode(), ShieldMode::kStopped);
+  EXPECT_DOUBLE_EQ(u.norm(), 0.0);
+  // reset is REFUSED while inputs are still invalid
+  EXPECT_FALSE(shield.Reset());
+}
+
+// --- layer units ---
+
+TEST(ShieldUnitTest, EnvelopeBoxAndRateIndependentPerChannel) {
+  CommandEnvelope<2> env;
+  env.u_min << -1.0, -2.0;
+  env.u_max << 1.0, 2.0;
+  env.rate_limit << 10.0, std::numeric_limits<double>::infinity();
+  const Eigen::Vector2d prev(0.0, 0.0);
+  bool clamped = false;
+  // channel 0 rate-limited, channel 1 free until the box
+  auto out = env.Apply({5.0, 5.0}, prev, 0.1, &clamped);
+  EXPECT_TRUE(clamped);
+  EXPECT_DOUBLE_EQ(out(0), 1.0);  // box binds before rate (10*0.1 = 1.0)
+  EXPECT_DOUBLE_EQ(out(1), 2.0);
+  out = env.Apply({0.5, 1.5}, prev, 0.1, &clamped);
+  EXPECT_FALSE(clamped);
+  EXPECT_DOUBLE_EQ(out(0), 0.5);
+  EXPECT_DOUBLE_EQ(out(1), 1.5);
+}
+
+TEST(ShieldUnitTest, LadderRefusesIllegalEvents) {
+  FallbackLadder ladder({0.1, 0.2});
+  EXPECT_EQ(ladder.mode(), ShieldMode::kNormal);
+  EXPECT_FALSE(ladder.Reset(true));  // no row (Normal, Reset)
+  ladder.OnRecovered();              // no row (Normal, Recovered)
+  EXPECT_EQ(ladder.mode(), ShieldMode::kNormal);
+  ladder.OnFault();
+  EXPECT_EQ(ladder.mode(), ShieldMode::kHold);
+  ladder.OnFault();  // refused, stays
+  EXPECT_EQ(ladder.mode(), ShieldMode::kHold);
+}
+
+TEST(ShieldUnitTest, BarrierIsMinimalAndSatisfiesConstraint) {
+  DiffDriveBarrierFilter::Config cfg;
+  cfg.obstacles.push_back({Eigen::Vector2d(1.0, 0.0), 0.2});
+  cfg.u_min << -0.8, -2.0;
+  cfg.u_max << 0.8, 2.0;
+  DiffDriveBarrierFilter filter(cfg);
+  ShieldReport report;
+  // heading away from the obstacle: untouched
+  const Eigen::Vector3d away(0.0, 0.0, M_PI);
+  auto u = filter.Filter(away, {0.5, 0.0}, &report);
+  EXPECT_FALSE(report.barrier_active);
+  EXPECT_DOUBLE_EQ(u(0), 0.5);
+  // close and head-on: modified, and the CBF row holds at the solution
+  const Eigen::Vector3d close(0.5, 0.0, 0.0);
+  u = filter.Filter(close, {0.8, 0.0}, &report);
+  EXPECT_TRUE(report.barrier_active);
+  EXPECT_LT(u(0), 0.8);
+  // recompute h and a at the look-ahead point: a.u + alpha*h >= 0
+  const Eigen::Vector2d p_l(0.5 + cfg.look_ahead, 0.0);
+  const double safe =
+      0.2 + cfg.margin + cfg.look_ahead;  // robot_radius = 0
+  const Eigen::Vector2d d = p_l - Eigen::Vector2d(1.0, 0.0);
+  const double h = d.squaredNorm() - safe * safe;
+  Eigen::Matrix2d M;
+  M << 1.0, 0.0, 0.0, cfg.look_ahead;  // theta = 0
+  const Eigen::Vector2d a = 2.0 * M.transpose() * d;
+  EXPECT_GE(a.dot(u) + cfg.alpha * h, -1e-9);
+}


### PR DESCRIPTION
## Summary

The hard constraint layer the MPPI tech note and `CircularObstacleCost` explicitly defer to — a **library stage** between `Command()` and the actuator write, per the algorithm-core composition rule (no runtime tier).

**Scenario-driven:** `docs/control/safety_shield.md` defines the acceptance set S1–S6; `test_shield_scenarios.cpp` implements them verbatim (S5, the quadruped GRF cone projection, ships with the future SRB shield).

Three layers + a façade:

- **`CommandEnvelope<N>`** — per-channel box + slew-rate limits relative to the last *issued* command (S1: a 0→10 m/s spike is followed at the configured accel limit and saturates at the box).
- **`FallbackLadder`** — `Normal → Hold → Stopping → Stopped` with an `AnyState` e-stop wildcard and a guarded operator `Reset`, built on the vendored **ctfsm** engine (#64 — its first in-tree consumer). The transition table *is* the policy: `InputRecovered` only has a row in `Hold`, so there is no automatic recovery from `Stopping`/`Stopped` — refused by construction (S2/S4/S6, including e-stop mid-ramp and `Reset()` refused while inputs are still invalid).
- **`DiffDriveBarrierFilter`** — CBF-QP hard obstacle constraint (look-ahead-point unicycle formulation, so the barrier is linear in both v and ω). Minimal modification via the vendored QuadProg++ (2-variable QP: active obstacle rows + actuator box); pass-through fast path when the raw command already satisfies every row; **infeasibility is reported and treated as a fault, never silently passed through** (S3: closed-loop sim drives full-speed at an obstacle and never crosses the margin band).
- **`WheeledShield`** — boundary validation (finite command/state, staleness max), per-tick sequencing, `ShieldReport` every tick plus telemetry (`control.shield.mode` / `.faults` / `.barrier_active`). The control path never throws; faults degrade through the ladder.

**Build note:** `CTFSM_INSTALL=ON` for the vendored fsm submodule — `shield` is an exported target linking `ctfsm::ctfsm`, so ctfsm must belong to an installed export set (also restores the ctfsm header installation flagged in #64).

## Verification

- 8 tests: 5 scenarios + 3 layer units (envelope channel independence, ladder event-refusal legality, barrier minimality + CBF-row satisfaction at the QP solution)
- WERROR viz-on 65/65, viz-off 64/64, ASan shield suite clean