### PR TITLE
test: integration tier — composed pipelines vs simulation + nightly campaigns

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Test
         working-directory: ${{runner.workspace}}/build
         shell: bash
-        run: ctest
+        run: ctest -LE campaign --output-on-failure
 
   sanitizers:
     runs-on: ubuntu-24.04
@@ -103,4 +103,4 @@ jobs:
       - name: Test
         working-directory: build
         shell: bash
-        run: ctest --output-on-failure
+        run: ctest -LE campaign --output-on-failure

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,44 @@
+# Nightly validation: the campaign-labeled robustness suites (Monte-Carlo
+# closed loops under plant-model mismatch) that are too long for PR CI.
+# Scheduled runs execute on the default branch (devel).
+name: Nightly
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  BUILD_TYPE: Release
+
+jobs:
+  campaigns:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-22.04, ubuntu-24.04 ]
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install dependencies
+        run: |
+          sudo apt-get update && sudo apt-get install -y libgl1-mesa-dev \
+           libglfw3-dev libcairo2-dev libtbb-dev libboost-all-dev \
+           libeigen3-dev libopencv-dev libyaml-cpp-dev \
+           libncurses-dev libpcl-dev libglm-dev
+      - name: Update submodules
+        run: git submodule update --init --recursive
+      - name: Configure CMake
+        shell: bash
+        run: cmake -B build -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DBUILD_TESTING=ON -DXMOTION_WERROR=ON
+      - name: Build
+        shell: bash
+        run: cmake --build build -j
+      - name: Campaigns
+        working-directory: build
+        shell: bash
+        run: ctest -L campaign --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,6 +159,13 @@ install(TARGETS stb pnm rapidcsv stopwatch EXPORT xmNavigationTargets)
 ## Add source directories
 add_subdirectory(src)
 
+## Cross-module integration tests (composed algorithm pipelines against
+## the simulation tier). Campaign-labeled tests are excluded from PR CI
+## and run by the nightly workflow.
+if (BUILD_TESTS)
+  add_subdirectory(tests)
+endif ()
+
 ## Aggregate interface target: consumers link a single `xmotion::xmNavigation` to pull
 ## in the XMotion algorithm libraries (estimation, control, planning).
 add_library(xmNavigation INTERFACE)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(integration)

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -1,0 +1,19 @@
+## Integration tier: composed algorithm pipelines validated against the
+## simulation tier (see docs/LESSONS.md + the validation-ladder notes) —
+## unit tests pin each algorithm; these pin the compositions.
+##
+## Labels:
+##   integration — composed closed-loop scenarios; run on every PR
+##   campaign    — Monte-Carlo robustness with plant-model mismatch;
+##                 excluded from PR ctest (-LE campaign), run nightly.
+##                 Campaign binaries still BUILD on PRs so they cannot rot.
+
+add_executable(test_pipeline_diffdrive test_pipeline_diffdrive.cpp)
+target_link_libraries(test_pipeline_diffdrive
+    estimation mppi shield sim gtest gtest_main)
+gtest_discover_tests(test_pipeline_diffdrive PROPERTIES LABELS integration)
+
+add_executable(campaign_diffdrive campaign_diffdrive.cpp)
+target_link_libraries(campaign_diffdrive
+    mppi shield sim gtest gtest_main)
+gtest_discover_tests(campaign_diffdrive PROPERTIES LABELS campaign)

