### PR TITLE
chore(estimation): drop the dangling Mekf6TelemetryAccess friend

### DIFF
--- a/src/estimation/include/xmnav/estimation/mekf6.hpp
+++ b/src/estimation/include/xmnav/estimation/mekf6.hpp
@@ -110,8 +110,6 @@ class Mekf6 {
       telemetry::GetCounter("estimation.mekf6.gate_rejections");
   telemetry::Counter invalid_input_counter_ =
       telemetry::GetCounter("estimation.mekf6.invalid_inputs");
-
-  friend class Mekf6TelemetryAccess;
 };
 }  // namespace xmotion
 


### PR DESCRIPTION
Leftover from the W4 instrumentation: `Mekf6TelemetryAccess` is defined nowhere in the repo — the filter owns its telemetry handles directly and tests verify through public behavior. A friend declaration of an undefined class is misleading and a latent encapsulation hole (any later class with that name in the namespace silently gains full private access). MEKF suites 11/11 locally.