--- a/tests/integration/campaign_diffdrive.cpp
+++ b/tests/integration/campaign_diffdrive.cpp
@@ -1,0 +1,145 @@
+/*
+ * campaign_diffdrive.cpp
+ *
+ * Robustness campaign (ctest label: campaign — nightly, not PR CI): the
+ * wheeled MPPI + shield loop under plant-model mismatch, Monte Carlo over
+ * seeds. The controller plans with the nominal kinematic model; the true
+ * plant executes with an actuator gain deficit and a first-order lag —
+ * unmodeled dynamics the nominal-plant tests never exercise. Acceptance
+ * is a PASS RATE across the seed population, not a single trajectory.
+ *
+ * Mismatch (stated test conditions):
+ *   - actuator gain 0.90 on v, 0.95 on omega
+ *   - first-order actuator lag tau = 80 ms on both channels
+ *   - process noise sigma = (2 mm, 2 mm, 4 mrad) per step
+ *
+ * Copyright (c) 2026 Ruixiang Du (rdu)
+ */
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <cstdio>
+#include <random>
+
+#include "xmnav/models/diff_drive.hpp"
+#include "xmnav/mppi/critics.hpp"
+#include "xmnav/mppi/mppi.hpp"
+#include "xmnav/shield/wheeled_shield.hpp"
+
+using namespace xmotion;
+
+namespace {
+
+#if !defined(NDEBUG) || defined(__SANITIZE_ADDRESS__) || \
+    defined(__SANITIZE_THREAD__)
+constexpr int kSamples = 128;
+constexpr int kRuns = 6;
+#else
+constexpr int kSamples = 512;
+constexpr int kRuns = 40;
+#endif
+
+constexpr double kDt = 0.05;
+const Eigen::Vector2d kGoal{3.0, 1.0};
+
+struct RunResult {
+  bool reached = false;
+  bool shield_fault = false;
+  double final_dist = 0.0;
+  int ticks_to_goal = 0;
+};
+
+RunResult RunOnce(std::uint64_t seed) {
+  Se2GoalCost goal_cost;
+  goal_cost.goal << kGoal.x(), kGoal.y(), 0.0;
+  CircularObstacleCost obstacle_cost;
+  obstacle_cost.obstacles.push_back({Eigen::Vector2d(1.4, 0.15), 0.3});
+  obstacle_cost.obstacles.push_back({Eigen::Vector2d(2.4, 1.15), 0.3});
+  // SYSTEM RULE this tier enforces: the planner's soft margin (0.25) must
+  // exceed the shield's hard inflation (margin 0.05 + look-ahead 0.15),
+  // or the two layers disagree about which corridors exist and the robot
+  // wedges against the invisible CBF wall (first version of this test
+  // found exactly that deadlock).
+  obstacle_cost.margin = 0.25;
+  auto cost = MakeCompositeCost(goal_cost, obstacle_cost);
+
+  using Controller = Mppi<DiffDriveModel, decltype(cost)>;
+  Controller::Params p;
+  p.num_samples = kSamples;
+  p.horizon_steps = 40;
+  p.dt = kDt;
+  p.lambda = 0.3;
+  p.sigma << 0.3, 0.8;
+  p.u_min << -0.8, -2.0;
+  p.u_max << 0.8, 2.0;
+  p.normalize_cost_spread = true;
+  p.seed = seed;
+  Controller mppi(DiffDriveModel{}, cost, p);
+
+  WheeledShield::Config sc;
+  sc.envelope.u_min = p.u_min;
+  sc.envelope.u_max = p.u_max;
+  sc.envelope.rate_limit << 3.0, 10.0;
+  sc.barrier.u_min = p.u_min;
+  sc.barrier.u_max = p.u_max;
+  sc.barrier.margin = 0.05;
+  for (const auto &ob : obstacle_cost.obstacles) {
+    sc.barrier.obstacles.push_back({ob.center, ob.radius});
+  }
+  WheeledShield shield(sc);
+
+  std::mt19937_64 rng(seed ^ 0x9e3779b97f4a7c15ULL);
+  std::normal_distribution<double> unit;
+
+  // true plant with unmodeled actuator dynamics
+  const Eigen::Vector2d gain(0.90, 0.95);
+  const double lag_alpha = kDt / (0.08 + kDt);
+  Eigen::Vector2d u_actuated = Eigen::Vector2d::Zero();
+
+  DiffDriveModel plant;
+  DiffDriveModel::State x = DiffDriveModel::State::Zero();
+  RunResult result;
+  for (int t = 0; t < 600; ++t) {
+    mppi.Plan(x);  // full state feedback; mismatch is the subject here
+    const auto u = shield.Filter(mppi.Command(), x, 0.0, kDt);
+    if (shield.mode() != ShieldMode::kNormal) {
+      result.shield_fault = true;
+      break;
+    }
+    u_actuated += lag_alpha * (gain.cwiseProduct(u) - u_actuated);
+    x = plant.Step(x, u_actuated, t, kDt);
+    x(0) += 0.002 * unit(rng);
+    x(1) += 0.002 * unit(rng);
+    x(2) += 0.004 * unit(rng);
+    if ((x.head<2>() - kGoal).norm() < 0.3) {
+      result.reached = true;
+      result.ticks_to_goal = t;
+      break;
+    }
+  }
+  result.final_dist = (x.head<2>() - kGoal).norm();
+  return result;
+}
+
+}  // namespace
+
+TEST(DiffDriveCampaignTest, GoalReachedUnderActuatorMismatch) {
+  int reached = 0, faults = 0;
+  double worst_dist = 0.0;
+  for (int i = 0; i < kRuns; ++i) {
+    const auto r = RunOnce(1000 + static_cast<std::uint64_t>(i));
+    reached += r.reached ? 1 : 0;
+    faults += r.shield_fault ? 1 : 0;
+    worst_dist = std::max(worst_dist, r.final_dist);
+    if (!r.reached) {
+      std::printf("  seed %d: final_dist=%.3f fault=%d\n", 1000 + i,
+                  r.final_dist, r.shield_fault ? 1 : 0);
+    }
+  }
+  const double pass_rate = static_cast<double>(reached) / kRuns;
+  std::printf("campaign: %d/%d reached (%.0f%%), worst final dist %.3f\n",
+              reached, kRuns, 100.0 * pass_rate, worst_dist);
+  EXPECT_GE(pass_rate, 0.9) << "goal-reach rate under actuator mismatch";
+  EXPECT_EQ(faults, 0) << "shield fault-mode excursions";
+}

--- a/tests/integration/test_pipeline_diffdrive.cpp
+++ b/tests/integration/test_pipeline_diffdrive.cpp
@@ -1,0 +1,185 @@
+/*
+ * test_pipeline_diffdrive.cpp
+ *
+ * Integration scenario: the composed wheeled pipeline against simulation.
+ *
+ *   IMU+mag synthesis -> Mekf9 (yaw) -> dead-reckoned pose -> Mppi -> shield
+ *                                                                  |
+ *   true plant (diff-drive + process noise)  <---------------------+
+ *
+ * The controller never sees ground truth: it plans on a pose estimate
+ * built from the MEKF9 yaw (gravity pins roll/pitch, the magnetometer
+ * anchors heading — MEKF6 is deliberately NOT used here: without a mag
+ * the yaw-rate bias is unobservable and its estimate free-wanders, which
+ * the first version of this scenario demonstrated) and dead-reckoned
+ * position from issued commands. The shield sits between Command() and
+ * the plant with the same obstacle set as the cost.
+ *
+ * What the units cannot catch and this does: estimator drift feeding the
+ * planner, the shield's barrier acting on an *estimated* (wrong) pose,
+ * and the closed loop still reaching the goal within stated tolerances.
+ *
+ * Test conditions (anti-pattern #9): deterministic seeds, nominal plant
+ * with process noise, IMU noise/biases stated inline; robustness under
+ * plant-model mismatch lives in campaign_diffdrive.cpp.
+ *
+ * Copyright (c) 2026 Ruixiang Du (rdu)
+ */
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <random>
+
+#include "xmnav/estimation/mekf9.hpp"
+#include "xmnav/models/diff_drive.hpp"
+#include "xmnav/mppi/critics.hpp"
+#include "xmnav/mppi/mppi.hpp"
+#include "xmnav/shield/wheeled_shield.hpp"
+
+using namespace xmotion;
+
+namespace {
+
+#if !defined(NDEBUG) || defined(__SANITIZE_ADDRESS__) || \
+    defined(__SANITIZE_THREAD__)
+constexpr int kSamples = 128;
+#else
+constexpr int kSamples = 512;
+#endif
+
+constexpr double kDt = 0.05;
+constexpr double kGravity = 9.81;
+const Eigen::Vector2d kGoal{3.0, 1.0};
+
+double YawOf(const Eigen::Quaterniond &q) {
+  return std::atan2(2.0 * (q.w() * q.z() + q.x() * q.y()),
+                    1.0 - 2.0 * (q.y() * q.y() + q.z() * q.z()));
+}
+
+double WrapAngle(double a) {
+  while (a > M_PI) a -= 2.0 * M_PI;
+  while (a < -M_PI) a += 2.0 * M_PI;
+  return a;
+}
+
+}  // namespace
+
+TEST(PipelineIntegrationTest, EstimateFedMppiWithShieldReachesGoal) {
+  // --- obstacle course shared by cost and shield barrier ---
+  Se2GoalCost goal_cost;
+  goal_cost.goal << kGoal.x(), kGoal.y(), 0.0;
+  CircularObstacleCost obstacle_cost;
+  obstacle_cost.obstacles.push_back({Eigen::Vector2d(1.4, 0.15), 0.3});
+  obstacle_cost.obstacles.push_back({Eigen::Vector2d(2.4, 1.15), 0.3});
+  // SYSTEM RULE this tier enforces: the planner's soft margin (0.25) must
+  // exceed the shield's hard inflation (margin 0.05 + look-ahead 0.15),
+  // or the two layers disagree about which corridors exist and the robot
+  // wedges against the invisible CBF wall (first version of this test
+  // found exactly that deadlock).
+  obstacle_cost.margin = 0.25;
+
+  // --- controller (plans on the ESTIMATED state) ---
+  auto cost = MakeCompositeCost(goal_cost, obstacle_cost);
+  using Controller = Mppi<DiffDriveModel, decltype(cost)>;
+  Controller::Params p;
+  p.num_samples = kSamples;
+  p.horizon_steps = 40;
+  p.dt = kDt;
+  p.lambda = 0.3;
+  p.sigma << 0.3, 0.8;
+  p.u_min << -0.8, -2.0;
+  p.u_max << 0.8, 2.0;
+  p.normalize_cost_spread = true;
+  Controller mppi(DiffDriveModel{}, cost, p);
+
+  // --- shield between Command() and the plant ---
+  WheeledShield::Config sc;
+  sc.envelope.u_min = p.u_min;
+  sc.envelope.u_max = p.u_max;
+  sc.envelope.rate_limit << 3.0, 10.0;
+  sc.barrier.u_min = p.u_min;
+  sc.barrier.u_max = p.u_max;
+  sc.barrier.margin = 0.05;
+  for (const auto &ob : obstacle_cost.obstacles) {
+    sc.barrier.obstacles.push_back({ob.center, ob.radius});
+  }
+  WheeledShield shield(sc);
+
+  // --- estimator: MEKF yaw from a synthesized IMU ---
+  // gyro noise 0.005 rad/s, accel noise 0.05 m/s^2; the yaw-rate bias
+  // (0.002 rad/s) is unobservable from gravity and drifts the heading by
+  // ~0.05 rad over the run — the realism this scenario exists to absorb
+  Mekf9::Params ep;
+  ep.sigma_omega = Eigen::Vector3d::Constant(0.005);
+  ep.sigma_f = Eigen::Vector3d::Constant(0.05);
+  ep.sigma_beta_omega = Eigen::Vector3d::Constant(1e-4);
+  ep.sigma_beta_f = Eigen::Vector3d::Constant(1e-4);
+  ep.init_state_cov = Mekf9::StateCovariance::Identity() * 1e-2;
+  ep.accel_noise_cov =
+      Mekf9::ObservationNoiseCovariance::Identity() * 0.05 * 0.05;
+  ep.mag_noise_cov =
+      Mekf9::ObservationNoiseCovariance::Identity() * 0.02 * 0.02;
+  ep.mag_reference = Eigen::Vector3d(1.0, 0.0, 0.0);
+  Mekf9 mekf;
+  mekf.Initialize(ep);
+  const Eigen::Vector3d gyro_bias(0.005, -0.005, 0.002);
+
+  std::mt19937_64 rng(11);
+  std::normal_distribution<double> unit;
+
+  // --- closed loop: truth vs estimate ---
+  DiffDriveModel plant;
+  DiffDriveModel::State x_true = DiffDriveModel::State::Zero();
+  Eigen::Vector2d p_hat = Eigen::Vector2d::Zero();
+  double yaw_hat = 0.0;
+  WheeledShield::Control u = WheeledShield::Control::Zero();
+  double max_yaw_error = 0.0;
+  int shield_interventions = 0;
+
+  for (int t = 0; t < 500; ++t) {
+    // IMU synthesis from the executed motion (level planar body)
+    Eigen::Vector3d gyro(0.0, 0.0, u(1));
+    gyro += gyro_bias + 0.005 * Eigen::Vector3d(unit(rng), unit(rng),
+                                                unit(rng));
+    Eigen::Vector3d accel(0.0, 0.0, -kGravity);
+    accel += 0.05 * Eigen::Vector3d(unit(rng), unit(rng), unit(rng));
+    // magnetometer: the inertial reference rotated into the (yaw-only)
+    // body frame, plus noise
+    Eigen::Vector3d mag(std::cos(x_true(2)), -std::sin(x_true(2)), 0.0);
+    mag += 0.02 * Eigen::Vector3d(unit(rng), unit(rng), unit(rng));
+    ASSERT_TRUE(mekf.Update(gyro, accel, mag, kDt)) << "tick " << t;
+    yaw_hat = YawOf(mekf.GetQuaternion());
+    max_yaw_error =
+        std::max(max_yaw_error, std::abs(WrapAngle(yaw_hat - x_true(2))));
+
+    // plan on the estimate, shield, actuate the true plant
+    DiffDriveModel::State x_hat;
+    x_hat << p_hat.x(), p_hat.y(), yaw_hat;
+    mppi.Plan(x_hat);
+    u = shield.Filter(mppi.Command(), x_hat, /*state_age=*/0.0, kDt);
+    ASSERT_EQ(shield.mode(), ShieldMode::kNormal) << "tick " << t;
+    if (shield.LastReport().modified) ++shield_interventions;
+
+    x_true = plant.Step(x_true, u, t, kDt);
+    x_true(0) += 0.002 * unit(rng);  // process noise on the true plant
+    x_true(1) += 0.002 * unit(rng);
+    x_true(2) += 0.004 * unit(rng);
+
+    // dead-reckoned position from the issued command + estimated heading
+    p_hat += u(0) * Eigen::Vector2d(std::cos(yaw_hat), std::sin(yaw_hat)) *
+             kDt;
+  }
+
+  // the TRUE robot reached the goal despite planning on the estimate
+  const double true_goal_dist = (x_true.head<2>() - kGoal).norm();
+  EXPECT_LT(true_goal_dist, 0.35) << "true state: " << x_true.transpose();
+  // heading estimate stayed usable (mag anchors yaw; gravity holds
+  // roll/pitch)
+  EXPECT_LT(max_yaw_error, 0.15);
+  // dead reckoning stayed close enough to steer by
+  EXPECT_LT((p_hat - x_true.head<2>()).norm(), 0.5);
+  // the pipeline ran; the envelope engaging occasionally is normal, a
+  // fault-mode excursion is not (asserted every tick above)
+  EXPECT_GE(shield_interventions, 0);
+}


### PR DESCRIPTION
## Summary

The integration-test tier discussed for the validation ladder: unit tests pin each algorithm; `tests/integration/` pins their **compositions** against the simulation tier.

**Two ctest labels:**
- **`integration`** — runs on every PR. First scenario: the full composed wheeled pipeline — synthesized IMU+mag → `Mekf9` (yaw) → dead-reckoned pose → `Mppi` → `WheeledShield` → true plant with process noise. The controller never sees ground truth; asserts the *true* robot reaches the goal, yaw error stays < 0.15 rad, dead reckoning stays steerable, and the shield never leaves `kNormal`.
- **`campaign`** — Monte-Carlo robustness under **plant–model mismatch** (actuator gain 0.90/0.95, 80 ms first-order lag, process noise), acceptance by **pass rate** (≥90% of 40 seeds; measured 100%). Excluded from PR ctest (`-LE campaign`) but still *built* on PRs so it can't rot; executed by the new **Nightly workflow** (scheduled on devel + `workflow_dispatch`).

## Findings the tier produced before it ever ran green (its reason to exist)

1. **Planner/shield margin coherence**: the first run of both scenarios deadlocked identically — every seed wedged at the same spot. MPPI's soft obstacle margin (0.1) considered the corridor passable; the shield's hard CBF inflation (margin + look-ahead ≈ 0.2) walled it off, and the robot spun against the invisible barrier. System rule now documented in and enforced by the scenarios: **the planner's soft margin must exceed the shield's hard inflation.**
2. **MEKF6 yaw-bias wander**: with gravity as the only observation, the z gyro-bias estimate free-wandered to −0.07 rad/s (true: +0.002) and dragged yaw 1.3 rad off. The scenario now uses MEKF9 (mag anchors yaw) — and the MEKF6 behavior is flagged for a NEES consistency pass in estimation round 2.

## Verification

WERROR viz-on 87/87 (`-LE campaign`) plus campaign 40/40; viz-off 86/86; ASan pipeline + reduced-scale campaign clean. PR CI now runs `ctest -LE campaign --output-on-failure` in both jobs.