### PR TITLE
feat(models): classical benchmark models + simulation scenarios + technical note

### DIFF
--- a/docs/typst/bibliography.bib
+++ b/docs/typst/bibliography.bib
@@ -230,3 +230,50 @@
   pages     = {16:1--16:12},
   doi       = {10.1145/2063384.2063405}
 }
+
+@article{Barto1983-cartpole,
+  author  = {Barto, Andrew G. and Sutton, Richard S. and Anderson, Charles W.},
+  title   = {Neuronlike Adaptive Elements That Can Solve Difficult Learning Control Problems},
+  journal = {IEEE Transactions on Systems, Man, and Cybernetics},
+  volume  = {SMC-13},
+  number  = {5},
+  pages   = {834--846},
+  year    = {1983},
+  doi     = {10.1109/TSMC.1983.6313077}
+}
+
+@book{Rajamani2011,
+  author    = {Rajamani, Rajesh},
+  title     = {Vehicle Dynamics and Control},
+  edition   = {2},
+  publisher = {Springer},
+  year      = {2011},
+  doi       = {10.1007/978-1-4614-1433-9}
+}
+
+@inproceedings{Kong2015-bicycle,
+  author    = {Kong, Jason and Pfeiffer, Mark and Schildbach, Georg and Borrelli, Francesco},
+  title     = {Kinematic and Dynamic Vehicle Models for Autonomous Driving Control Design},
+  booktitle = {IEEE Intelligent Vehicles Symposium (IV)},
+  pages     = {1094--1099},
+  year      = {2015},
+  doi       = {10.1109/IVS.2015.7225830}
+}
+
+@inproceedings{Mellinger2011-minsnap,
+  author    = {Mellinger, Daniel and Kumar, Vijay},
+  title     = {Minimum Snap Trajectory Generation and Control for Quadrotors},
+  booktitle = {IEEE International Conference on Robotics and Automation (ICRA)},
+  pages     = {2520--2525},
+  year      = {2011},
+  doi       = {10.1109/ICRA.2011.5980409}
+}
+
+@inproceedings{DiCarlo2018-convexmpc,
+  author    = {Di Carlo, Jared and Wensing, Patrick M. and Katz, Benjamin and Bledt, Gerardo and Kim, Sangbae},
+  title     = {Dynamic Locomotion in the {MIT} {Cheetah} 3 Through Convex Model-Predictive Control},
+  booktitle = {IEEE/RSJ International Conference on Intelligent Robots and Systems (IROS)},
+  pages     = {1--9},
+  year      = {2018},
+  doi       = {10.1109/IROS.2018.8594448}
+}

--- a/docs/typst/main.pdf
+++ b/docs/typst/main.pdf
@@ -6492,8 +6492,8 @@ endobj
   /Title (Libxmotion Implementation Notes)
   /Author (Ruixiang Du)
   /Creator (Typst 0.14.2)
-  /ModDate (D:20260706232016+08'00)
-  /CreationDate (D:20260706232016+08'00)
+  /ModDate (D:20260710090046+08'00)
+  /CreationDate (D:20260710090046+08'00)
 >>
 endobj
 
@@ -6504,7 +6504,7 @@ endobj
   /Subtype /XML
 >>
 stream
-<?xpacket begin="﻿" id="W5M0MpCehiHzreSzNTczkc9d"?><x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="xmp-writer"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/"  xmlns:xmp="http://ns.adobe.com/xap/1.0/"  xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"  xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"  xmlns:pdf="http://ns.adobe.com/pdf/1.3/" ><dc:title><rdf:Alt><rdf:li xml:lang="x-default">Libxmotion Implementation Notes</rdf:li></rdf:Alt></dc:title><dc:creator><rdf:Seq><rdf:li>Ruixiang Du</rdf:li></rdf:Seq></dc:creator><xmp:CreatorTool>Typst 0.14.2</xmp:CreatorTool><dc:language><rdf:Bag><rdf:li>en</rdf:li></rdf:Bag></dc:language><xmp:ModifyDate>2026-07-06T23:20:16+08:00</xmp:ModifyDate><xmp:CreateDate>2026-07-06T23:20:16+08:00</xmp:CreateDate><xmpTPg:NPages>9</xmpTPg:NPages><dc:format>application/pdf</dc:format><xmpMM:InstanceID>XO8Ss9O3u4hHYRhpsxX0EQ==</xmpMM:InstanceID><xmpMM:DocumentID>CmMS+WNa6sRLPJhJ0zjuVw==</xmpMM:DocumentID><xmpMM:RenditionClass>proof</xmpMM:RenditionClass><pdf:PDFVersion>1.7</pdf:PDFVersion></rdf:Description></rdf:RDF></x:xmpmeta><?xpacket end="r"?>
+<?xpacket begin="﻿" id="W5M0MpCehiHzreSzNTczkc9d"?><x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="xmp-writer"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/"  xmlns:xmp="http://ns.adobe.com/xap/1.0/"  xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"  xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"  xmlns:pdf="http://ns.adobe.com/pdf/1.3/" ><dc:title><rdf:Alt><rdf:li xml:lang="x-default">Libxmotion Implementation Notes</rdf:li></rdf:Alt></dc:title><dc:creator><rdf:Seq><rdf:li>Ruixiang Du</rdf:li></rdf:Seq></dc:creator><xmp:CreatorTool>Typst 0.14.2</xmp:CreatorTool><dc:language><rdf:Bag><rdf:li>en</rdf:li></rdf:Bag></dc:language><xmp:ModifyDate>2026-07-10T09:00:46+08:00</xmp:ModifyDate><xmp:CreateDate>2026-07-10T09:00:46+08:00</xmp:CreateDate><xmpTPg:NPages>9</xmpTPg:NPages><dc:format>application/pdf</dc:format><xmpMM:InstanceID>B8EA2O/Fv3Bpk6X2VNHRTg==</xmpMM:InstanceID><xmpMM:DocumentID>CmMS+WNa6sRLPJhJ0zjuVw==</xmpMM:DocumentID><xmpMM:RenditionClass>proof</xmpMM:RenditionClass><pdf:PDFVersion>1.7</pdf:PDFVersion></rdf:Description></rdf:RDF></x:xmpmeta><?xpacket end="r"?>
 endstream
 endobj
 
@@ -7053,7 +7053,7 @@ trailer
   /Size 519
   /Root 518 0 R
   /Info 516 0 R
-  /ID [(CmMS+WNa6sRLPJhJ0zjuVw==) (XO8Ss9O3u4hHYRhpsxX0EQ==)]
+  /ID [(CmMS+WNa6sRLPJhJ0zjuVw==) (B8EA2O/Fv3Bpk6X2VNHRTg==)]
 >>
 startxref
 198909

--- a/docs/typst/models.pdf
+++ b/docs/typst/models.pdf
@@ -5,7 +5,7 @@
 <<
   /Type /Pages
   /Count 4
-  /Kids [297 0 R 302 0 R 306 0 R 319 0 R]
+  /Kids [304 0 R 309 0 R 313 0 R 326 0 R]
 >>
 endobj
 
@@ -23,7 +23,7 @@ endobj
   /Parent 2 0 R
   /Next 4 0 R
   /Title (1 Conventions)
-  /Dest 273 0 R
+  /Dest 280 0 R
 >>
 endobj
 
@@ -36,7 +36,7 @@ endobj
   /Last 8 0 R
   /Count -4
   /Title (2 Wheeled platforms)
-  /Dest 278 0 R
+  /Dest 285 0 R
 >>
 endobj
 
@@ -45,7 +45,7 @@ endobj
   /Parent 4 0 R
   /Next 6 0 R
   /Title (2.1 Differential drive (kinematic unicycle))
-  /Dest 274 0 R
+  /Dest 281 0 R
 >>
 endobj
 
@@ -55,7 +55,7 @@ endobj
   /Next 7 0 R
   /Prev 5 0 R
   /Title (2.2 Kinematic bicycle (Ackermann))
-  /Dest 275 0 R
+  /Dest 282 0 R
 >>
 endobj
 
@@ -65,7 +65,7 @@ endobj
   /Next 8 0 R
   /Prev 6 0 R
   /Title (2.3 Bicycle with acceleration input)
-  /Dest 276 0 R
+  /Dest 283 0 R
 >>
 endobj
 
@@ -74,7 +74,7 @@ endobj
   /Parent 4 0 R
   /Prev 7 0 R
   /Title (2.4 Single-track model with linear tires ("dynamic bicycle"))
-  /Dest 277 0 R
+  /Dest 284 0 R
 >>
 endobj
 
@@ -87,7 +87,7 @@ endobj
   /Last 10 0 R
   /Count -1
   /Title (3 Underactuated benchmark)
-  /Dest 280 0 R
+  /Dest 287 0 R
 >>
 endobj
 
@@ -95,7 +95,7 @@ endobj
 <<
   /Parent 9 0 R
   /Title (3.1 Cart-pole (inverted pendulum on a cart))
-  /Dest 279 0 R
+  /Dest 286 0 R
 >>
 endobj
 
@@ -108,7 +108,7 @@ endobj
   /Last 12 0 R
   /Count -1
   /Title (4 Aerial platform)
-  /Dest 282 0 R
+  /Dest 289 0 R
 >>
 endobj
 
@@ -116,7 +116,7 @@ endobj
 <<
   /Parent 11 0 R
   /Title (4.1 Quadrotor (rigid body))
-  /Dest 281 0 R
+  /Dest 288 0 R
 >>
 endobj
 
@@ -126,7 +126,7 @@ endobj
   /Next 14 0 R
   /Prev 11 0 R
   /Title (5 Legged platform)
-  /Dest 283 0 R
+  /Dest 290 0 R
 >>
 endobj
 
@@ -136,7 +136,7 @@ endobj
   /Next 15 0 R
   /Prev 13 0 R
   /Title (6 Choosing a model)
-  /Dest 284 0 R
+  /Dest 291 0 R
 >>
 endobj
 
@@ -145,13 +145,13 @@ endobj
   /Parent 2 0 R
   /Prev 14 0 R
   /Title (Bibliography)
-  /Dest 285 0 R
+  /Dest 292 0 R
 >>
 endobj
 
 16 0 obj
 <<
-  /Nums [0 237 0 R 1 238 0 R 2 239 0 R 3 240 0 R]
+  /Nums [0 244 0 R 1 245 0 R 2 246 0 R 3 247 0 R]
 >>
 endobj
 
@@ -174,19 +174,19 @@ endobj
 endobj
 
 18 0 obj
-[236 0 R 235 0 R 232 0 R 229 0 R 227 0 R 228 0 R 227 0 R 227 0 R 227 0 R 227 0 R 227 0 R 227 0 R 227 0 R 226 0 R 226 0 R 220 0 R 225 0 R 220 0 R 224 0 R 224 0 R 220 0 R 220 0 R 223 0 R 220 0 R 222 0 R 220 0 R 220 0 R 221 0 R 220 0 R 220 0 R 220 0 R 219 0 R 219 0 R 218 0 R 218 0 R 215 0 R 217 0 R 217 0 R 217 0 R 217 0 R 217 0 R 217 0 R 217 0 R 217 0 R 217 0 R 215 0 R 216 0 R 216 0 R 216 0 R 216 0 R 216 0 R 216 0 R 216 0 R 215 0 R 214 0 R 214 0 R 214 0 R 214 0 R 214 0 R 214 0 R 214 0 R 214 0 R 214 0 R 214 0 R 214 0 R 214 0 R 214 0 R 214 0 R 214 0 R 214 0 R 214 0 R 214 0 R 214 0 R 212 0 R 212 0 R 213 0 R 212 0 R 211 0 R 211 0 R 207 0 R 210 0 R 210 0 R 210 0 R 210 0 R 210 0 R 210 0 R 210 0 R 210 0 R 210 0 R 207 0 R 209 0 R 209 0 R 209 0 R 209 0 R 209 0 R 209 0 R 209 0 R 207 0 R 208 0 R 207 0 R 206 0 R 206 0 R 206 0 R 206 0 R 206 0 R 206 0 R 206 0 R 206 0 R 206 0 R 206 0 R 206 0 R 206 0 R 206 0 R 206 0 R 206 0 R 206 0 R 206 0 R 206 0 R 206 0 R 206 0 R 206 0 R 206 0 R 206 0 R 206 0 R 202 0 R 205 0 R 202 0 R 204 0 R 204 0 R 204 0 R 204 0 R 204 0 R 204 0 R 202 0 R 202 0 R 203 0 R 202 0 R 201 0 R 201 0 R 198 0 R 200 0 R 200 0 R 200 0 R 200 0 R 200 0 R 200 0 R 200 0 R 200 0 R 200 0 R 200 0 R 200 0 R 198 0 R 199 0 R 199 0 R 199 0 R 199 0 R 199 0 R 199 0 R 199 0 R 198 0 R]
+[243 0 R 242 0 R 239 0 R 236 0 R 234 0 R 235 0 R 234 0 R 234 0 R 234 0 R 234 0 R 234 0 R 234 0 R 234 0 R 233 0 R 233 0 R 220 0 R 232 0 R 220 0 R 231 0 R 231 0 R 220 0 R 220 0 R 230 0 R 220 0 R 229 0 R 220 0 R 220 0 R 228 0 R 220 0 R 220 0 R 220 0 R 227 0 R 220 0 R 226 0 R 220 0 R 220 0 R 225 0 R 220 0 R 224 0 R 220 0 R 220 0 R 223 0 R 223 0 R 223 0 R 223 0 R 223 0 R 223 0 R 223 0 R 223 0 R 220 0 R 222 0 R 222 0 R 222 0 R 222 0 R 222 0 R 222 0 R 220 0 R 221 0 R 220 0 R 219 0 R 219 0 R 218 0 R 218 0 R 215 0 R 217 0 R 217 0 R 217 0 R 217 0 R 217 0 R 217 0 R 217 0 R 217 0 R 217 0 R 215 0 R 216 0 R 216 0 R 216 0 R 216 0 R 216 0 R 216 0 R 216 0 R 215 0 R 214 0 R 214 0 R 214 0 R 214 0 R 214 0 R 214 0 R 214 0 R 214 0 R 214 0 R 214 0 R 214 0 R 214 0 R 214 0 R 214 0 R 214 0 R 214 0 R 214 0 R 214 0 R 214 0 R 212 0 R 212 0 R 213 0 R 212 0 R 211 0 R 211 0 R 207 0 R 210 0 R 210 0 R 210 0 R 210 0 R 210 0 R 210 0 R 210 0 R 210 0 R 210 0 R 207 0 R 209 0 R 209 0 R 209 0 R 209 0 R 209 0 R 209 0 R 209 0 R 207 0 R 208 0 R 207 0 R 206 0 R 206 0 R 206 0 R 206 0 R 206 0 R 206 0 R 206 0 R 206 0 R 206 0 R 206 0 R 206 0 R 206 0 R 206 0 R 206 0 R 206 0 R 206 0 R 206 0 R 206 0 R 206 0 R 206 0 R 206 0 R 206 0 R 206 0 R 206 0 R 202 0 R 205 0 R 202 0 R 204 0 R 204 0 R 204 0 R 204 0 R 204 0 R 204 0 R 202 0 R 202 0 R 203 0 R 202 0 R]
 endobj
 
 19 0 obj
-[197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 191 0 R 196 0 R 191 0 R 195 0 R 195 0 R 195 0 R 195 0 R 195 0 R 195 0 R 191 0 R 191 0 R 194 0 R 191 0 R 191 0 R 193 0 R 193 0 R 193 0 R 193 0 R 191 0 R 192 0 R 191 0 R 190 0 R 190 0 R 180 0 R 189 0 R 180 0 R 180 0 R 188 0 R 180 0 R 187 0 R 187 0 R 187 0 R 187 0 R 187 0 R 187 0 R 187 0 R 187 0 R 187 0 R 187 0 R 187 0 R 187 0 R 187 0 R 187 0 R 187 0 R 187 0 R 187 0 R 180 0 R 180 0 R 186 0 R 180 0 R 185 0 R 185 0 R 185 0 R 185 0 R 185 0 R 185 0 R 185 0 R 185 0 R 180 0 R 180 0 R 184 0 R 184 0 R 184 0 R 184 0 R 184 0 R 180 0 R 183 0 R 180 0 R 182 0 R 182 0 R 180 0 R 180 0 R 181 0 R 181 0 R 181 0 R 181 0 R 181 0 R 180 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 178 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 167 0 R 175 0 R 175 0 R 175 0 R 175 0 R 167 0 R 167 0 R 174 0 R 174 0 R 174 0 R 174 0 R 167 0 R 173 0 R 173 0 R 173 0 R 173 0 R 173 0 R 173 0 R 173 0 R 167 0 R 172 0 R 172 0 R 172 0 R 172 0 R 172 0 R 172 0 R 172 0 R 172 0 R 172 0 R 167 0 R 171 0 R 171 0 R 171 0 R 171 0 R 171 0 R 171 0 R 171 0 R 167 0 R 170 0 R 170 0 R 170 0 R 170 0 R 170 0 R 170 0 R 170 0 R 167 0 R 169 0 R 169 0 R 169 0 R 169 0 R 169 0 R 169 0 R 169 0 R 169 0 R 169 0 R 169 0 R 169 0 R 169 0 R 167 0 R 168 0 R 167 0 R 167 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 160 0 R 165 0 R 165 0 R 160 0 R 164 0 R 164 0 R 164 0 R 164 0 R 164 0 R 164 0 R 164 0 R 160 0 R 160 0 R 163 0 R 163 0 R 163 0 R 163 0 R 163 0 R 163 0 R 163 0 R 160 0 R 162 0 R 160 0 R 160 0 R 161 0 R 160 0 R 159 0 R 159 0 R 158 0 R 158 0 R 147 0 R 157 0 R 147 0 R 156 0 R 156 0 R 156 0 R 156 0 R 156 0 R 156 0 R 156 0 R 156 0 R 156 0 R 156 0 R 156 0 R 156 0 R 156 0 R 147 0 R 155 0 R 147 0 R 154 0 R 154 0 R 147 0 R 153 0 R 153 0 R 153 0 R 147 0 R 152 0 R 152 0 R 152 0 R 147 0 R 151 0 R 151 0 R 151 0 R 147 0 R 147 0 R 150 0 R 147 0 R 149 0 R 147 0 R 148 0 R 147 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 145 0 R 145 0 R 145 0 R 145 0 R 145 0 R 145 0 R 145 0 R 145 0 R 145 0 R 145 0 R 145 0 R 145 0 R 145 0 R 145 0 R 145 0 R 137 0 R 144 0 R 144 0 R 144 0 R 137 0 R 143 0 R 143 0 R 143 0 R 143 0 R 143 0 R 143 0 R 143 0 R 143 0 R 143 0 R 143 0 R 143 0 R 143 0 R 137 0 R 137 0 R 142 0 R 142 0 R 142 0 R 142 0 R 137 0 R 141 0 R 141 0 R 141 0 R 141 0 R 141 0 R 141 0 R 137 0 R 140 0 R 140 0 R 140 0 R 140 0 R 140 0 R 140 0 R 137 0 R 139 0 R 139 0 R 139 0 R 139 0 R 137 0 R 138 0 R 137 0 R 137 0 R]
+[201 0 R 201 0 R 198 0 R 200 0 R 200 0 R 200 0 R 200 0 R 200 0 R 200 0 R 200 0 R 200 0 R 200 0 R 200 0 R 200 0 R 198 0 R 199 0 R 199 0 R 199 0 R 199 0 R 199 0 R 199 0 R 199 0 R 198 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 191 0 R 196 0 R 191 0 R 195 0 R 195 0 R 195 0 R 195 0 R 195 0 R 195 0 R 191 0 R 191 0 R 194 0 R 191 0 R 191 0 R 193 0 R 193 0 R 193 0 R 193 0 R 191 0 R 192 0 R 191 0 R 190 0 R 190 0 R 180 0 R 189 0 R 180 0 R 180 0 R 188 0 R 180 0 R 187 0 R 187 0 R 187 0 R 187 0 R 187 0 R 187 0 R 187 0 R 187 0 R 187 0 R 187 0 R 187 0 R 187 0 R 187 0 R 187 0 R 187 0 R 187 0 R 187 0 R 180 0 R 180 0 R 186 0 R 180 0 R 185 0 R 185 0 R 185 0 R 185 0 R 185 0 R 185 0 R 185 0 R 185 0 R 180 0 R 180 0 R 184 0 R 184 0 R 184 0 R 184 0 R 184 0 R 180 0 R 183 0 R 180 0 R 182 0 R 182 0 R 180 0 R 180 0 R 181 0 R 181 0 R 181 0 R 181 0 R 181 0 R 180 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 178 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 167 0 R 175 0 R 175 0 R 175 0 R 175 0 R 167 0 R 167 0 R 174 0 R 174 0 R 174 0 R 174 0 R 167 0 R 173 0 R 173 0 R 173 0 R 173 0 R 173 0 R 173 0 R 173 0 R 167 0 R 172 0 R 172 0 R 172 0 R 172 0 R 172 0 R 172 0 R 172 0 R 172 0 R 172 0 R 167 0 R 171 0 R 171 0 R 171 0 R 171 0 R 171 0 R 171 0 R 171 0 R 167 0 R 170 0 R 170 0 R 170 0 R 170 0 R 170 0 R 170 0 R 170 0 R 167 0 R 169 0 R 169 0 R 169 0 R 169 0 R 169 0 R 169 0 R 169 0 R 169 0 R 169 0 R 169 0 R 169 0 R 169 0 R 167 0 R 168 0 R 167 0 R 167 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 160 0 R 165 0 R 165 0 R 160 0 R 164 0 R 164 0 R 164 0 R 164 0 R 164 0 R 164 0 R 164 0 R 160 0 R 160 0 R 163 0 R 163 0 R 163 0 R 163 0 R 163 0 R 163 0 R 163 0 R 160 0 R 162 0 R 160 0 R 160 0 R 161 0 R 160 0 R 159 0 R 159 0 R 158 0 R 158 0 R 147 0 R 157 0 R 147 0 R 156 0 R 156 0 R 156 0 R 156 0 R 156 0 R 156 0 R 156 0 R 156 0 R 156 0 R 156 0 R 156 0 R 156 0 R 156 0 R 147 0 R 155 0 R 147 0 R 154 0 R 154 0 R 147 0 R 153 0 R 153 0 R 153 0 R 147 0 R 152 0 R 152 0 R 152 0 R 147 0 R 151 0 R 151 0 R 151 0 R 147 0 R 147 0 R 150 0 R 147 0 R 149 0 R 147 0 R 148 0 R 147 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 145 0 R 145 0 R 145 0 R 145 0 R 145 0 R 145 0 R 145 0 R 145 0 R 145 0 R 145 0 R 145 0 R 145 0 R 145 0 R 145 0 R 145 0 R]
 endobj
 
 20 0 obj
-[136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 133 0 R 135 0 R 135 0 R 135 0 R 135 0 R 135 0 R 135 0 R 135 0 R 135 0 R 135 0 R 133 0 R 133 0 R 133 0 R 133 0 R 134 0 R 133 0 R 132 0 R 132 0 R 131 0 R 131 0 R 120 0 R 130 0 R 120 0 R 129 0 R 129 0 R 129 0 R 129 0 R 120 0 R 128 0 R 128 0 R 128 0 R 128 0 R 120 0 R 127 0 R 120 0 R 126 0 R 126 0 R 126 0 R 126 0 R 120 0 R 125 0 R 120 0 R 120 0 R 124 0 R 120 0 R 120 0 R 123 0 R 123 0 R 123 0 R 123 0 R 123 0 R 123 0 R 123 0 R 120 0 R 122 0 R 120 0 R 120 0 R 121 0 R 120 0 R 119 0 R 119 0 R 119 0 R 119 0 R 119 0 R 119 0 R 119 0 R 119 0 R 119 0 R 119 0 R 119 0 R 119 0 R 119 0 R 119 0 R 119 0 R 119 0 R 119 0 R 119 0 R 119 0 R 119 0 R 119 0 R 119 0 R 119 0 R 119 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 117 0 R 108 0 R 108 0 R 116 0 R 116 0 R 116 0 R 116 0 R 116 0 R 116 0 R 108 0 R 115 0 R 115 0 R 115 0 R 115 0 R 115 0 R 115 0 R 115 0 R 115 0 R 115 0 R 115 0 R 115 0 R 115 0 R 115 0 R 115 0 R 115 0 R 115 0 R 115 0 R 115 0 R 115 0 R 115 0 R 115 0 R 115 0 R 115 0 R 115 0 R 115 0 R 108 0 R 114 0 R 108 0 R 113 0 R 113 0 R 113 0 R 113 0 R 108 0 R 108 0 R 112 0 R 112 0 R 112 0 R 112 0 R 112 0 R 112 0 R 112 0 R 112 0 R 108 0 R 111 0 R 111 0 R 111 0 R 111 0 R 111 0 R 111 0 R 111 0 R 111 0 R 111 0 R 111 0 R 111 0 R 111 0 R 108 0 R 110 0 R 108 0 R 108 0 R 109 0 R 108 0 R 107 0 R 107 0 R 104 0 R 104 0 R 104 0 R 104 0 R 106 0 R 104 0 R 105 0 R 104 0 R 103 0 R 103 0 R 102 0 R 100 0 R 98 0 R 95 0 R 94 0 R 94 0 R 93 0 R 91 0 R 90 0 R 90 0 R 89 0 R 89 0 R 87 0 R 86 0 R 86 0 R 85 0 R 83 0 R 82 0 R 81 0 R 81 0 R 80 0 R]
+[137 0 R 144 0 R 144 0 R 144 0 R 137 0 R 143 0 R 143 0 R 143 0 R 143 0 R 143 0 R 143 0 R 143 0 R 143 0 R 143 0 R 143 0 R 143 0 R 143 0 R 137 0 R 137 0 R 142 0 R 142 0 R 142 0 R 142 0 R 137 0 R 141 0 R 141 0 R 141 0 R 141 0 R 141 0 R 141 0 R 137 0 R 140 0 R 140 0 R 140 0 R 140 0 R 140 0 R 140 0 R 137 0 R 139 0 R 139 0 R 139 0 R 139 0 R 137 0 R 138 0 R 137 0 R 137 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 133 0 R 135 0 R 135 0 R 135 0 R 135 0 R 135 0 R 135 0 R 135 0 R 135 0 R 135 0 R 133 0 R 133 0 R 133 0 R 133 0 R 134 0 R 133 0 R 132 0 R 132 0 R 131 0 R 131 0 R 120 0 R 130 0 R 120 0 R 129 0 R 129 0 R 129 0 R 129 0 R 120 0 R 128 0 R 128 0 R 128 0 R 128 0 R 120 0 R 127 0 R 120 0 R 126 0 R 126 0 R 126 0 R 126 0 R 120 0 R 125 0 R 120 0 R 120 0 R 124 0 R 120 0 R 120 0 R 123 0 R 123 0 R 123 0 R 123 0 R 123 0 R 123 0 R 123 0 R 120 0 R 122 0 R 120 0 R 120 0 R 121 0 R 120 0 R 119 0 R 119 0 R 119 0 R 119 0 R 119 0 R 119 0 R 119 0 R 119 0 R 119 0 R 119 0 R 119 0 R 119 0 R 119 0 R 119 0 R 119 0 R 119 0 R 119 0 R 119 0 R 119 0 R 119 0 R 119 0 R 119 0 R 119 0 R 119 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 117 0 R 108 0 R 108 0 R 116 0 R 116 0 R 116 0 R 116 0 R 116 0 R 116 0 R 108 0 R 115 0 R 115 0 R 115 0 R 115 0 R 115 0 R 115 0 R 115 0 R 115 0 R 115 0 R 115 0 R 115 0 R 115 0 R 115 0 R 115 0 R 115 0 R 115 0 R 115 0 R 115 0 R 115 0 R 115 0 R 115 0 R 115 0 R 115 0 R 115 0 R 115 0 R 108 0 R 114 0 R 108 0 R 113 0 R 113 0 R 113 0 R 113 0 R 108 0 R 108 0 R 112 0 R 112 0 R 112 0 R 112 0 R 112 0 R 112 0 R 112 0 R 112 0 R 108 0 R 111 0 R 111 0 R 111 0 R 111 0 R 111 0 R 111 0 R 111 0 R 111 0 R 111 0 R 111 0 R 111 0 R 111 0 R 108 0 R 110 0 R 108 0 R 108 0 R 109 0 R 108 0 R 107 0 R 107 0 R 104 0 R 104 0 R 104 0 R 104 0 R 106 0 R 104 0 R 105 0 R 104 0 R 103 0 R 103 0 R 102 0 R 100 0 R 98 0 R 95 0 R 94 0 R 94 0 R 93 0 R 91 0 R 90 0 R 90 0 R 89 0 R 89 0 R 87 0 R 86 0 R 86 0 R 85 0 R]
 endobj
 
 21 0 obj
-[78 0 R 77 0 R 77 0 R 76 0 R 76 0 R 74 0 R 73 0 R 73 0 R 72 0 R 72 0 R 70 0 R 69 0 R 69 0 R 68 0 R 65 0 R 64 0 R 59 0 R 59 0 R 62 0 R 62 0 R 59 0 R 61 0 R 59 0 R 56 0 R 51 0 R 54 0 R 51 0 R 53 0 R 51 0 R 48 0 R 43 0 R 43 0 R 46 0 R 46 0 R 43 0 R 45 0 R 43 0 R 40 0 R 35 0 R 35 0 R 38 0 R 35 0 R 35 0 R 37 0 R 35 0 R 32 0 R 26 0 R 26 0 R 30 0 R 30 0 R 26 0 R 29 0 R 28 0 R 26 0 R]
+[83 0 R 82 0 R 81 0 R 81 0 R 80 0 R 78 0 R 77 0 R 77 0 R 76 0 R 76 0 R 74 0 R 73 0 R 73 0 R 72 0 R 72 0 R 70 0 R 69 0 R 69 0 R 68 0 R 65 0 R 64 0 R 59 0 R 59 0 R 62 0 R 62 0 R 59 0 R 61 0 R 59 0 R 56 0 R 51 0 R 54 0 R 51 0 R 53 0 R 51 0 R 48 0 R 43 0 R 43 0 R 46 0 R 46 0 R 43 0 R 45 0 R 43 0 R 40 0 R 35 0 R 35 0 R 38 0 R 35 0 R 35 0 R 37 0 R 35 0 R 32 0 R 26 0 R 26 0 R 30 0 R 30 0 R 26 0 R 29 0 R 28 0 R 26 0 R]
 endobj
 
 22 0 obj
@@ -194,7 +194,7 @@ endobj
   /Type /StructElem
   /S /Document
   /P 17 0 R
-  /K [236 0 R 230 0 R 229 0 R 227 0 R 226 0 R 220 0 R 219 0 R 218 0 R 215 0 R 214 0 R 212 0 R 211 0 R 207 0 R 206 0 R 202 0 R 201 0 R 198 0 R 197 0 R 191 0 R 190 0 R 180 0 R 179 0 R 178 0 R 177 0 R 176 0 R 167 0 R 166 0 R 160 0 R 159 0 R 158 0 R 147 0 R 146 0 R 145 0 R 137 0 R 136 0 R 133 0 R 132 0 R 131 0 R 120 0 R 119 0 R 118 0 R 108 0 R 107 0 R 104 0 R 103 0 R 66 0 R 65 0 R 23 0 R]
+  /K [243 0 R 237 0 R 236 0 R 234 0 R 233 0 R 220 0 R 219 0 R 218 0 R 215 0 R 214 0 R 212 0 R 211 0 R 207 0 R 206 0 R 202 0 R 201 0 R 198 0 R 197 0 R 191 0 R 190 0 R 180 0 R 179 0 R 178 0 R 177 0 R 176 0 R 167 0 R 166 0 R 160 0 R 159 0 R 158 0 R 147 0 R 146 0 R 145 0 R 137 0 R 136 0 R 133 0 R 132 0 R 131 0 R 120 0 R 119 0 R 118 0 R 108 0 R 107 0 R 104 0 R 103 0 R 66 0 R 65 0 R 23 0 R]
 >>
 endobj
 
@@ -234,8 +234,8 @@ endobj
   /Type /StructElem
   /S /BibEntry
   /P 25 0 R
-  /K [46 47 30 0 R 50 27 0 R 53]
-  /Pg 319 0 R
+  /K [51 52 30 0 R 55 27 0 R 58]
+  /Pg 326 0 R
 >>
 endobj
 
@@ -246,12 +246,12 @@ endobj
   /P 26 0 R
   /K [29 0 R <<
     /Type /OBJR
-    /Pg 319 0 R
-    /Obj 317 0 R
+    /Pg 326 0 R
+    /Obj 324 0 R
   >> 28 0 R <<
     /Type /OBJR
-    /Pg 319 0 R
-    /Obj 318 0 R
+    /Pg 326 0 R
+    /Obj 325 0 R
   >>]
 >>
 endobj
@@ -265,8 +265,8 @@ endobj
     /O /Layout
     /TextDecorationType /Underline
   >>]
-  /K [52]
-  /Pg 319 0 R
+  /K [57]
+  /Pg 326 0 R
 >>
 endobj
 
@@ -279,8 +279,8 @@ endobj
     /O /Layout
     /TextDecorationType /Underline
   >>]
-  /K [51]
-  /Pg 319 0 R
+  /K [56]
+  /Pg 326 0 R
 >>
 endobj
 
@@ -289,8 +289,8 @@ endobj
   /Type /StructElem
   /S /Em
   /P 26 0 R
-  /K [48 49]
-  /Pg 319 0 R
+  /K [53 54]
+  /Pg 326 0 R
 >>
 endobj
 
@@ -308,12 +308,12 @@ endobj
   /Type /StructElem
   /S /Link
   /P 31 0 R
-  /K [45 <<
+  /K [50 <<
     /Type /OBJR
-    /Pg 319 0 R
-    /Obj 316 0 R
+    /Pg 326 0 R
+    /Obj 323 0 R
   >>]
-  /Pg 319 0 R
+  /Pg 326 0 R
 >>
 endobj
 
@@ -340,8 +340,8 @@ endobj
   /Type /StructElem
   /S /BibEntry
   /P 34 0 R
-  /K [38 39 38 0 R 41 42 36 0 R 44]
-  /Pg 319 0 R
+  /K [43 44 38 0 R 46 47 36 0 R 49]
+  /Pg 326 0 R
 >>
 endobj
 
@@ -352,8 +352,8 @@ endobj
   /P 35 0 R
   /K [37 0 R <<
     /Type /OBJR
-    /Pg 319 0 R
-    /Obj 315 0 R
+    /Pg 326 0 R
+    /Obj 322 0 R
   >>]
 >>
 endobj
@@ -367,8 +367,8 @@ endobj
     /O /Layout
     /TextDecorationType /Underline
   >>]
-  /K [43]
-  /Pg 319 0 R
+  /K [48]
+  /Pg 326 0 R
 >>
 endobj
 
@@ -377,8 +377,8 @@ endobj
   /Type /StructElem
   /S /Em
   /P 35 0 R
-  /K [40]
-  /Pg 319 0 R
+  /K [45]
+  /Pg 326 0 R
 >>
 endobj
 
@@ -396,12 +396,12 @@ endobj
   /Type /StructElem
   /S /Link
   /P 39 0 R
-  /K [37 <<
+  /K [42 <<
     /Type /OBJR
-    /Pg 319 0 R
-    /Obj 314 0 R
+    /Pg 326 0 R
+    /Obj 321 0 R
   >>]
-  /Pg 319 0 R
+  /Pg 326 0 R
 >>
 endobj
 
@@ -428,8 +428,8 @@ endobj
   /Type /StructElem
   /S /BibEntry
   /P 42 0 R
-  /K [30 31 46 0 R 34 44 0 R 36]
-  /Pg 319 0 R
+  /K [35 36 46 0 R 39 44 0 R 41]
+  /Pg 326 0 R
 >>
 endobj
 
@@ -440,8 +440,8 @@ endobj
   /P 43 0 R
   /K [45 0 R <<
     /Type /OBJR
-    /Pg 319 0 R
-    /Obj 313 0 R
+    /Pg 326 0 R
+    /Obj 320 0 R
   >>]
 >>
 endobj
@@ -455,8 +455,8 @@ endobj
     /O /Layout
     /TextDecorationType /Underline
   >>]
-  /K [35]
-  /Pg 319 0 R
+  /K [40]
+  /Pg 326 0 R
 >>
 endobj
 
@@ -465,8 +465,8 @@ endobj
   /Type /StructElem
   /S /Em
   /P 43 0 R
-  /K [32 33]
-  /Pg 319 0 R
+  /K [37 38]
+  /Pg 326 0 R
 >>
 endobj
 
@@ -484,12 +484,12 @@ endobj
   /Type /StructElem
   /S /Link
   /P 47 0 R
-  /K [29 <<
+  /K [34 <<
     /Type /OBJR
-    /Pg 319 0 R
-    /Obj 312 0 R
+    /Pg 326 0 R
+    /Obj 319 0 R
   >>]
-  /Pg 319 0 R
+  /Pg 326 0 R
 >>
 endobj
 
@@ -516,8 +516,8 @@ endobj
   /Type /StructElem
   /S /BibEntry
   /P 50 0 R
-  /K [24 54 0 R 26 52 0 R 28]
-  /Pg 319 0 R
+  /K [29 54 0 R 31 52 0 R 33]
+  /Pg 326 0 R
 >>
 endobj
 
@@ -528,8 +528,8 @@ endobj
   /P 51 0 R
   /K [53 0 R <<
     /Type /OBJR
-    /Pg 319 0 R
-    /Obj 311 0 R
+    /Pg 326 0 R
+    /Obj 318 0 R
   >>]
 >>
 endobj
@@ -543,8 +543,8 @@ endobj
     /O /Layout
     /TextDecorationType /Underline
   >>]
-  /K [27]
-  /Pg 319 0 R
+  /K [32]
+  /Pg 326 0 R
 >>
 endobj
 
@@ -553,8 +553,8 @@ endobj
   /Type /StructElem
   /S /Em
   /P 51 0 R
-  /K [25]
-  /Pg 319 0 R
+  /K [30]
+  /Pg 326 0 R
 >>
 endobj
 
@@ -572,12 +572,12 @@ endobj
   /Type /StructElem
   /S /Link
   /P 55 0 R
-  /K [23 <<
+  /K [28 <<
     /Type /OBJR
-    /Pg 319 0 R
-    /Obj 310 0 R
+    /Pg 326 0 R
+    /Obj 317 0 R
   >>]
-  /Pg 319 0 R
+  /Pg 326 0 R
 >>
 endobj
 
@@ -604,8 +604,8 @@ endobj
   /Type /StructElem
   /S /BibEntry
   /P 58 0 R
-  /K [16 17 62 0 R 20 60 0 R 22]
-  /Pg 319 0 R
+  /K [21 22 62 0 R 25 60 0 R 27]
+  /Pg 326 0 R
 >>
 endobj
 
@@ -616,8 +616,8 @@ endobj
   /P 59 0 R
   /K [61 0 R <<
     /Type /OBJR
-    /Pg 319 0 R
-    /Obj 309 0 R
+    /Pg 326 0 R
+    /Obj 316 0 R
   >>]
 >>
 endobj
@@ -631,8 +631,8 @@ endobj
     /O /Layout
     /TextDecorationType /Underline
   >>]
-  /K [21]
-  /Pg 319 0 R
+  /K [26]
+  /Pg 326 0 R
 >>
 endobj
 
@@ -641,8 +641,8 @@ endobj
   /Type /StructElem
   /S /Em
   /P 59 0 R
-  /K [18 19]
-  /Pg 319 0 R
+  /K [23 24]
+  /Pg 326 0 R
 >>
 endobj
 
@@ -660,12 +660,12 @@ endobj
   /Type /StructElem
   /S /Link
   /P 63 0 R
-  /K [15 <<
+  /K [20 <<
     /Type /OBJR
-    /Pg 319 0 R
-    /Obj 308 0 R
+    /Pg 326 0 R
+    /Obj 315 0 R
   >>]
-  /Pg 319 0 R
+  /Pg 326 0 R
 >>
 endobj
 
@@ -675,8 +675,8 @@ endobj
   /S /H1
   /P 22 0 R
   /T (Bibliography)
-  /K [14]
-  /Pg 319 0 R
+  /K [19]
+  /Pg 326 0 R
 >>
 endobj
 
@@ -715,8 +715,8 @@ endobj
     /O /Layout
     /BorderStyle /Solid
   >>]
-  /K [13]
-  /Pg 319 0 R
+  /K [18]
+  /Pg 326 0 R
 >>
 endobj
 
@@ -732,8 +732,8 @@ endobj
     /O /Layout
     /BorderStyle /Solid
   >>]
-  /K [11 12]
-  /Pg 319 0 R
+  /K [16 17]
+  /Pg 326 0 R
 >>
 endobj
 
@@ -749,8 +749,8 @@ endobj
     /O /Layout
     /BorderStyle /Solid
   >>]
-  /K [10]
-  /Pg 319 0 R
+  /K [15]
+  /Pg 326 0 R
 >>
 endobj
 
@@ -775,8 +775,8 @@ endobj
     /O /Layout
     /BorderStyle /Solid
   >>]
-  /K [8 9]
-  /Pg 319 0 R
+  /K [13 14]
+  /Pg 326 0 R
 >>
 endobj
 
@@ -792,8 +792,8 @@ endobj
     /O /Layout
     /BorderStyle /Solid
   >>]
-  /K [6 7]
-  /Pg 319 0 R
+  /K [11 12]
+  /Pg 326 0 R
 >>
 endobj
 
@@ -809,8 +809,8 @@ endobj
     /O /Layout
     /BorderStyle /Solid
   >>]
-  /K [5]
-  /Pg 319 0 R
+  /K [10]
+  /Pg 326 0 R
 >>
 endobj
 
@@ -835,8 +835,8 @@ endobj
     /O /Layout
     /BorderStyle /Solid
   >>]
-  /K [3 4]
-  /Pg 319 0 R
+  /K [8 9]
+  /Pg 326 0 R
 >>
 endobj
 
@@ -852,8 +852,8 @@ endobj
     /O /Layout
     /BorderStyle /Solid
   >>]
-  /K [1 2]
-  /Pg 319 0 R
+  /K [6 7]
+  /Pg 326 0 R
 >>
 endobj
 
@@ -869,8 +869,8 @@ endobj
     /O /Layout
     /BorderStyle /Solid
   >>]
-  /K [0]
-  /Pg 319 0 R
+  /K [5]
+  /Pg 326 0 R
 >>
 endobj
 
@@ -895,8 +895,8 @@ endobj
     /O /Layout
     /BorderStyle /Solid
   >>]
-  /K [268]
-  /Pg 306 0 R
+  /K [4]
+  /Pg 326 0 R
 >>
 endobj
 
@@ -912,8 +912,8 @@ endobj
     /O /Layout
     /BorderStyle /Solid
   >>]
-  /K [82 0 R 266 267]
-  /Pg 306 0 R
+  /K [82 0 R 2 3]
+  /Pg 326 0 R
 >>
 endobj
 
@@ -922,8 +922,8 @@ endobj
   /Type /StructElem
   /S /Strong
   /P 81 0 R
-  /K [265]
-  /Pg 306 0 R
+  /K [1]
+  /Pg 326 0 R
 >>
 endobj
 
@@ -939,8 +939,8 @@ endobj
     /O /Layout
     /BorderStyle /Solid
   >>]
-  /K [264]
-  /Pg 306 0 R
+  /K [0]
+  /Pg 326 0 R
 >>
 endobj
 
@@ -965,8 +965,8 @@ endobj
     /O /Layout
     /BorderStyle /Solid
   >>]
-  /K [263]
-  /Pg 306 0 R
+  /K [309]
+  /Pg 313 0 R
 >>
 endobj
 
@@ -982,8 +982,8 @@ endobj
     /O /Layout
     /BorderStyle /Solid
   >>]
-  /K [261 262]
-  /Pg 306 0 R
+  /K [307 308]
+  /Pg 313 0 R
 >>
 endobj
 
@@ -999,8 +999,8 @@ endobj
     /O /Layout
     /BorderStyle /Solid
   >>]
-  /K [260]
-  /Pg 306 0 R
+  /K [306]
+  /Pg 313 0 R
 >>
 endobj
 
@@ -1025,8 +1025,8 @@ endobj
     /O /Layout
     /BorderStyle /Solid
   >>]
-  /K [258 259]
-  /Pg 306 0 R
+  /K [304 305]
+  /Pg 313 0 R
 >>
 endobj
 
@@ -1042,8 +1042,8 @@ endobj
     /O /Layout
     /BorderStyle /Solid
   >>]
-  /K [256 257]
-  /Pg 306 0 R
+  /K [302 303]
+  /Pg 313 0 R
 >>
 endobj
 
@@ -1059,8 +1059,8 @@ endobj
     /O /Layout
     /BorderStyle /Solid
   >>]
-  /K [255]
-  /Pg 306 0 R
+  /K [301]
+  /Pg 313 0 R
 >>
 endobj
 
@@ -1085,8 +1085,8 @@ endobj
     /O /Layout
     /BorderStyle /Solid
   >>]
-  /K [254]
-  /Pg 306 0 R
+  /K [300]
+  /Pg 313 0 R
 >>
 endobj
 
@@ -1102,8 +1102,8 @@ endobj
     /O /Layout
     /BorderStyle /Solid
   >>]
-  /K [252 253]
-  /Pg 306 0 R
+  /K [298 299]
+  /Pg 313 0 R
 >>
 endobj
 
@@ -1119,8 +1119,8 @@ endobj
     /O /Layout
     /BorderStyle /Solid
   >>]
-  /K [251]
-  /Pg 306 0 R
+  /K [297]
+  /Pg 313 0 R
 >>
 endobj
 
@@ -1154,8 +1154,8 @@ endobj
   /Type /StructElem
   /S /Strong
   /P 97 0 R
-  /K [250]
-  /Pg 306 0 R
+  /K [296]
+  /Pg 313 0 R
 >>
 endobj
 
@@ -1180,8 +1180,8 @@ endobj
   /Type /StructElem
   /S /Strong
   /P 99 0 R
-  /K [249]
-  /Pg 306 0 R
+  /K [295]
+  /Pg 313 0 R
 >>
 endobj
 
@@ -1206,8 +1206,8 @@ endobj
   /Type /StructElem
   /S /Strong
   /P 101 0 R
-  /K [248]
-  /Pg 306 0 R
+  /K [294]
+  /Pg 313 0 R
 >>
 endobj
 
@@ -1217,8 +1217,8 @@ endobj
   /S /H1
   /P 22 0 R
   /T (Choosing a model)
-  /K [246 247]
-  /Pg 306 0 R
+  /K [292 293]
+  /Pg 313 0 R
 >>
 endobj
 
@@ -1227,8 +1227,8 @@ endobj
   /Type /StructElem
   /S /P
   /P 22 0 R
-  /K [238 239 240 241 106 0 R 243 105 0 R 245]
-  /Pg 306 0 R
+  /K [284 285 286 287 106 0 R 289 105 0 R 291]
+  /Pg 313 0 R
 >>
 endobj
 
@@ -1237,8 +1237,8 @@ endobj
   /Type /StructElem
   /S /Code
   /P 104 0 R
-  /K [244]
-  /Pg 306 0 R
+  /K [290]
+  /Pg 313 0 R
 >>
 endobj
 
@@ -1247,12 +1247,12 @@ endobj
   /Type /StructElem
   /S /Link
   /P 104 0 R
-  /K [242 <<
+  /K [288 <<
     /Type /OBJR
-    /Pg 306 0 R
-    /Obj 305 0 R
+    /Pg 313 0 R
+    /Obj 312 0 R
   >>]
-  /Pg 306 0 R
+  /Pg 313 0 R
 >>
 endobj
 
@@ -1262,8 +1262,8 @@ endobj
   /S /H1
   /P 22 0 R
   /T (Legged platform)
-  /K [236 237]
-  /Pg 306 0 R
+  /K [282 283]
+  /Pg 313 0 R
 >>
 endobj
 
@@ -1272,8 +1272,8 @@ endobj
   /Type /StructElem
   /S /P
   /P 22 0 R
-  /K [117 0 R 166 167 116 0 R 174 115 0 R 200 114 0 R 202 113 0 R 207 208 112 0 R 217 111 0 R 230 110 0 R 232 233 109 0 R 235]
-  /Pg 306 0 R
+  /K [117 0 R 212 213 116 0 R 220 115 0 R 246 114 0 R 248 113 0 R 253 254 112 0 R 263 111 0 R 276 110 0 R 278 279 109 0 R 281]
+  /Pg 313 0 R
 >>
 endobj
 
@@ -1282,8 +1282,8 @@ endobj
   /Type /StructElem
   /S /Code
   /P 108 0 R
-  /K [234]
-  /Pg 306 0 R
+  /K [280]
+  /Pg 313 0 R
 >>
 endobj
 
@@ -1292,8 +1292,8 @@ endobj
   /Type /StructElem
   /S /Formula
   /P 108 0 R
-  /K [231]
-  /Pg 306 0 R
+  /K [277]
+  /Pg 313 0 R
 >>
 endobj
 
@@ -1302,8 +1302,8 @@ endobj
   /Type /StructElem
   /S /Formula
   /P 108 0 R
-  /K [218 219 220 221 222 223 224 225 226 227 228 229]
-  /Pg 306 0 R
+  /K [264 265 266 267 268 269 270 271 272 273 274 275]
+  /Pg 313 0 R
 >>
 endobj
 
@@ -1312,8 +1312,8 @@ endobj
   /Type /StructElem
   /S /Formula
   /P 108 0 R
-  /K [209 210 211 212 213 214 215 216]
-  /Pg 306 0 R
+  /K [255 256 257 258 259 260 261 262]
+  /Pg 313 0 R
 >>
 endobj
 
@@ -1322,8 +1322,8 @@ endobj
   /Type /StructElem
   /S /Formula
   /P 108 0 R
-  /K [203 204 205 206]
-  /Pg 306 0 R
+  /K [249 250 251 252]
+  /Pg 313 0 R
 >>
 endobj
 
@@ -1332,8 +1332,8 @@ endobj
   /Type /StructElem
   /S /Strong
   /P 108 0 R
-  /K [201]
-  /Pg 306 0 R
+  /K [247]
+  /Pg 313 0 R
 >>
 endobj
 
@@ -1342,8 +1342,8 @@ endobj
   /Type /StructElem
   /S /Formula
   /P 108 0 R
-  /K [175 176 177 178 179 180 181 182 183 184 185 186 187 188 189 190 191 192 193 194 195 196 197 198 199]
-  /Pg 306 0 R
+  /K [221 222 223 224 225 226 227 228 229 230 231 232 233 234 235 236 237 238 239 240 241 242 243 244 245]
+  /Pg 313 0 R
 >>
 endobj
 
@@ -1352,8 +1352,8 @@ endobj
   /Type /StructElem
   /S /Formula
   /P 108 0 R
-  /K [168 169 170 171 172 173]
-  /Pg 306 0 R
+  /K [214 215 216 217 218 219]
+  /Pg 313 0 R
 >>
 endobj
 
@@ -1362,8 +1362,8 @@ endobj
   /Type /StructElem
   /S /Code
   /P 108 0 R
-  /K [165]
-  /Pg 306 0 R
+  /K [211]
+  /Pg 313 0 R
 >>
 endobj
 
@@ -1376,8 +1376,8 @@ endobj
     /O /Layout
     /Placement /Block
   >>]
-  /K [137 138 139 140 141 142 143 144 145 146 147 148 149 150 151 152 153 154 155 156 157 158 159 160 161 162 163 164]
-  /Pg 306 0 R
+  /K [183 184 185 186 187 188 189 190 191 192 193 194 195 196 197 198 199 200 201 202 203 204 205 206 207 208 209 210]
+  /Pg 313 0 R
 >>
 endobj
 
@@ -1390,8 +1390,8 @@ endobj
     /O /Layout
     /Placement /Block
   >>]
-  /K [113 114 115 116 117 118 119 120 121 122 123 124 125 126 127 128 129 130 131 132 133 134 135 136]
-  /Pg 306 0 R
+  /K [159 160 161 162 163 164 165 166 167 168 169 170 171 172 173 174 175 176 177 178 179 180 181 182]
+  /Pg 313 0 R
 >>
 endobj
 
@@ -1400,8 +1400,8 @@ endobj
   /Type /StructElem
   /S /P
   /P 22 0 R
-  /K [74 130 0 R 76 129 0 R 81 128 0 R 86 127 0 R 88 126 0 R 93 125 0 R 95 96 124 0 R 98 99 123 0 R 107 122 0 R 109 110 121 0 R 112]
-  /Pg 306 0 R
+  /K [120 130 0 R 122 129 0 R 127 128 0 R 132 127 0 R 134 126 0 R 139 125 0 R 141 142 124 0 R 144 145 123 0 R 153 122 0 R 155 156 121 0 R 158]
+  /Pg 313 0 R
 >>
 endobj
 
@@ -1410,8 +1410,8 @@ endobj
   /Type /StructElem
   /S /Formula
   /P 120 0 R
-  /K [111]
-  /Pg 306 0 R
+  /K [157]
+  /Pg 313 0 R
 >>
 endobj
 
@@ -1420,8 +1420,8 @@ endobj
   /Type /StructElem
   /S /Formula
   /P 120 0 R
-  /K [108]
-  /Pg 306 0 R
+  /K [154]
+  /Pg 313 0 R
 >>
 endobj
 
@@ -1430,8 +1430,8 @@ endobj
   /Type /StructElem
   /S /Formula
   /P 120 0 R
-  /K [100 101 102 103 104 105 106]
-  /Pg 306 0 R
+  /K [146 147 148 149 150 151 152]
+  /Pg 313 0 R
 >>
 endobj
 
@@ -1440,8 +1440,8 @@ endobj
   /Type /StructElem
   /S /Formula
   /P 120 0 R
-  /K [97]
-  /Pg 306 0 R
+  /K [143]
+  /Pg 313 0 R
 >>
 endobj
 
@@ -1450,8 +1450,8 @@ endobj
   /Type /StructElem
   /S /Strong
   /P 120 0 R
-  /K [94]
-  /Pg 306 0 R
+  /K [140]
+  /Pg 313 0 R
 >>
 endobj
 
@@ -1460,8 +1460,8 @@ endobj
   /Type /StructElem
   /S /Formula
   /P 120 0 R
-  /K [89 90 91 92]
-  /Pg 306 0 R
+  /K [135 136 137 138]
+  /Pg 313 0 R
 >>
 endobj
 
@@ -1470,8 +1470,8 @@ endobj
   /Type /StructElem
   /S /Formula
   /P 120 0 R
-  /K [87]
-  /Pg 306 0 R
+  /K [133]
+  /Pg 313 0 R
 >>
 endobj
 
@@ -1480,8 +1480,8 @@ endobj
   /Type /StructElem
   /S /Formula
   /P 120 0 R
-  /K [82 83 84 85]
-  /Pg 306 0 R
+  /K [128 129 130 131]
+  /Pg 313 0 R
 >>
 endobj
 
@@ -1490,8 +1490,8 @@ endobj
   /Type /StructElem
   /S /Formula
   /P 120 0 R
-  /K [77 78 79 80]
-  /Pg 306 0 R
+  /K [123 124 125 126]
+  /Pg 313 0 R
 >>
 endobj
 
@@ -1500,12 +1500,12 @@ endobj
   /Type /StructElem
   /S /Link
   /P 120 0 R
-  /K [75 <<
+  /K [121 <<
     /Type /OBJR
-    /Pg 306 0 R
-    /Obj 304 0 R
+    /Pg 313 0 R
+    /Obj 311 0 R
   >>]
-  /Pg 306 0 R
+  /Pg 313 0 R
 >>
 endobj
 
@@ -1515,8 +1515,8 @@ endobj
   /S /H2
   /P 22 0 R
   /T (Quadrotor (rigid body))
-  /K [72 73]
-  /Pg 306 0 R
+  /K [118 119]
+  /Pg 313 0 R
 >>
 endobj
 
@@ -1526,8 +1526,8 @@ endobj
   /S /H1
   /P 22 0 R
   /T (Aerial platform)
-  /K [70 71]
-  /Pg 306 0 R
+  /K [116 117]
+  /Pg 313 0 R
 >>
 endobj
 
@@ -1536,8 +1536,8 @@ endobj
   /Type /StructElem
   /S /P
   /P 22 0 R
-  /K [54 135 0 R 64 65 66 67 134 0 R 69]
-  /Pg 306 0 R
+  /K [100 135 0 R 110 111 112 113 134 0 R 115]
+  /Pg 313 0 R
 >>
 endobj
 
@@ -1546,8 +1546,8 @@ endobj
   /Type /StructElem
   /S /Code
   /P 133 0 R
-  /K [68]
-  /Pg 306 0 R
+  /K [114]
+  /Pg 313 0 R
 >>
 endobj
 
@@ -1556,8 +1556,8 @@ endobj
   /Type /StructElem
   /S /Formula
   /P 133 0 R
-  /K [55 56 57 58 59 60 61 62 63]
-  /Pg 306 0 R
+  /K [101 102 103 104 105 106 107 108 109]
+  /Pg 313 0 R
 >>
 endobj
 
@@ -1570,8 +1570,8 @@ endobj
     /O /Layout
     /Placement /Block
   >>]
-  /K [0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53]
-  /Pg 306 0 R
+  /K [46 47 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99]
+  /Pg 313 0 R
 >>
 endobj
 
@@ -1580,8 +1580,8 @@ endobj
   /Type /StructElem
   /S /P
   /P 22 0 R
-  /K [464 144 0 R 468 143 0 R 481 482 142 0 R 487 141 0 R 494 140 0 R 501 139 0 R 506 138 0 R 508 509]
-  /Pg 302 0 R
+  /K [0 144 0 R 4 143 0 R 17 18 142 0 R 23 141 0 R 30 140 0 R 37 139 0 R 42 138 0 R 44 45]
+  /Pg 313 0 R
 >>
 endobj
 
@@ -1590,8 +1590,8 @@ endobj
   /Type /StructElem
   /S /Strong
   /P 137 0 R
-  /K [507]
-  /Pg 302 0 R
+  /K [43]
+  /Pg 313 0 R
 >>
 endobj
 
@@ -1600,8 +1600,8 @@ endobj
   /Type /StructElem
   /S /Formula
   /P 137 0 R
-  /K [502 503 504 505]
-  /Pg 302 0 R
+  /K [38 39 40 41]
+  /Pg 313 0 R
 >>
 endobj
 
@@ -1610,8 +1610,8 @@ endobj
   /Type /StructElem
   /S /Formula
   /P 137 0 R
-  /K [495 496 497 498 499 500]
-  /Pg 302 0 R
+  /K [31 32 33 34 35 36]
+  /Pg 313 0 R
 >>
 endobj
 
@@ -1620,8 +1620,8 @@ endobj
   /Type /StructElem
   /S /Formula
   /P 137 0 R
-  /K [488 489 490 491 492 493]
-  /Pg 302 0 R
+  /K [24 25 26 27 28 29]
+  /Pg 313 0 R
 >>
 endobj
 
@@ -1630,8 +1630,8 @@ endobj
   /Type /StructElem
   /S /Formula
   /P 137 0 R
-  /K [483 484 485 486]
-  /Pg 302 0 R
+  /K [19 20 21 22]
+  /Pg 313 0 R
 >>
 endobj
 
@@ -1640,8 +1640,8 @@ endobj
   /Type /StructElem
   /S /Formula
   /P 137 0 R
-  /K [469 470 471 472 473 474 475 476 477 478 479 480]
-  /Pg 302 0 R
+  /K [5 6 7 8 9 10 11 12 13 14 15 16]
+  /Pg 313 0 R
 >>
 endobj
 
@@ -1650,8 +1650,8 @@ endobj
   /Type /StructElem
   /S /Formula
   /P 137 0 R
-  /K [465 466 467]
-  /Pg 302 0 R
+  /K [1 2 3]
+  /Pg 313 0 R
 >>
 endobj
 
@@ -1664,8 +1664,8 @@ endobj
     /O /Layout
     /Placement /Block
   >>]
-  /K [449 450 451 452 453 454 455 456 457 458 459 460 461 462 463]
-  /Pg 302 0 R
+  /K [472 473 474 475 476 477 478 479 480 481 482 483 484 485 486]
+  /Pg 309 0 R
 >>
 endobj
 
@@ -1678,8 +1678,8 @@ endobj
     /O /Layout
     /Placement /Block
   >>]
-  /K [409 410 411 412 413 414 415 416 417 418 419 420 421 422 423 424 425 426 427 428 429 430 431 432 433 434 435 436 437 438 439 440 441 442 443 444 445 446 447 448]
-  /Pg 302 0 R
+  /K [432 433 434 435 436 437 438 439 440 441 442 443 444 445 446 447 448 449 450 451 452 453 454 455 456 457 458 459 460 461 462 463 464 465 466 467 468 469 470 471]
+  /Pg 309 0 R
 >>
 endobj
 
@@ -1688,8 +1688,8 @@ endobj
   /Type /StructElem
   /S /P
   /P 22 0 R
-  /K [368 157 0 R 370 156 0 R 384 155 0 R 386 154 0 R 389 153 0 R 393 152 0 R 397 151 0 R 401 402 150 0 R 404 149 0 R 406 148 0 R 408]
-  /Pg 302 0 R
+  /K [391 157 0 R 393 156 0 R 407 155 0 R 409 154 0 R 412 153 0 R 416 152 0 R 420 151 0 R 424 425 150 0 R 427 149 0 R 429 148 0 R 431]
+  /Pg 309 0 R
 >>
 endobj
 
@@ -1698,8 +1698,8 @@ endobj
   /Type /StructElem
   /S /Formula
   /P 147 0 R
-  /K [407]
-  /Pg 302 0 R
+  /K [430]
+  /Pg 309 0 R
 >>
 endobj
 
@@ -1708,8 +1708,8 @@ endobj
   /Type /StructElem
   /S /Formula
   /P 147 0 R
-  /K [405]
-  /Pg 302 0 R
+  /K [428]
+  /Pg 309 0 R
 >>
 endobj
 
@@ -1718,8 +1718,8 @@ endobj
   /Type /StructElem
   /S /Formula
   /P 147 0 R
-  /K [403]
-  /Pg 302 0 R
+  /K [426]
+  /Pg 309 0 R
 >>
 endobj
 
@@ -1728,8 +1728,8 @@ endobj
   /Type /StructElem
   /S /Formula
   /P 147 0 R
-  /K [398 399 400]
-  /Pg 302 0 R
+  /K [421 422 423]
+  /Pg 309 0 R
 >>
 endobj
 
@@ -1738,8 +1738,8 @@ endobj
   /Type /StructElem
   /S /Formula
   /P 147 0 R
-  /K [394 395 396]
-  /Pg 302 0 R
+  /K [417 418 419]
+  /Pg 309 0 R
 >>
 endobj
 
@@ -1748,8 +1748,8 @@ endobj
   /Type /StructElem
   /S /Formula
   /P 147 0 R
-  /K [390 391 392]
-  /Pg 302 0 R
+  /K [413 414 415]
+  /Pg 309 0 R
 >>
 endobj
 
@@ -1758,8 +1758,8 @@ endobj
   /Type /StructElem
   /S /Strong
   /P 147 0 R
-  /K [387 388]
-  /Pg 302 0 R
+  /K [410 411]
+  /Pg 309 0 R
 >>
 endobj
 
@@ -1768,8 +1768,8 @@ endobj
   /Type /StructElem
   /S /Formula
   /P 147 0 R
-  /K [385]
-  /Pg 302 0 R
+  /K [408]
+  /Pg 309 0 R
 >>
 endobj
 
@@ -1778,8 +1778,8 @@ endobj
   /Type /StructElem
   /S /Formula
   /P 147 0 R
-  /K [371 372 373 374 375 376 377 378 379 380 381 382 383]
-  /Pg 302 0 R
+  /K [394 395 396 397 398 399 400 401 402 403 404 405 406]
+  /Pg 309 0 R
 >>
 endobj
 
@@ -1788,12 +1788,12 @@ endobj
   /Type /StructElem
   /S /Link
   /P 147 0 R
-  /K [369 <<
+  /K [392 <<
     /Type /OBJR
-    /Pg 302 0 R
-    /Obj 301 0 R
+    /Pg 309 0 R
+    /Obj 308 0 R
   >>]
-  /Pg 302 0 R
+  /Pg 309 0 R
 >>
 endobj
 
@@ -1803,8 +1803,8 @@ endobj
   /S /H2
   /P 22 0 R
   /T (Cart-pole (inverted pendulum on a cart))
-  /K [366 367]
-  /Pg 302 0 R
+  /K [389 390]
+  /Pg 309 0 R
 >>
 endobj
 
@@ -1814,8 +1814,8 @@ endobj
   /S /H1
   /P 22 0 R
   /T (Underactuated benchmark)
-  /K [364 365]
-  /Pg 302 0 R
+  /K [387 388]
+  /Pg 309 0 R
 >>
 endobj
 
@@ -1824,8 +1824,8 @@ endobj
   /Type /StructElem
   /S /P
   /P 22 0 R
-  /K [338 165 0 R 341 164 0 R 349 350 163 0 R 358 162 0 R 360 361 161 0 R 363]
-  /Pg 302 0 R
+  /K [361 165 0 R 364 164 0 R 372 373 163 0 R 381 162 0 R 383 384 161 0 R 386]
+  /Pg 309 0 R
 >>
 endobj
 
@@ -1834,8 +1834,8 @@ endobj
   /Type /StructElem
   /S /Code
   /P 160 0 R
-  /K [362]
-  /Pg 302 0 R
+  /K [385]
+  /Pg 309 0 R
 >>
 endobj
 
@@ -1844,8 +1844,8 @@ endobj
   /Type /StructElem
   /S /Strong
   /P 160 0 R
-  /K [359]
-  /Pg 302 0 R
+  /K [382]
+  /Pg 309 0 R
 >>
 endobj
 
@@ -1854,8 +1854,8 @@ endobj
   /Type /StructElem
   /S /Formula
   /P 160 0 R
-  /K [351 352 353 354 355 356 357]
-  /Pg 302 0 R
+  /K [374 375 376 377 378 379 380]
+  /Pg 309 0 R
 >>
 endobj
 
@@ -1864,8 +1864,8 @@ endobj
   /Type /StructElem
   /S /Formula
   /P 160 0 R
-  /K [342 343 344 345 346 347 348]
-  /Pg 302 0 R
+  /K [365 366 367 368 369 370 371]
+  /Pg 309 0 R
 >>
 endobj
 
@@ -1874,8 +1874,8 @@ endobj
   /Type /StructElem
   /S /Formula
   /P 160 0 R
-  /K [339 340]
-  /Pg 302 0 R
+  /K [362 363]
+  /Pg 309 0 R
 >>
 endobj
 
@@ -1888,8 +1888,8 @@ endobj
     /O /Layout
     /Placement /Block
   >>]
-  /K [296 297 298 299 300 301 302 303 304 305 306 307 308 309 310 311 312 313 314 315 316 317 318 319 320 321 322 323 324 325 326 327 328 329 330 331 332 333 334 335 336 337]
-  /Pg 302 0 R
+  /K [319 320 321 322 323 324 325 326 327 328 329 330 331 332 333 334 335 336 337 338 339 340 341 342 343 344 345 346 347 348 349 350 351 352 353 354 355 356 357 358 359 360]
+  /Pg 309 0 R
 >>
 endobj
 
@@ -1898,8 +1898,8 @@ endobj
   /Type /StructElem
   /S /P
   /P 22 0 R
-  /K [234 175 0 R 239 240 174 0 R 245 173 0 R 253 172 0 R 263 171 0 R 271 170 0 R 279 169 0 R 292 168 0 R 294 295]
-  /Pg 302 0 R
+  /K [257 175 0 R 262 263 174 0 R 268 173 0 R 276 172 0 R 286 171 0 R 294 170 0 R 302 169 0 R 315 168 0 R 317 318]
+  /Pg 309 0 R
 >>
 endobj
 
@@ -1908,8 +1908,8 @@ endobj
   /Type /StructElem
   /S /Strong
   /P 167 0 R
-  /K [293]
-  /Pg 302 0 R
+  /K [316]
+  /Pg 309 0 R
 >>
 endobj
 
@@ -1918,8 +1918,8 @@ endobj
   /Type /StructElem
   /S /Formula
   /P 167 0 R
-  /K [280 281 282 283 284 285 286 287 288 289 290 291]
-  /Pg 302 0 R
+  /K [303 304 305 306 307 308 309 310 311 312 313 314]
+  /Pg 309 0 R
 >>
 endobj
 
@@ -1928,8 +1928,8 @@ endobj
   /Type /StructElem
   /S /Formula
   /P 167 0 R
-  /K [272 273 274 275 276 277 278]
-  /Pg 302 0 R
+  /K [295 296 297 298 299 300 301]
+  /Pg 309 0 R
 >>
 endobj
 
@@ -1938,8 +1938,8 @@ endobj
   /Type /StructElem
   /S /Formula
   /P 167 0 R
-  /K [264 265 266 267 268 269 270]
-  /Pg 302 0 R
+  /K [287 288 289 290 291 292 293]
+  /Pg 309 0 R
 >>
 endobj
 
@@ -1948,8 +1948,8 @@ endobj
   /Type /StructElem
   /S /Formula
   /P 167 0 R
-  /K [254 255 256 257 258 259 260 261 262]
-  /Pg 302 0 R
+  /K [277 278 279 280 281 282 283 284 285]
+  /Pg 309 0 R
 >>
 endobj
 
@@ -1958,8 +1958,8 @@ endobj
   /Type /StructElem
   /S /Formula
   /P 167 0 R
-  /K [246 247 248 249 250 251 252]
-  /Pg 302 0 R
+  /K [269 270 271 272 273 274 275]
+  /Pg 309 0 R
 >>
 endobj
 
@@ -1968,8 +1968,8 @@ endobj
   /Type /StructElem
   /S /Formula
   /P 167 0 R
-  /K [241 242 243 244]
-  /Pg 302 0 R
+  /K [264 265 266 267]
+  /Pg 309 0 R
 >>
 endobj
 
@@ -1978,8 +1978,8 @@ endobj
   /Type /StructElem
   /S /Formula
   /P 167 0 R
-  /K [235 236 237 238]
-  /Pg 302 0 R
+  /K [258 259 260 261]
+  /Pg 309 0 R
 >>
 endobj
 
@@ -1992,8 +1992,8 @@ endobj
     /O /Layout
     /Placement /Block
   >>]
-  /K [185 186 187 188 189 190 191 192 193 194 195 196 197 198 199 200 201 202 203 204 205 206 207 208 209 210 211 212 213 214 215 216 217 218 219 220 221 222 223 224 225 226 227 228 229 230 231 232 233]
-  /Pg 302 0 R
+  /K [208 209 210 211 212 213 214 215 216 217 218 219 220 221 222 223 224 225 226 227 228 229 230 231 232 233 234 235 236 237 238 239 240 241 242 243 244 245 246 247 248 249 250 251 252 253 254 255 256]
+  /Pg 309 0 R
 >>
 endobj
 
@@ -2006,8 +2006,8 @@ endobj
     /O /Layout
     /Placement /Block
   >>]
-  /K [154 155 156 157 158 159 160 161 162 163 164 165 166 167 168 169 170 171 172 173 174 175 176 177 178 179 180 181 182 183 184]
-  /Pg 302 0 R
+  /K [177 178 179 180 181 182 183 184 185 186 187 188 189 190 191 192 193 194 195 196 197 198 199 200 201 202 203 204 205 206 207]
+  /Pg 309 0 R
 >>
 endobj
 
@@ -2016,8 +2016,8 @@ endobj
   /Type /StructElem
   /S /P
   /P 22 0 R
-  /K [153]
-  /Pg 302 0 R
+  /K [176]
+  /Pg 309 0 R
 >>
 endobj
 
@@ -2030,8 +2030,8 @@ endobj
     /O /Layout
     /Placement /Block
   >>]
-  /K [107 108 109 110 111 112 113 114 115 116 117 118 119 120 121 122 123 124 125 126 127 128 129 130 131 132 133 134 135 136 137 138 139 140 141 142 143 144 145 146 147 148 149 150 151 152]
-  /Pg 302 0 R
+  /K [130 131 132 133 134 135 136 137 138 139 140 141 142 143 144 145 146 147 148 149 150 151 152 153 154 155 156 157 158 159 160 161 162 163 164 165 166 167 168 169 170 171 172 173 174 175]
+  /Pg 309 0 R
 >>
 endobj
 
@@ -2040,8 +2040,8 @@ endobj
   /Type /StructElem
   /S /P
   /P 22 0 R
-  /K [52 189 0 R 54 55 188 0 R 57 187 0 R 75 76 186 0 R 78 185 0 R 87 88 184 0 R 94 183 0 R 96 182 0 R 99 100 181 0 R 106]
-  /Pg 302 0 R
+  /K [75 189 0 R 77 78 188 0 R 80 187 0 R 98 99 186 0 R 101 185 0 R 110 111 184 0 R 117 183 0 R 119 182 0 R 122 123 181 0 R 129]
+  /Pg 309 0 R
 >>
 endobj
 
@@ -2050,8 +2050,8 @@ endobj
   /Type /StructElem
   /S /Formula
   /P 180 0 R
-  /K [101 102 103 104 105]
-  /Pg 302 0 R
+  /K [124 125 126 127 128]
+  /Pg 309 0 R
 >>
 endobj
 
@@ -2060,8 +2060,8 @@ endobj
   /Type /StructElem
   /S /Formula
   /P 180 0 R
-  /K [97 98]
-  /Pg 302 0 R
+  /K [120 121]
+  /Pg 309 0 R
 >>
 endobj
 
@@ -2070,8 +2070,8 @@ endobj
   /Type /StructElem
   /S /Formula
   /P 180 0 R
-  /K [95]
-  /Pg 302 0 R
+  /K [118]
+  /Pg 309 0 R
 >>
 endobj
 
@@ -2080,8 +2080,8 @@ endobj
   /Type /StructElem
   /S /Formula
   /P 180 0 R
-  /K [89 90 91 92 93]
-  /Pg 302 0 R
+  /K [112 113 114 115 116]
+  /Pg 309 0 R
 >>
 endobj
 
@@ -2090,8 +2090,8 @@ endobj
   /Type /StructElem
   /S /Formula
   /P 180 0 R
-  /K [79 80 81 82 83 84 85 86]
-  /Pg 302 0 R
+  /K [102 103 104 105 106 107 108 109]
+  /Pg 309 0 R
 >>
 endobj
 
@@ -2100,8 +2100,8 @@ endobj
   /Type /StructElem
   /S /Strong
   /P 180 0 R
-  /K [77]
-  /Pg 302 0 R
+  /K [100]
+  /Pg 309 0 R
 >>
 endobj
 
@@ -2110,8 +2110,8 @@ endobj
   /Type /StructElem
   /S /Formula
   /P 180 0 R
-  /K [58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74]
-  /Pg 302 0 R
+  /K [81 82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97]
+  /Pg 309 0 R
 >>
 endobj
 
@@ -2120,12 +2120,12 @@ endobj
   /Type /StructElem
   /S /Link
   /P 180 0 R
-  /K [56 <<
+  /K [79 <<
     /Type /OBJR
-    /Pg 302 0 R
-    /Obj 300 0 R
+    /Pg 309 0 R
+    /Obj 307 0 R
   >>]
-  /Pg 302 0 R
+  /Pg 309 0 R
 >>
 endobj
 
@@ -2134,12 +2134,12 @@ endobj
   /Type /StructElem
   /S /Link
   /P 180 0 R
-  /K [53 <<
+  /K [76 <<
     /Type /OBJR
-    /Pg 302 0 R
-    /Obj 299 0 R
+    /Pg 309 0 R
+    /Obj 306 0 R
   >>]
-  /Pg 302 0 R
+  /Pg 309 0 R
 >>
 endobj
 
@@ -2149,8 +2149,8 @@ endobj
   /S /H2
   /P 22 0 R
   /T (Single-track model with linear tires ("dynamic bicycle"))
-  /K [50 51]
-  /Pg 302 0 R
+  /K [73 74]
+  /Pg 309 0 R
 >>
 endobj
 
@@ -2159,8 +2159,8 @@ endobj
   /Type /StructElem
   /S /P
   /P 22 0 R
-  /K [29 196 0 R 31 195 0 R 38 39 194 0 R 41 42 193 0 R 47 192 0 R 49]
-  /Pg 302 0 R
+  /K [52 196 0 R 54 195 0 R 61 62 194 0 R 64 65 193 0 R 70 192 0 R 72]
+  /Pg 309 0 R
 >>
 endobj
 
@@ -2169,8 +2169,8 @@ endobj
   /Type /StructElem
   /S /Code
   /P 191 0 R
-  /K [48]
-  /Pg 302 0 R
+  /K [71]
+  /Pg 309 0 R
 >>
 endobj
 
@@ -2179,8 +2179,8 @@ endobj
   /Type /StructElem
   /S /Formula
   /P 191 0 R
-  /K [43 44 45 46]
-  /Pg 302 0 R
+  /K [66 67 68 69]
+  /Pg 309 0 R
 >>
 endobj
 
@@ -2189,8 +2189,8 @@ endobj
   /Type /StructElem
   /S /Strong
   /P 191 0 R
-  /K [40]
-  /Pg 302 0 R
+  /K [63]
+  /Pg 309 0 R
 >>
 endobj
 
@@ -2199,8 +2199,8 @@ endobj
   /Type /StructElem
   /S /Formula
   /P 191 0 R
-  /K [32 33 34 35 36 37]
-  /Pg 302 0 R
+  /K [55 56 57 58 59 60]
+  /Pg 309 0 R
 >>
 endobj
 
@@ -2209,8 +2209,8 @@ endobj
   /Type /StructElem
   /S /Code
   /P 191 0 R
-  /K [30]
-  /Pg 302 0 R
+  /K [53]
+  /Pg 309 0 R
 >>
 endobj
 
@@ -2223,8 +2223,8 @@ endobj
     /O /Layout
     /Placement /Block
   >>]
-  /K [0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28]
-  /Pg 302 0 R
+  /K [23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51]
+  /Pg 309 0 R
 >>
 endobj
 
@@ -2233,8 +2233,8 @@ endobj
   /Type /StructElem
   /S /P
   /P 22 0 R
-  /K [139 200 0 R 151 199 0 R 159]
-  /Pg 297 0 R
+  /K [2 200 0 R 14 199 0 R 22]
+  /Pg 309 0 R
 >>
 endobj
 
@@ -2243,8 +2243,8 @@ endobj
   /Type /StructElem
   /S /Formula
   /P 198 0 R
-  /K [152 153 154 155 156 157 158]
-  /Pg 297 0 R
+  /K [15 16 17 18 19 20 21]
+  /Pg 309 0 R
 >>
 endobj
 
@@ -2253,8 +2253,8 @@ endobj
   /Type /StructElem
   /S /Formula
   /P 198 0 R
-  /K [140 141 142 143 144 145 146 147 148 149 150]
-  /Pg 297 0 R
+  /K [3 4 5 6 7 8 9 10 11 12 13]
+  /Pg 309 0 R
 >>
 endobj
 
@@ -2264,8 +2264,8 @@ endobj
   /S /H2
   /P 22 0 R
   /T (Bicycle with acceleration input)
-  /K [137 138]
-  /Pg 297 0 R
+  /K [0 1]
+  /Pg 309 0 R
 >>
 endobj
 
@@ -2274,8 +2274,8 @@ endobj
   /Type /StructElem
   /S /P
   /P 22 0 R
-  /K [124 205 0 R 126 204 0 R 133 134 203 0 R 136]
-  /Pg 297 0 R
+  /K [152 205 0 R 154 204 0 R 161 162 203 0 R 164]
+  /Pg 304 0 R
 >>
 endobj
 
@@ -2284,8 +2284,8 @@ endobj
   /Type /StructElem
   /S /Code
   /P 202 0 R
-  /K [135]
-  /Pg 297 0 R
+  /K [163]
+  /Pg 304 0 R
 >>
 endobj
 
@@ -2294,8 +2294,8 @@ endobj
   /Type /StructElem
   /S /Formula
   /P 202 0 R
-  /K [127 128 129 130 131 132]
-  /Pg 297 0 R
+  /K [155 156 157 158 159 160]
+  /Pg 304 0 R
 >>
 endobj
 
@@ -2304,12 +2304,12 @@ endobj
   /Type /StructElem
   /S /Link
   /P 202 0 R
-  /K [125 <<
+  /K [153 <<
     /Type /OBJR
-    /Pg 297 0 R
-    /Obj 296 0 R
+    /Pg 304 0 R
+    /Obj 303 0 R
   >>]
-  /Pg 297 0 R
+  /Pg 304 0 R
 >>
 endobj
 
@@ -2322,8 +2322,8 @@ endobj
     /O /Layout
     /Placement /Block
   >>]
-  /K [100 101 102 103 104 105 106 107 108 109 110 111 112 113 114 115 116 117 118 119 120 121 122 123]
-  /Pg 297 0 R
+  /K [128 129 130 131 132 133 134 135 136 137 138 139 140 141 142 143 144 145 146 147 148 149 150 151]
+  /Pg 304 0 R
 >>
 endobj
 
@@ -2332,8 +2332,8 @@ endobj
   /Type /StructElem
   /S /P
   /P 22 0 R
-  /K [79 210 0 R 89 209 0 R 97 208 0 R 99]
-  /Pg 297 0 R
+  /K [107 210 0 R 117 209 0 R 125 208 0 R 127]
+  /Pg 304 0 R
 >>
 endobj
 
@@ -2342,8 +2342,8 @@ endobj
   /Type /StructElem
   /S /Formula
   /P 207 0 R
-  /K [98]
-  /Pg 297 0 R
+  /K [126]
+  /Pg 304 0 R
 >>
 endobj
 
@@ -2352,8 +2352,8 @@ endobj
   /Type /StructElem
   /S /Formula
   /P 207 0 R
-  /K [90 91 92 93 94 95 96]
-  /Pg 297 0 R
+  /K [118 119 120 121 122 123 124]
+  /Pg 304 0 R
 >>
 endobj
 
@@ -2362,8 +2362,8 @@ endobj
   /Type /StructElem
   /S /Formula
   /P 207 0 R
-  /K [80 81 82 83 84 85 86 87 88]
-  /Pg 297 0 R
+  /K [108 109 110 111 112 113 114 115 116]
+  /Pg 304 0 R
 >>
 endobj
 
@@ -2373,8 +2373,8 @@ endobj
   /S /H2
   /P 22 0 R
   /T (Kinematic bicycle (Ackermann))
-  /K [77 78]
-  /Pg 297 0 R
+  /K [105 106]
+  /Pg 304 0 R
 >>
 endobj
 
@@ -2383,8 +2383,8 @@ endobj
   /Type /StructElem
   /S /P
   /P 22 0 R
-  /K [73 74 213 0 R 76]
-  /Pg 297 0 R
+  /K [101 102 213 0 R 104]
+  /Pg 304 0 R
 >>
 endobj
 
@@ -2393,8 +2393,8 @@ endobj
   /Type /StructElem
   /S /Code
   /P 212 0 R
-  /K [75]
-  /Pg 297 0 R
+  /K [103]
+  /Pg 304 0 R
 >>
 endobj
 
@@ -2407,8 +2407,8 @@ endobj
     /O /Layout
     /Placement /Block
   >>]
-  /K [54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72]
-  /Pg 297 0 R
+  /K [82 83 84 85 86 87 88 89 90 91 92 93 94 95 96 97 98 99 100]
+  /Pg 304 0 R
 >>
 endobj
 
@@ -2417,8 +2417,8 @@ endobj
   /Type /StructElem
   /S /P
   /P 22 0 R
-  /K [35 217 0 R 45 216 0 R 53]
-  /Pg 297 0 R
+  /K [63 217 0 R 73 216 0 R 81]
+  /Pg 304 0 R
 >>
 endobj
 
@@ -2427,8 +2427,8 @@ endobj
   /Type /StructElem
   /S /Formula
   /P 215 0 R
-  /K [46 47 48 49 50 51 52]
-  /Pg 297 0 R
+  /K [74 75 76 77 78 79 80]
+  /Pg 304 0 R
 >>
 endobj
 
@@ -2437,8 +2437,8 @@ endobj
   /Type /StructElem
   /S /Formula
   /P 215 0 R
-  /K [36 37 38 39 40 41 42 43 44]
-  /Pg 297 0 R
+  /K [64 65 66 67 68 69 70 71 72]
+  /Pg 304 0 R
 >>
 endobj
 
@@ -2448,8 +2448,8 @@ endobj
   /S /H2
   /P 22 0 R
   /T (Differential drive (kinematic unicycle))
-  /K [33 34]
-  /Pg 297 0 R
+  /K [61 62]
+  /Pg 304 0 R
 >>
 endobj
 
@@ -2459,8 +2459,8 @@ endobj
   /S /H1
   /P 22 0 R
   /T (Wheeled platforms)
-  /K [31 32]
-  /Pg 297 0 R
+  /K [59 60]
+  /Pg 304 0 R
 >>
 endobj
 
@@ -2469,8 +2469,8 @@ endobj
   /Type /StructElem
   /S /P
   /P 22 0 R
-  /K [15 225 0 R 17 224 0 R 20 21 223 0 R 23 222 0 R 25 26 221 0 R 28 29 30]
-  /Pg 297 0 R
+  /K [15 232 0 R 17 231 0 R 20 21 230 0 R 23 229 0 R 25 26 228 0 R 28 29 30 227 0 R 32 226 0 R 34 35 225 0 R 37 224 0 R 39 40 223 0 R 49 222 0 R 56 221 0 R 58]
+  /Pg 304 0 R
 >>
 endobj
 
@@ -2479,28 +2479,28 @@ endobj
   /Type /StructElem
   /S /Code
   /P 220 0 R
-  /K [27]
-  /Pg 297 0 R
+  /K [57]
+  /Pg 304 0 R
 >>
 endobj
 
 222 0 obj
 <<
   /Type /StructElem
-  /S /Code
+  /S /Formula
   /P 220 0 R
-  /K [24]
-  /Pg 297 0 R
+  /K [50 51 52 53 54 55]
+  /Pg 304 0 R
 >>
 endobj
 
 223 0 obj
 <<
   /Type /StructElem
-  /S /Code
+  /S /Formula
   /P 220 0 R
-  /K [22]
-  /Pg 297 0 R
+  /K [41 42 43 44 45 46 47 48]
+  /Pg 304 0 R
 >>
 endobj
 
@@ -2509,8 +2509,8 @@ endobj
   /Type /StructElem
   /S /Code
   /P 220 0 R
-  /K [18 19]
-  /Pg 297 0 R
+  /K [38]
+  /Pg 304 0 R
 >>
 endobj
 
@@ -2519,29 +2519,28 @@ endobj
   /Type /StructElem
   /S /Code
   /P 220 0 R
-  /K [16]
-  /Pg 297 0 R
+  /K [36]
+  /Pg 304 0 R
 >>
 endobj
 
 226 0 obj
 <<
   /Type /StructElem
-  /S /H1
-  /P 22 0 R
-  /T (Conventions)
-  /K [13 14]
-  /Pg 297 0 R
+  /S /Code
+  /P 220 0 R
+  /K [33]
+  /Pg 304 0 R
 >>
 endobj
 
 227 0 obj
 <<
   /Type /StructElem
-  /S /P
-  /P 22 0 R
-  /K [4 228 0 R 6 7 8 9 10 11 12]
-  /Pg 297 0 R
+  /S /Code
+  /P 220 0 R
+  /K [31]
+  /Pg 304 0 R
 >>
 endobj
 
@@ -2549,84 +2548,155 @@ endobj
 <<
   /Type /StructElem
   /S /Code
-  /P 227 0 R
-  /K [5]
-  /Pg 297 0 R
+  /P 220 0 R
+  /K [27]
+  /Pg 304 0 R
 >>
 endobj
 
 229 0 obj
 <<
   /Type /StructElem
-  /S /H1
-  /P 22 0 R
-  /T (Abstract)
-  /K [3]
-  /Pg 297 0 R
+  /S /Code
+  /P 220 0 R
+  /K [24]
+  /Pg 304 0 R
 >>
 endobj
 
 230 0 obj
 <<
   /Type /StructElem
-  /S /Div
-  /P 22 0 R
-  /K [231 0 R]
+  /S /Code
+  /P 220 0 R
+  /K [22]
+  /Pg 304 0 R
 >>
 endobj
 
 231 0 obj
 <<
   /Type /StructElem
-  /S /Div
-  /P 230 0 R
-  /K [233 0 R 232 0 R]
+  /S /Code
+  /P 220 0 R
+  /K [18 19]
+  /Pg 304 0 R
 >>
 endobj
 
 232 0 obj
 <<
   /Type /StructElem
-  /S /P
-  /P 231 0 R
-  /K [2]
-  /Pg 297 0 R
+  /S /Code
+  /P 220 0 R
+  /K [16]
+  /Pg 304 0 R
 >>
 endobj
 
 233 0 obj
 <<
   /Type /StructElem
-  /S /Div
-  /P 231 0 R
-  /K [234 0 R]
+  /S /H1
+  /P 22 0 R
+  /T (Conventions)
+  /K [13 14]
+  /Pg 304 0 R
 >>
 endobj
 
 234 0 obj
 <<
   /Type /StructElem
-  /S /Div
-  /P 233 0 R
-  /K [235 0 R]
+  /S /P
+  /P 22 0 R
+  /K [4 235 0 R 6 7 8 9 10 11 12]
+  /Pg 304 0 R
 >>
 endobj
 
 235 0 obj
 <<
   /Type /StructElem
-  /S /Strong
+  /S /Code
   /P 234 0 R
+  /K [5]
+  /Pg 304 0 R
+>>
+endobj
+
+236 0 obj
+<<
+  /Type /StructElem
+  /S /H1
+  /P 22 0 R
+  /T (Abstract)
+  /K [3]
+  /Pg 304 0 R
+>>
+endobj
+
+237 0 obj
+<<
+  /Type /StructElem
+  /S /Div
+  /P 22 0 R
+  /K [238 0 R]
+>>
+endobj
+
+238 0 obj
+<<
+  /Type /StructElem
+  /S /Div
+  /P 237 0 R
+  /K [240 0 R 239 0 R]
+>>
+endobj
+
+239 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 238 0 R
+  /K [2]
+  /Pg 304 0 R
+>>
+endobj
+
+240 0 obj
+<<
+  /Type /StructElem
+  /S /Div
+  /P 238 0 R
+  /K [241 0 R]
+>>
+endobj
+
+241 0 obj
+<<
+  /Type /StructElem
+  /S /Div
+  /P 240 0 R
+  /K [242 0 R]
+>>
+endobj
+
+242 0 obj
+<<
+  /Type /StructElem
+  /S /Strong
+  /P 241 0 R
   /A [<<
     /O /Layout
     /Placement /Block
   >>]
   /K [1]
-  /Pg 297 0 R
+  /Pg 304 0 R
 >>
 endobj
 
-236 0 obj
+243 0 obj
 <<
   /Type /StructElem
   /S /Span
@@ -2636,11 +2706,11 @@ endobj
     /Placement /Block
   >>]
   /K [0]
-  /Pg 297 0 R
+  /Pg 304 0 R
 >>
 endobj
 
-237 0 obj
+244 0 obj
 <<
   /Type /PageLabel
   /S /D
@@ -2648,7 +2718,7 @@ endobj
 >>
 endobj
 
-238 0 obj
+245 0 obj
 <<
   /Type /PageLabel
   /S /D
@@ -2656,7 +2726,7 @@ endobj
 >>
 endobj
 
-239 0 obj
+246 0 obj
 <<
   /Type /PageLabel
   /S /D
@@ -2664,7 +2734,7 @@ endobj
 >>
 endobj
 
-240 0 obj
+247 0 obj
 <<
   /Type /PageLabel
   /S /D
@@ -2672,34 +2742,34 @@ endobj
 >>
 endobj
 
-241 0 obj
+248 0 obj
 <<
   /Type /Font
   /Subtype /Type0
-  /BaseFont /ZRHHZU+NewCM10-Regular-Identity-H
+  /BaseFont /XSOLNC+NewCM10-Regular-Identity-H
   /Encoding /Identity-H
-  /DescendantFonts [242 0 R]
-  /ToUnicode 245 0 R
+  /DescendantFonts [249 0 R]
+  /ToUnicode 252 0 R
 >>
 endobj
 
-242 0 obj
+249 0 obj
 <<
   /Type /Font
   /Subtype /CIDFontType0
-  /BaseFont /ZRHHZU+NewCM10-Regular
+  /BaseFont /XSOLNC+NewCM10-Regular
   /CIDSystemInfo <<
     /Registry (Adobe)
     /Ordering (Identity)
     /Supplement 0
   >>
-  /FontDescriptor 244 0 R
+  /FontDescriptor 251 0 R
   /DW 0
-  /W [0 0 500 1 1 722 2 3 444 4 5 556 6 6 278 7 7 500 8 8 278 9 9 333 10 10 750 11 11 500 12 12 389 13 13 278 14 14 708 15 15 833 16 16 392 17 17 528 18 18 681 19 19 306 20 20 917 21 21 556 22 22 394 23 23 556 24 24 528 25 25 500 26 26 278 27 27 778 28 28 556 29 29 389 30 30 528 31 31 278 32 32 500 33 34 528 35 35 333 36 36 389 37 37 722 38 38 556 39 39 1000 40 40 681 41 41 556 42 42 736 43 43 778 44 44 500 45 45 722 46 46 750 47 47 764 48 48 750 49 49 361 50 50 556 51 51 278 52 52 500 53 53 653 54 54 278 55 55 500 56 56 278 57 57 306 58 58 1028 59 59 583 60 60 444 61 61 833 62 62 778 63 63 500 64 64 278 65 65 500 66 66 625 67 67 778 68 68 686 69 69 500 70 70 778 71 71 785 72 72 514 73 73 472 74 74 750 75 75 472 76 80 500 81 81 833 82 82 778]
+  /W [0 0 500 1 1 722 2 3 444 4 5 556 6 6 278 7 7 500 8 8 278 9 9 333 10 10 750 11 11 500 12 12 389 13 13 278 14 14 708 15 15 833 16 16 392 17 17 528 18 18 681 19 19 306 20 20 917 21 21 556 22 22 394 23 23 556 24 24 528 25 25 500 26 26 278 27 27 778 28 28 556 29 29 389 30 30 528 31 31 278 32 32 500 33 34 528 35 35 333 36 36 389 37 37 722 38 38 556 39 39 1000 40 40 681 41 41 556 42 42 736 43 43 778 44 44 500 45 45 722 46 46 750 47 47 764 48 48 750 49 49 361 50 50 556 51 51 278 52 52 583 53 53 514 54 54 444 55 55 500 56 56 653 57 57 278 58 58 500 59 59 278 60 60 306 61 61 1028 62 62 833 63 63 778 64 64 500 65 65 278 66 66 500 67 67 625 68 68 778 69 69 686 70 70 500 71 71 778 72 72 785 73 73 472 74 74 750 75 75 472 76 80 500 81 81 833 82 82 778]
 >>
 endobj
 
-243 0 obj
+250 0 obj
 <<
   /Length 13
   /Filter /FlateDecode
@@ -2710,10 +2780,10 @@ xœûÿ  Aª
 endstream
 endobj
 
-244 0 obj
+251 0 obj
 <<
   /Type /FontDescriptor
-  /FontName /ZRHHZU+NewCM10-Regular
+  /FontName /XSOLNC+NewCM10-Regular
   /Flags 131076
   /FontBBox [-40 -250 1009 750]
   /ItalicAngle 0
@@ -2721,12 +2791,12 @@ endobj
   /Descent -194
   /CapHeight 683
   /StemV 95.4
-  /CIDSet 243 0 R
-  /FontFile3 246 0 R
+  /CIDSet 250 0 R
+  /FontFile3 253 0 R
 >>
 endobj
 
-245 0 obj
+252 0 obj
 <<
   /Length 1774
   /Type /CMap
@@ -2807,27 +2877,27 @@ endcodespacerange
 <0031> <0049>
 <0032> <0053>
 <0033> <003B>
-<0034> <0032>
-<0035> <0046>
-<0036> <005B>
-<0037> <0031>
-<0038> <005D>
-<0039> <006A>
-<003A> <0057>
-<003B> <00660066>
-<003C> <007A>
-<003D> <0025>
-<003E> <0026>
-<003F> <0033>
-<0040> <2019>
-<0041> <0030>
-<0042> <004C>
-<0043> <0051>
-<0044> <00660074>
-<0045> <0035>
-<0046> <002B>
-<0047> <0047>
-<0048> <004A>
+<0034> <00660066>
+<0035> <004A>
+<0036> <007A>
+<0037> <0032>
+<0038> <0046>
+<0039> <005B>
+<003A> <0031>
+<003B> <005D>
+<003C> <006A>
+<003D> <0057>
+<003E> <0025>
+<003F> <0026>
+<0040> <0033>
+<0041> <2019>
+<0042> <0030>
+<0043> <004C>
+<0044> <0051>
+<0045> <00660074>
+<0046> <0035>
+<0047> <002B>
+<0048> <0047>
 <0049> <201C>
 <004A> <0056>
 <004B> <201D>
@@ -2848,64 +2918,60 @@ end
 endstream
 endobj
 
-246 0 obj
+253 0 obj
 <<
   /Length 8297
   /Filter /FlateDecode
   /Subtype /CIDFontType0C
 >>
 stream
-xœZT×úg]fçÚVeE£ÑØk,‰±Æ*ö‚ " ½,E–²°ì·»ô.eaÁ.jìcŒ‰±Dc^b411ßàå=ÿgA“¼÷òòÞùŸÃÙ=ÌÌïÞï~å÷ûÝ•ÙØÚÚÈd²ž‹ÝÃf-3zÄ2wµkõÚéu©/t¤~2¡‹
- ã³Û—¦ýÝ£/óE_ÛJ¦ŸÌ¾‡õ3¸W?›çÏ»°þ³®Û@ë—S·A6r™L¡glößä>³»_ˆWHÄYo9Œ=fòˆ±£ÇŽw˜áâïçì°<ØßÇß×+Ä+x¤ÃrO¯`‡0ÿ o¯`‡ ww×`÷Íj¿ÍîA!žîsW8-w˜ãïâ°ÐËÍÝ/ØÝaÄ‡`wwÏ€)£F…¨=FúyŒÚâï<Ê§ã¡àQÖq#æ8.^>báüYï/vzdHxˆÃÿ ‡Íî!®^>Á#ml:ÙÈl–J:ûÖ~¼Ú,ÍÚ~Ùif…ÐÅv¹·ÎiÝº@·®b³Áh0éFc·n—ºZLiÆ4“É”Ú­»ÜFfcccãdu¡½À`uY?›)Vô±³q²`“mó\¶Qv­ÓÒN»å³äÛå1òç¶.¶õ¶ß2ÞŠ>
-=;‚5“.¤¬óèÎw»ÌîÚ½[×nou·ï^ÜýïÊ eòq]ìÙ­§W¯×{•öª·j÷1g²Ç>‹Wò:þ×Þ~½›^‰~åê«Ž¯žõAŸQ}õix-âõ)¯gôõí·¸ßwÂ(a—J¡:ëàÝÿþÉúÈz£Ï){¬xhPÿAÕoN<hp(•æ•=ŠÇÊö–J»Û*Ž¶EòÒ|<Þ6ŸU^QZŠ+EY­3îa†Enß·u†´šGuB8U[€ÉÃ	ùÕ8
-¡²’K’@!¤­Œõ‚¨‚›¢Áô„ƒðtDtc@Þn•TÆB1ä¦dwBà0ÈßšG'%uÕXÐ·gše-×,—ÆaW>+Þ˜(ÄA²69Þsàˆ…5à¶+¤Î÷04C-Á*…Ù%V<¤½(5ö¢¯ý2YT@y‘j>öái¬"ßºeÙäI}}³ªÃPõƒ:‹lw®zðÂN,è¬v’’µ~#?ˆÙdå¸}8'Þl<®Ê„úM:­/D“ÀÂ°Šòâ»>™Vÿí5ŠÚÐžÔþÑ$øZvË”#A”ú˜q‹èÓh‡.¡û%îŠTÕ[dWAèwtbáˆ>µQ;¶/…‰°Ñ1ÒƒèñG÷Ô€óiFÂZUÛÖYóðAÆ„¶:™y8 Â…ìÏ—O^¼½b™@£þðÓn™5æ—f+ÿÂìLXïâ¿ˆÀ/w‰öÿÍ*-ùV¹Êÿd·m7ìÓˆ²§v·ÒÌYz‹ìü¤ÔzHr†;E¬&>ÊÔ®UQóoƒ;™˜¨IÞ­'Ü«Ë¥ù!å¾^aþA¥»„ÝÅ•RcÞ&bÁýÃf»ª/ÑíÒ-…ÝãO9±Kƒ´š­IR\ÏB#Ô{Ôm®_S°Èä9ëçûo+¯(,.WANbõÃÎš#ÙU@ŽœÚ<Vµ…]­{_·ÐwºWÐ*ØH8Í”‡A„f8¸·èáf¦¸ít=¤ä\ÞW*úNÏ†Ïòr^»©æ¨ 6¶àä4Ò¾âVYûË›¹:Ìè-²í~éV‡þé6ÊMŒ’^RþØ>T†}+¤ÉòV—VDÚYG;›À‡yëTÐ6>•
-˜¸½!}Ï§R‘Åú|}©Î ‡pÒVÄÀúÖ·v6agë6„C;UÒ65Ñ OÑixÛC&3Æ O’éE*é»=”‹4º=ÇvµÈ%oÜÊ£ýà§´;í5”Êh/Êÿ<;c÷@N˜”Áƒ¬PoT;oô[.°±$à`Ð~8µP'Êöï<x¨d/ý°O]îRîKÁ(i®Æ‚ï„a¼ˆÃì~¾dÁ×,Ü3¼=ùSAËÙ¾î[æÁ7;ñ‘¾a­ñA
-ýd_‡·’ˆšåÄÛ´RA{|S+\®¸|Qeu÷Sô*»óTŽË%%_\æçìçW\YYVV)Ðk¶ÿvMyDl6c½h‡ª<ýpæcî@«
-ðpwòU*ÏyXté"|NîŽºI{m|Ê_5ª¶2Ö#Yóžì#õU`Ÿû÷þ¦¢=ñ¿`íD*è Ô+ªé‡ì©xXóöJUmág¯š<P ½ë“Ó«UXŽKØG#ç©”¸ðŸSÝ/Ù÷åŽ´žøËr°Í=êîŒlç?æèWÿcŽùóýßêÍz9Û§ÍOïp’Ô‹¯ò©tf‚Ç¼(ØÉÝª?›ŠÂÄì…C°WGÄPvFrv­
-G²ÜG÷¾ÒÁF½NÄ¿d»Y(´äT©”´{»A´fÒÓæ«ÍõÍ\‹dM¦- ÷ã„r8—ÑÓÀ)—Ïfe\hj4–ˆÈúé¢Á<`‘1Ê@|Ø"}–¢!,*&>ÐþT	RÃÕüy"ÊLØé7À“‹2_öot‚¾-)Üú€‰©„J}e2QVˆ{Êñ‚hWóî˜ž Óî×V[IËÿ0äkÚO Oÿ=n5¦Ïaì«P£#b0û^»;âp*‹ÝÐæ«Çª½×µ¡ãn+°´# î)pô_«RÒï;Ü2þV†Y†¶ÍîÊ±µµ_·¥zåûo¯ì/Pö]ŸëôË¿òýUTˆ´3öëÃ‡÷&È‡ü„˜¤ˆh"!a;+ó‹Ë%–¼¨E˜_±_ÉŸÉ{¿œ¯TÆÖ³¿ÊD:U Oˆ Ô¿í,õ•N1qf„ ¡S[½î?T¤Z‹Ú¿wbR£Sã² L)Ùõ­Ý m—™—.«3}õPCŽ(GjÌñ¤ˆ¾è£»[°¨™s—Êz‹ìûñéGT ýÌpØ^êÃúÕº”¯ B»x‹ò”ûa*TáÀnK™ÏrÓ‘·…HÖl#\½ï:gµ8ƒGyðžÀÝ)h€:ãÙÊ%âžêPÛEg’½’!‚(i†Æl,’úÙUÆM‡Cs“°íy8î»+&gkÕæ×§ìy¹pjÊî v‚Ô1FC\6 \H-RýÈî€tÉ£KŠKÒ¹Wl‚í@•à>œÀ³À§º*°BûYá®˜“nFÂ,Xíé6&‚Ç©ðÛº\}J,hHˆPÑWÙm-¤‚ÁPTd4‚±°h¿ë}	d~ü™ªÃ}‡EÜ÷òA;èp"Ãí£ƒwÞvüº¹3'&:&pÝ o3\CÇík «¢CÙ©0‡'aEåy2†mÏ\ñ¬¢]ŽdàtRno‘å–¬€cH%¡¯áf×ž=GÊÊÅÚ†üCÖŒLöÕ‚/¬4F[3–s(IÎˆ†HˆŒNÔ’ES§þÈÄeÒ ??³Ø@¸\©Ž	…õ† #ña?ƒþ#yDyf½#$¯_¶né’äP >l¹Q4”ùÎuÜtµ)!òÁ\Y}î3òÅ`&C“	Zˆ‹Û 'œ®#¿wB½~W2QÒM¥¸ìôÒ‚R„Ò˜R;w®ÂU{¹†c5R„4„ßSµYƒZ×M„£×jW“FÂœ9ðl4»[B£·GlOðÉuÃ·y»€™õh9*±ËÏM×¨‰jZ]±²b),† pƒwJ¨U¥;ŠëýtE@¾½téKÔEÖ•Öî®M-Â½¢H“^“”¨²-7¦@È*J/UÑÙÔ†‡ ½÷ö ø˜7ðJa§¡*ßB¸‹šŒœÒŠ½p`0„ìÔÖ•_1{Í[oÎi:.ÀÁ=uûMäŒâÚÂ„ŽÆÚÑUÿ{SU"¯1cg3Þ
-k±~Û´ Í%„KË/‰—2,\³K«;~Ãc4†}èº€¥ãè:ºú®ŽÁÅô‹ùåiØ­
-HVD
-qŠHH†DÝÛn#ƒG ¡ÐÞ8ç¢¾ƒpöÃi´ÕŽJ3_ÅÝö„¦|jÙR½!DØ¦ˆ½A›¾áÂª¼Í@Ií¨Ýw#Ÿ¨NÀáÊ]Y«Ž…ïòuÞ“_UÔyÏ9Ù@$E…n\¸Zd–ã”£üÌ+ª*8YëD8Mn8è¬9>’®q¸Yê#FYìž^Â‚®§Tˆ><rCQ[a*¸nShf^‚ôËéÚª6Ïßj°­	™ß›
-¾™LjdãŠ/€`×Ÿ@^5©7íþþÄ‚¸4D•€Š	³œ}eÓ‘Ê& WÎ£ŒJIsiDè³ía²G§åx‹&ð`ã¶´ÚyãRÀ€3÷àLì½rsÀ&HO2i!ÆÌ]B9²švŠ¡r˜S³i÷)s–ö¸óA¤AŠ	Ò‰’vÏ
-•F‰²")J.¥Jy‘IöÓ‡ o…Ÿuúì‡¸ä¤$D3¨-V1Ú\H åõP(€He:& Ü¾Öœ¼ )Ú\‚)2iQÆÄ\È…”Ì”,‚¯à5&³tÇ¾fƒ.Óé¡¸â©ç›å¸ÑÀ_npóŒÜP+äC^Zv–ñ]ÿÅ×kµz=$‘„Ô¤Ôœë×‘”/œqRzE.9¶úñÙq™!
-’bu±„þí3™ÄhH Mf\6äAJ–)‹àßžÍdRs!Àºbêj.¼fi£hWt‹;ð'ËõÛ bõÉ‰1äMª§r43IYÉ)BÊë è_—}Š Ï“àÐ6YÐF½ÜÎ Ü—‰á…bJ†
-HyxAH˜:Ú×¹Ñã¨pN•"8[šÆ”_h2tL¬#è†¶SÑ‚Kr©Œ®ä_0	é”šuÍDWlºðJ¥½i¯‡o"Q}
-ûÌ•„ÎýCð1>xƒïupt”wÀz 3ßC»~ÚòùÆñ+UJz	OË²±PŽ•èÈŸ¦…KÙßƒ#OË±M<\Ó`÷åÈ8b	Å‚’’@:H.ŠøaÈ):¨;Ði[èlÚ“Ú‘èHhS’Ò îr¹&ì”ƒr¸E”W²B%™˜/Ê
-[gÈ[Ú½®NöÓ«Œ´z½VoŽ ?ÐBrb4M3‡`“”£7B*ÙYÅˆoè_ðëðy$gE§j³}ÓÃÉš8‹™Dk¤¼|šÊtíï=
-9ºo‚vôW&5ÊoJcZjùk¢uLŠ¦ãš©=P;ãWLáQ1·ÆÐŽ;Î5â3n±âÑù-hlá½¨o=¢
-a*¸¬Œ €ŸþZ~kakÏ3ù!k>ÿ=Ý<lIvôsõqßº·Å<Ê‚ë¢JÀ…7±P†ì‚ú“f”Á¨,s/ßdZ›ˆÆôR¦Û>‹,ýG¤¢„žïˆ8ÑÊïáZ³˜,òVÌæƒAtdÈL:íó‚ßgf{¿­²`ab‚Æg¨0^Ð^#`çòª"ðGuÛY Ÿ2`:`\ÉoäçsÅA¹{µVJ€ƒš¡™kÃ½Ò,žvAFñèÎÞóÂ.¨-Ù”¬õ‡H²µ<º¨´´`×™å3FÒ®«©L ŠÆªrÊ'#_âX–{v0=z“Š–þù3’œ}þübµÍóçØõøóçççÙ<ÞöËôçÏÏw³¢¼«6ƒˆÇÍx¬¢Ã{%WÔð5ŸÙÑ‚ NŸ ík!¾)ê[}ƒ‰¸¸¶zyÑÃ²kçàùž*nÑÁýøHžó{	LkM—Ûée¨ý–OC–-€F¨ñÚã>0> ·wÂ55x|¨ÝäÚŽ›*ª–Æñs‚§Ð!•cŽJ!ÇlÊ2VB1ûh›D©”È¿ÔîÉ[Cz‹ì
-MñÝOh$~‹óp“‘q¼é«v ¥ó† ð€eàe">ì^}ZÄAdl¬•ò4Óc€—™ˆ]á©›îàÓÁÓD|ÊØÿ‰¡ ÎB‚p>-aÒâ2£!†øn†0Á‡­1}
-{€(AÄ×DI&Ãã—­âÁd^,­c‹!-RˆÄÇz¶Í|°`¼ÜÏB­Jà1h„F8Þ®¾ (wÙÙ"Ou€:©3£¼¢[Gˆ²“O¤€]òÖÅgAzûöiõ±ñô‡ÉTd1]½›ð®Ú}N…2¸7º˜¾iŒ]0•¨0¶i'A’u2kf0[jW„:Ò	tu¡nø6ƒ‹qâ¨B¢Rþ¨¥óâ¡ŽÄš|ï‰ø›$ÓEG»þ&ÉÐÇ,0ôáëi.¤^ì_»º;Kû#¡2ì+ ÷¿Ý
-S1dÂ^‚WØj8ðDPb‡ˆ$CáÎ‘ÇýXÞº
-ïñ¸Œ¾Žcè´?W$:)ð]p.QîTîè±6,`ÙÒ7¼Ù‘ûÒ¶=Ï+ÎÃ%uÓì}K2'ÀTb•p(m“µºö#XGˆJ×TêÓÊ0‰¹Éé‘	:mb¡nmß1«Ý¶¯ÐðùÉ„¬5×YÊU`2dŒä ¾‚ ÇéÆdÔBñu‚ Á‡­íˆj™<UÚâ5FI~o¼Ó[dßÕ½`—¦ìëB¹Õï‚;l†wÛXÎ^7½X³Nó®hÕë°êáº5V•#Õ"¾/â4ñœˆS*d'/~|^”KI¸˜‡ÇóoN,&Ô^dåo>§áÓç®¾f:)ÍÙ möF†:%ôú„â¹Œñ­ÜÔ0¬Ðiô‡IÇg^ÈNjŠùtÛÎ„]	[J³¶ÂV2{Í¬‰‚LK]ydé	ÝE}­>+t/™Ùúf–cz6€)¥ú¸èuÑã`g¸ñ`§ß±Ð_êY¦¶®|eòç+^b¤T“„tC¶1#üaê‚	ñÖ¾ÛŽ“²?»DPÂ—¿Ä9¿ü(Úýå‡_àî™´gòAŠDß„±ÛâçƒOŸ08…³'à1AÅ˜TI™£Æ:ÓŽšœ†òˆrO¡ýíúÒNÔ†o`ß˜L¸à5ï._Dèrº•Ñh ‚‰Ä*”) â!ŠvØ÷žÛ½ë÷‚,ø†…«“~•ÖñÖþrðOû‹¢Ætê¡¾i/¬[YnÙpÈ­Q¡þû}ÖËÞ51vë0a¦)¸·:ºW7‹SÚ]iÚûlø^vÙ+Çjâ÷}6üá^ÚïÛY%ˆRx1L†ŸË¥‰½EovŒ.»N%fËÀ",Z0¼­ä±ÎÀ±rÒ–ÏzèbÆÞÖ™Ý…½`¥PÖ€ûÝJ×½rGMü³í´ŸÛÃêÆ*é÷ÔÕ\ðµÜ.~»=húu~3÷nYÃƒ¤¡Ã­áËL+Fp`ã&,¬107?¥8v’òˆbÿˆ°ÀU'ýO	WÏ_üFÅÙ·°ý\ê¡•~ƒÄZÑ®ðY0·ú™¶ÕYßd½/ŽBõ±¾x+„ƒVŸ¬%thÛ&:^Šfô)ÉiJv†rAd=tsÁUZp“NA	äxóûTÕ6ƒN4ŒÞ¤OÓŸ?~ü*¤$æl!¸¾­•1Å™bs!Œé)¹'K©8¥-íŸ¯r“ÐIºÅžÚ—UD9¿N¤šíÐÔÍÐlß—û¥•´öàk=w;	K`£{b’_Sj á”¬¢6ªÿ†¶ü7Œi$ì½Ã‡ü»
-&Xe0©ä#uaV=QkÚ§‹†8ˆ!”¥^È°Ü·o6~t¤"%u‹do–UHåÒ täƒq´KèFJ¬² (uc2³Û!in<Dô
-hè0i?Õa' ¨ ZÕÖ‰³¦O"‰J‡"[J\èdFj3šÌwÍv'ÏŸ³ülÁ)çq™…;v¼uþKÞ‰	Ú„5sçÌ„÷a‘eù±ð¡ùÞ@¦ÍžH;ÓîŸM¹zåÔ=´UA
-=öÑ–£‰µð4‰i)Ä o[ñ÷1L\4$XéRV\d1%#›H¦V-“–i4Aii»É#»äîìy£Ðæ)á©ÍªY«Âæçâ|ç£Ü’ãM3’cÛà?Ü¸éÓ¿©D^-b£xYT›±Àl×Ø²çBªå^°pŽ·zKy‡êLìyZÂƒT›˜ ×-ê<×eet>•a¿Èž8ûÉÐLF¶Ì^4cy\ÓfÕŒ%£‡2Î`Œ¿¹ðÜ†3ûêª/9ž‰<_À…SÆ;$H¡{wÁVgX«š¼÷<¾÷“ƒ×I}sIÍ=ië„Kxî–æOpCwDrkoUÍYèBY[¿`Ù¢˜!á|µ»öÄ1óú|ß}‹ŠükWÕm!JuÅe$8°»üxÞb‡#Àx`Ïr­ÒœÆÃÍ…×Þ(¹¹óô§ppÏnŽ;9ìÍiŽÓ¶šÃ+ÅbsåÑõ°]4çÖáþÞð¡zŒ
-b’—nô]ç¥ÒÇëƒ“ ^Ÿ ‡X¢I‡Â~ÅÍº¹oÑ¾sü6ª\`úÏ35‰¢öÚ€b¿`ï¨£¿2•ß|ó“UÞiý Lv»Õž×d¸J 33/Ûk‚k¤{€WxpL"ÄCbzB*¤@Zjv69|Ür>&Ý¼ÕÁ¾‚Rmn}Õ,«oÁŒ¹ä‚Wx¸‘xÃóóßO.pG˜¸i¤÷œÄ©ðLOÓ0mß”+aG€œ€/JöWu)õ\'“rx˜s5¶_æë›a‰%â{ÍYx gà"4gœ(Â®W3-@ª¡9¢hH–Lƒ…D"†…Ic_t¬µpI×Û)fPíEg™¬àFwàž]ìnÈûN¨ºÑ°	6ÃÔˆŒ»ò¯0ªP¡Dž®|rÉRo>o–*-v'ãp3îiæ4šVïX>²5Bèãõ±Ú®¾.°‚v_$\³v9~í‡t¡ÃðmúKGÐñtuÆat~ ˆP“V™™?<oÔ·@~*Â>MªþøSchÿþSÕ'½.Õàã›  7Ü¼¢˜Ú^ÜF0¾zðûN H›y¯pï$5Õñó+KªëU'Àìš½”(ë4–¨ßê©õ`ÿ‹“¶£üÈJÑú!Qügõÿ9L`¹(M¨âe)¦•lû©œõPNxy’'pMëižê·Ó¼ V?9xµ’3uvúaX®1ã+-ïÿà_j6…Ù}zïíGÈßãì{J+p]'?¦6Â:p‰ôð$¸ŠåHI±¶:¡
-öøô›Ü4]j‚Šël ƒD]XÜÚ°y@¸N6n°!}}I¼)É*´s{†ÄB|¤Ša# >ÏzèdJIË.¨;ñË†Œˆ‚-ÆÍ°<Á1Ø5xó–À@fÂ²ãÛÎnút“Þ¤ÏR½ÃRV¶Í²5Ê3aƒŠ+yuÂ¥¡h+ ùé{ä¬dmQ(6ïÅæ0™Äì•·º£‰/‡(Vaµ"ŠÂÂ <J Õ´š
-‡°°"ÈSa5­VDAxq1å	XUl^«”ØW-b”(jç=oß“·c¢•y(uŒ¼&âSÅÞ7i¶¨°Ô–rqþÐµ5íhMõYáWøfL1ü×üÇ»jÅ‰!@èbú6K]©+Ž§ãp™ê
-Ü(ß}&W½×-H&dä«p&[Ÿ’ú‘ ¤¯«Í€¶+ÐVm–BE»´]€¶?ÞáÖHîÔˆ×1®0ÜMÄ§–ý¢=UmëÙQkœV
-Ü -ÌÓ„x,gWy­±¿Š›­öŠÚ¨â`ÆeÇ{ÂOpåÓì«†0Ân"-aòà‚ ¤ïKÂS\&ûÌŒÓÍVXìÄ—oÛé!„AT¬V«ONÖ $çA
-T¥vá|N»öIÒS5“¦Ñ.ŽeÎûj
-w–¸²÷ÿo òG}hëÛ¢¬¨u¼Õ¯^ù$»éP…þÓ—BÄë´Vxµ -”:IFFk}1ÊS`iÇKsÚñgð‘U%t'¸½í“žªË…`LMÍ#,ÝfòêvV~b Ö•ß~*Ã…ëÞ$ÝáÏpùM-†¼¬´4ë’¬Ë0FAx'ÌZ¸(&æwÐòv±®ûÿ7P©®¨}p«ô‚àË‹]ãý’ûØó>÷ø¸´oòh¦ì'c…å°6ÂÅy“sˆ+LÚëë·ÐÎACcéiâÍÒè76,¶Á
-cÀn²?£r‡œ¯ŽôÛ<ïÄ¦Û*äQ‰}Ñ[5ê?Ékè8{E	ÀçBD…#p•Ôí<º'·Bµ×çï”…°(_è`RRi[’B©•î|Y&ÃÙäRDë«<MRP%$ç&‘ ØJ7Y€1d^ÈÍIO»¹@Ð¨-ËŒ¡¯o¥*DbÁùàA8%4±ð¡éÃŒ)¥ywöŸ'ø:.c2­‘Qb­Z­=,²Æ£%GQwT.mÀwy¨Õpo/‰ÌZ°÷³º#Ç ™<{jôà)3F
-atn\ŸSdÙ¶Ôo‚!ýš÷2ßµü*Ì¶Výe›×9zÚó³aWÒnØAÎ}ÔxùÊÅU³„’6žŸ1}Õä	³Î·pºêâíC{Le*ÂùÂbëT¤¥-ßìµn
-Î¸ïŸk“6 ÜØï©\˜[V‡­#e,¦aÏÚ&¡µf/²Ýœ}Ê¶›veÖŸÝxxµ§¯SžÒb$³¿U¡ü»¿á«ª1ÖÁšm¾ŽC`!øžÕæG‚P×ªß‡8â"R¸VÃZòòÇÈ=¨6Ëž6£‡õOn¯lÝ*9òÿ$Ñ-ïè–[QñÕ	…q°Ì-b{Hkñ #hçÕTö_q¿Ç_*Š©'ÒkÒe~sr\0„:'²0‘ÐÞt+2ìã»õg„2¨IÜéO¬¸µ¼u’ÅZ˜7>±úü¿5{WIGãü ‡á8tæñ´ö›8j}íkÌÃ|ó“–»øÆlš)(ÿ yý
+xœZT×úg]fçÚVeE£ÑØk,‰ÏK,¨Ø‚ˆ€ô²X…e¿Ý¥w)‹à€€(vPc/$Æc‰X¢1/1š˜˜oð’çÿ,h’÷^^Þ;ÿs8»ggæÎwïw¿òûý.2[[™LÖ}¡{ØŒ£F[âî¡öq²^›%½)õ†.‚ÔG&t²Q´va{ÓÔ_=z3_ô¶­`úØØÈì»Y?ƒ{ô±±yñ¢K?ë5]ú[¿œº°‘Ëd
+¥8m£ÿ÷¹ÝýB¼B"ÍxÇaôÈQ‡9z¬Ã4¿?¯`‡¥Áþ>þ¾^!^ÁÃ–zz;„ùy;x;¹û¸»»otPûmtrñtw˜½Ìi©Ã,¿‡ù^nî~ÁîÃ†98»»;x†„L1"Dí1Ü?ÈcÄ&¿à>í°Ž6ËqáÒaóçÎø`¡ÓÃCÂC6ù9ltqõò	ncÓÁFf³XÒÙ·ôáÕfiÆvôËJ5+„N¶Ký»tLíÒ	ºt;™FƒÑhH3»t¹ÔÙ²×”jL5™L)]ºÊmd6666NVÚ V—õ±±±™dõH/;'«~6Y6/dëe×;,î°K>C¾U#aëb[gûã­è¥Ð³ÃX3éDJ;Žìx¯ÓÌÎ]»tîòNWû®E]U)«•Oºéºa÷.Ý½z¼Ù£¤GÝ`»9“ý{ö™¼’×ñ¿ôôëÙøZôkW_ÏîÕ¹×Æ^·ÞXñ†ú†7n¾9½7ÛûnŸg¡TÕGµÅá=‡Û}kúþÚ/ó­^o%÷ïÑ¿ªÿ¡}T½=aà€¡Ð Ím54à±yCO©¿´«µ¿¢¡5’—æâ±Ö¹¬ò
+ˆÒÂP\.Êj,˜~Ó-rûÞ-Ó¤•|8ª[Â©ÚL.ŽË«Â!P e™Tœ!­¥¬DõÜ|{M?ÂA8Oa¯Žˆnl?ÈÝ¥’JY(‚Ü‚ä,ã(y›sé8¢¤®úãt³¬¼ãšäÒìÌgn3&q¤MÚæÙÄÂ*pÛRë{š †`¥Âl‚âÇËÑ”ŒèO{Ð7~Œ,* ¼P5{ñ4V‘ŠïÜ¶ìò4“¾¹QÕn¨êa­E¶«W<|i'tV;‰IZ¿áÆl²|Ì>‡ãoÕSeÀy}µÇÖ¢I`AXyYÑöŸL©ûí1‚ÚÐîÔþñ $øF%vÉ”ÃA”z™q“èSo‡.¡û%îŠTÙSdW@èwtbá.ˆ>5QÛ7-†ñ°Þ1Òƒèñ÷ˆö×€óizüjUëvÖYsðAÆ„¶:™98 ÂùìO—O\8Ÿµl‰@£þðÓf™5æWf+þÂìtXëâ¿€ÀÏw‰öýÍ*-þV¹Šÿd·•m3ìS²gvw~™ÔÄYzŠìÜÄ”:Hr†;I¬&.fhW«¨ù·ÁLL5T'íÒîõ¥ÒüŽ2_¯0ÿ €’ÀÂ®¢r‹J©1o1ÿÁa³]å5t»tÅÂEKa÷ùANìâ ­fsâ×²PuµëVå¯2qÖÚ¹¾E[ÊÊŠÊTPµÎ°£úHV%#'7ŽVmbWê>ÐÍ÷ê´ÖN3éQÐy¡	î)<D¸éÉn;\)>›û¥Š¾×Ès†¡3¼œWo¨nà£úfœ˜JÚVÜ"kÛayW‹é=E¶ÍO ýÃêÐ?ÝF¹‰QÒKÊÚ†Ê°w¹4±\ÞâÒâÀƒH;êhGø0Oam€
+Z§ÐgR>—­7„¡ó©PäA‘>O_¢3è!œ´²°¶¿õ­MØÑºMýáÐ•´MI0è“µDÚúˆÉˆ1èÓ€äBZ¡J:Âî€CO¥Æ"lË±ÍrÉ7óh?ðíJ{¦2Úƒò?ÁŽØõ‡ï‘&¤óàËÔëÕÎëýV¬/8´ÎBÔÁñÒý;*Þd?ìS—¹”¹Àbp'Jš£±à{a¸MÄùav?]
+²àî9ÞÁîüÉ ¥ì4_÷MsàëíŠø–Hß²ÆÖØ …~¢¯Ã;‰DÍrâZ¡ Ý¾‰©.—_¾ ²ºûú?“Ý}&Ç¥’’¯.õóöó+®¨(-­èuÛ»¦<"6™±N´CU3žz4ý	w E…óx¸7ñ*•g?*¼t>'÷FÜ¢=…Ö>¥ŠkF‡ªµ”õHÒüMö‘z+°×ƒûWÑîx›Ÿ·z<•t êUÆ´CvW<ª~w¹ª”6ó3WLì/ÐŠµIiU*,ÃEìãúásTJœÿÏ)‰î—ì{sGZŽÿe9ØâuoZ–ósôËÿ1GüyŽþoõƒf¾ší³¦gw9ÉFêÁWúT¸ÓÁcN”ì`nÕŸMEaböÀ!Ø£#b(;-)«F…ÃYnÐãúû_i`£^§‹@â_¼Õ,X²+UJÚµÍ Z3éYÓÕ¦º&®Y²&Ó&Pƒû1B9œÍè	©`‚äËg2ÓÏ7Ö‹DdýtÑà°Àe >l¡>SÑ³-žÐ¾T	RÃUÿy"ÊLØá7ÀÓ1×úÖ;A	ß’n}ÀÆÄT@…¾"‰(+AÄÝex^´«~
+wMOÑé)÷K‹­¤å¿ôí#Ðgÿ7ŠjÓç°vÃU¨Ö1˜ý[›;âp2‹]ÐæË'ªþ=×µ¡cn3°¤= î+pô]­RÒïÚÝ2övºY†¶MïÉ±¥¥_»©jùï.ï+Pö}ŸôÚ_ùþ**DÚ	ûÕáÃûäA^|LbD4‘ü°yE¥‚‹_Ö"‡rÌ+ÇØ/åÏå=_ÍW*ekŒY×„R‘NVèã#õo=C}¥“LœY!@èäßV¯û©ÆÀ¢ö×LJtJ\&d)=9‹ ¾¥« õ2óÊeµ¦O êàc¨ÕåpY#žñ£—}tW36qîRiO‘ý`[ÚH?1\þ¶—ú°~5.eË€ÐNýÞ¡<å¾„
+Õ8°ËRIæ²ÜTäm!’4[Wç»ÆYíÎàQ¼;p¯î$ì…Zã™ŠÅâîªãPõ[Eg’µ’ ‚(iºÆl,”úÚUÆ‡Cs°íy8æ»3&{såÆt×t§¬99p
+ªËöÞì )£Œ>†¸,  9R¨úÝi!’ :F——¨s/ß [*Á}8g¾ÿue`¹ö³(Â]1'ÞŠ„°ÒÓm2Œ“áwt9úäX Ñ¡¢¯³[ >KHƒ¡°ÐhcAá~×úb Èüø3U»û‹¸ïäÃ60Ðî<D†ÛGþî¼YìØ5³§O<tTàº Þa¸½í·¯ƒn´Šf'ÃH*œ€ýåçÈ(¶-sAÄ3"ˆvÙ’ÓI9=E–[´"Œ!„¾Ó˜»w)-köæ²fl`’¯>|a¹1Úš±œCqRz4DBdlt‚–,˜<ù&.Œ
+yyEÂå€HmtL(¬5‰û)ô‡ÉcÊ3k!ií’5‹%…ñaËŒ¢¡È·Ö¨ã¦ªMñ9æŠª³Ÿ‘/2éšœHÐB\ÜÖ =átíù½êô;“ˆ’n(Á%§”ä— ”Ä”Øá˜«p®ÚË5«‘"¤Aüö˜ÊB¬×ºn Õ¸V¹šÔ0fÍ‚¿Áz³»%4zkÄfðŸw1Ìq‹·¸‘—¢;ýÔx]€ê¨Æ•åËËÃBˆ7x'‡ŠP	ÉP²½¨Î¯®È7—.]SAmdmPIÍ®š” Ük€40é5‰	ˆ![rbò…ÌÂ´ImxÐ{oÚâïcž@	ì0TæYwA“ž]R¾î„‚Z;óËf®zçíYÇ8¸»v¿‰œVÜE[×ÞXÛ»ê±oªJä5fìhÆÛaÍÖo»´¹„pié%ñRº…kriqÇ¯yŒ¦S°GçÑÁt]C¡@ÿ†k…£p!íB^Y*v©†|’‘Bœ"’ A÷®Ûðàa@è‡´'ŽÂÙè„oá œ€}p
+í@µ#âGÍUqAw<¡1O…Z¶Do¶("AoÐ¦­;¿"w#þC‡S;j÷íð§ªãp¸bg}æŠ£á»|•ûôužÂsN6‰Q¡ëç¯Ô†™áxå(?}÷ŠªGÖ8ÎF“:kŽ§ËEj–z‰Q»g—0¿™ë. ÜàÇÔV˜®ëÃÔš˜W ýršv½ªÕó·lkBæ÷¦‚ïC“Y¿ì Øù§ï‘WMèI»~0~šàîE{£ŠÁ EƒYÎ¾¢ñHE#+gÇPF¥¤94"ôùÖ0ÙãSr¼Mãy0qËvÚí¼q1à0Àé»q:vÃ9Ù`¤%š´£f/¢YI;ÄP9Œ‡ÉY´ëG”9C»Ýý0R!ÙiDI»f†J#DY¡%—R¤þ¼È†$ùéC€ŒµÂÏZ}V„C\Rb¢† éÔ+m$²:(@¤2 n_kNž‡dmŽÁþ™Ô(cBä@rFr&Á×ð:“Q²}_“Á
+—éÔP\öL†sÍr\oà/ïuóŒÜP#äAnjV¦ñ}ÿ…ë×jµz=$’ø”Ä”ì7”/qBzM.9¶øñYq!
+cu±„þýÓ™„hH  MF\äBr¦)“àßŸOgRr Àºbêj.¸fi½hWx›;ð'Ëõù[ bõI	1ämª§r43‰™IÉLÊj¡ð_—}
+!×“ààVYÐ"F½ÔÖ< Üµð19Ýù¤,<?$Líë\ïÑ œ‡½'KOœ)MaÊÎ7òÛ'ÖtƒÛ¨hþ%¹TJ—ó/™„tRÍºd¢Ë7œ%ýÓž´Ç£·‘¨>…½ûÌ„ÎþCð1>x“ïupt”wÀZ ÓÞG;ÚüùÍú±ËUJz	OÉ²°@ŽèÈŸ¢‹Ùßƒ#OÉ±M<\×`×¥È8b·qcA‰‰ $F|?è$Ôè”Mt&íNíHt$´É‰©	>9\#vÈF9Ü&Ê+™¡’LÌe-Óä-Nm^W'ùéÕ@†[½^£7G€h!)!šŒ¤ƒ°’IÌÖ!…ì¨ƒ"Ä·tŒ/øµû¼ò“2£S´Y¾iádMŠEL‚5’_=Meº¶÷6@¶.Û› ý…I‰2m³¥15%—ü€5?ÒZ&YÓ~ÍÔ¨ñK¦ AÌ©6´áŽ³õxÚŒ›¬xtn3›¹C/ëÀ;©B˜.k##à§„–ßXØšsL^HýªÏOw›’ýœC}Ü7/ÂmrÒàÚ¨b0AÁ,‚!+¿îÄGé¥p jKÝË6˜–À¢ÄŸ0­D†i¶Ï#Kþ©h¡gÄ»"Ž·òÆû¸Ú‚C,&‹¼Å³ø E2NB{½d EØGYÞïª,X¤§ñ,ŒÂø—´…Wà0Ø±4ŸªˆüQÝzÀ§˜vWüùù\ñRP@î~•à€&hâZq4ƒ§Q<¾»çœ°jb‹B6$iý!’l.‹.,)Éßyziý´á´óJ*¨âŸ±ªÜ„òßÉÈ5ÍrÏ¦EoPÑ’?F’³/^\¨²yñ;{ñâÜ›/ZžúâÅ¹.6@”÷Ôfñ˜¶Ctxj¯ä
+[¾âS!+ZÐ Äéãµ3=#‚`5lkŒú†Dßd".¬®ZZø¨ôúY¸N¾£ŠÛt @?þ’çü^ÓÓå6`zjþ€åS‘eó¡ª½v{€ÌÁm¯;á÷z|¤Ý	äúö[å*ª–Æð³‚'ÑA•c¶J ÛlÊ4V@h›H¨”È¿ÒîË[BzŠì2MöÝOh$~ƒsp“ž~¬ñË6 ¥ó† ð€%àe">ì}jÄAdl¬•ò4Ñ£€—™—ˆ]á©›îàSÁÓD|JÙÿ‰¡ Î@‚p.-fRã2¢!†øn„0Á‡­6}
+»(AÄ7DI&Ãc—­âÁD^(­a‹ 5Rˆl‹!ôL«ø`!ÀX+¸Ÿ&„Z•À£Põp¬M	|IQî±3Ežê uRGFyE-¶e'žJ;å-Ã0ŠÏ„´¶íÓêc·Ñ·&R…tå.lÄ£¸b×YÊàþÈ"ú¶1
+t¹@òÁT¬ÂØv¤‰ÖÉ¬šÆlªYÙ0u¤ãèêBÝð]:
+âøïQ…D¥üA-JçÄCí‰5ñþSñ7I¦“ŽvþM’¡OXÚoð{C×ÒN\"H=Ø¿vuW–öEBeØ[@|³¦"È€=¯°Upà© ÄvI†ÂÝ#O0ú‰¼eÞçq	}GÑ)®HtPàû(à \¤Ø¨<ÜÑcuXÀ’Åoy»=÷¥Ýl[ž?QœƒKêÆ™ûeŒƒÉÄ*;á*QZ&kqí)F°Ž•¦©"Ô§…ar’Ò"!tÚ„(BÝZ¿e"Vºm]¦'àó£	Yk*®
+²”©ÀdÈ4ÉA|ŽÑaŒ!Ñ¨…Dâë‚[Ó%Ô3xª´ÅëŒ’îý=¾ñnO1}_÷’]š²neV¾î°Þos`{ÃôrÍ:ÍûB 5VoÀn¨ƒÖXUW‹øˆSÄ³"N*—¸ðñœA.%âBžÌ½5¾ˆP{‘Y·ñ8œ‚OŸ½ø˜é„Tgƒ´Y/®k”xÐëãcˆçÆ·bÃÞÑ`…Nc /L86ýz@VbcÌ§[vÄïŒ/ßT˜¹6“™«fŒü`JÊò#‹ë.èkô™Û@÷Š™­mgfi`0¦e˜’«Ž‰^<îv„›ßvøý¥žejíÌW$}¾ìFJ1@H3dÓÓÀ&Ï›¿ÍÚwÛpRÖg7‘Ê¹íµ:Ål‡¦&h‚&ûÞÜÏ-¤¥_ã¹ËIXëÝýjR€¥dµQý·Ò¼é¿I¬H;!aï>tàß%Áª1¨hL©³Š5ZCÐŽ8]4ÄA¡,õB†å¾yt«þâ‘òp”ôMµÐvÚªÍR¨h·mç¡íw¹U’{{Bò:ÆÆ€»‰øÔ°ßC´§ªu-;b•Órë§…ÙàqŠpýfï,«ñ/òWq3Õ^QëUL»ìx_ø®|šuÕFØE¤EìÞ\8/(©+X${³¬\ê(— #¤ˆ£B×SbÕ E©“‘Õ†1r¶A„@¯€†Ž³ “úca-v ‚
+ •­]™8•×¨4(°Y¡„k®á¬Ÿí~þþgøš{.-Ãé|"Á7~}ìÖømsA„ÎgO‰Â™ãð„ bÔMª¤Ì´£À´½:{oYD™§Ð¶×ú’‹ÇkOÁ×°oL$ÜExoÕûKº”nf4VëÁDbÊdñˆE;ì}ßíþûA|ËÂÕJ¿Hkxk·?ø§Ý^Qmºu°¾nks›YnÉPÈ©V¡þ.û]æ+$1>vóa¦*¸wÚ±D‹S>ÚÛ´çùÐ=2ì´GŽéÔÄïü|è£=´Ï?¶²J¥ZñB˜>—Kã{ŠÞì(]V­J:Å–‚1DX0ox[©|œ†£e¤5õÐÅŒ¼­3»{ÀJh­éÿ»•Î{ä8†šøç[i·Gÿ:ØUÒï¨«9ÿ+)¸í(Âíaã/s›¸oqÓ*$jEl×2¬ˆÍuŽ7O°öÀœ¼ä¢\ØAÊ"Šüý#ÂWœð?)\=wákgßÒÏöO%¤núPé{1H¬í
+žs+Ÿk[x‘õMòÑûioë‹6C8huÛ’´„nÝ@ÇJÑŒ>9)RÈÎSP&ˆ¬‡n6¸¡Jë nÂI(†lbþ€ªZ§Ñq’†Ñ›ôi`úóÇ]…ä„ìM×¶¶0¦8Slä‚1-9‡àD)'µ¦þóUn:I·™‚“û2ë€(q¾“©Ìh2ß3Û8wÖò“'Ã%îè±–¹¯¸V,$ÄkãWÍž0>€–¥GÃ·‡æy™2s<íH»~6éê•“÷ÑV¹p(ôèÅM	5ð4Š©ÉÄ o]öë(&.â­-3.2Á˜œžE$S‹–IÍ0š •4·Þâ‘]toæ¿¼Qhõ”ñÔfÅŒassp¾w1§øXã´~‚äØ:ð7nêÔßo*‘W‹X/^ÕfÌ7ÛÕ7ï>ŸbùÙ‚ç-Üãc-ÞRÄÁ:FãÛ…¥ƒ–ð Ä&ÄëuK;ÏvYGeØg=²ÇÏ|ò4‘ƒ‘Í3L[ÚW ×ÔÕ£ÉÈÁŒóºÀ XcoÍwàô¾ÚªKŽ§#Ãpþ¤ñ.	RèÞŸ·Ù–ÁŠFïÝíùäàR×T\}ß@Z;à"ž»­¹“ÆÜÔ‘ÜÞSY}ú‚PÚšÍÏ[² Þ&@È#8_îª9~Ô¼6Ïwß‚Bÿšµ›ˆR]~	ö/ÁN?œ³Øáð‡ðÚ³\‹´§ðpkþõ·Šoí8õ)Ü Üó[cNy{Šã”Íæð
+±È\Ñ°¶
+â‘¦œ Ü¯{?RRALÒâÀõ¾k¼tAúmúà¤xØ¦×C,Ñ¤Áva¿âVíìwhïY~ëU.0u»çéêÑ»IM@‘_°wÔú‘ßÌE™€Ê¯¿þÑ*)µ|&»ÓbÏkÒ]Å‘‘›eŒƒÎ5Þ5Ò=À+<8&¶ABZ|
+$CjJV9|Ìr>&çêÝ¼ÕÁ¾‚RmnyÝ,«kÆôf¹ä‚Wx¸™pÓóóußMÌwG˜¸a¸÷¬„ÉðLMµwÊ¾IWÂŽ 9_ïÿ¶òRÊu¸A&dó0fkæmºÄ×6Â"KÄwš3ðNÃhJ?^ˆ¯fX€TASDá L'˜ó‰2D“F¿¬ŸXcá.J7Úh–f@íAg™¨àF¶c­ì.ÈýV¨º‘°6Âä—(»ò¯Ð­@¡Dž.zÉRg>g–*,v'žàP3îiæ4šïX>²4Bè·écµË\}]`-í
+¾@¸&ìtìÚ!èB‡à»ôC:›£céêŒCèüP¡:µ"#ohîˆo€üXˆ½U}ñG&ÇÐ¾}'«Ox7,‚•àã  'Ü´¬ˆÚ^ÜB0¾|ø{£éíO›x¯pïD5•ÛæUWÕ©ŽƒÙ5k1QÖj,Q¿ÁëÁÄþ—§{¼h¥…}(þó‰Ãÿr€ÁrQšPÅ+„L+Ø¶“@ëA ðêôPà5ÖDÕo'ˆA¬~bð j%„êrìðýf\eÆ×š?øÞ¿<Ôl
+³kxzÿÝÇÈßçì»KËp'>¡6Âp‰ôð$¸‚åHq‘¶*¾vûôëœT]J¼Šëh ƒ]XÜê°9@¸6n°.mmñ6S¢UÜçvŠ…m‘*z„€m¹Öƒ.SrjV~íñ/á(XÖ¥Gäo2n„Uà	ŽÁ®Á7®2–ÛršpS§šô&}ªí–ÒÒ-–ÍQžñëT\ñëã.F[Éß!g%ˆB±i6…É$f¼ÅM|Q8D	´«¹PáQ­¢UlT8„…B®
+«h•"
+Â‹Š 0WÀ*¬ds¡H¥ÄÞj£Di@×z÷¾¼%¬àJ©cÜà]ð0ŸJöI³I5¥¶”‹óÿ®®n#]«ªÎ¿À×£ŠèÀ¿æ\Þ•ËŽBÒwéhêJ]q,ƒKTWàfÙ®Ó9ê=nY@2 =O…ÓÙºä”‹‚’~ 	ÏpY˜ì33N5[a±_¶e‡‡Q±Z­>)I ”ÉP™öÙùsÙmÚ'IKHNÐL˜B;9–:ï«.ØQ&àòžÿ¿Êô¡-ïŠ²Â–5ò¿¶†î“ä¦BÖ†{T_!°M§µ6ôy­¡ÔI22Zë‹TœK[‡žÕÖ¡9ë€‹V•ÐàÖÖçLZxŠ.¶ƒ1%%—`°t‡É­ÝQñ‰XW~ç™ç·¯{ƒt—?|Àå7u´r3SS­ÿ”d]†1
+Á;~Æü11¿3€æ/°“uÝÿ¿JuyÍÃÛ%ç-ðGYv[ìê?Àî¸'Ç¤ux‹G3e?-,…Õ.ÎœC\a*Ð_½ƒ¶pöÖ—œ"Þ,~kÝba,3ì"ûÓ+¶‹ÁyêHß¸sŽo¸£B•Ø½U#ò¼¸×4‘°|ÎGÔBãp¨¸vGÃîœj8U^Û³½“çÃ:¢|©ƒI‰%­‰
+¥>Tº{­2L†3Ê¥ˆ–×yš¨ JHÊI,$A°™n° cÊÏ8Ÿ“–zr€ P[:šEßÜLU0€Ä‚óÁƒp Shdá#ÓGéÇ“Krïî?GðM\ÂdX#£ØZAZºYdõÅ¨kKëð}j4ÜëÃ‹#3çíù¬öÈQh"GŸ9pÒ´áDë×fÅÔY¶,öçƒHßçüŒÌ·Í¿3­xÉÆ5Žž„v¿É¬Û™¸¶“³ë/_¹°b†PÜÊóÓ¦®˜8nÆ¹fNU^¸sˆ`·ÉLyø!_XhŠÔ¯¤ùë=ÖMÁiüp­Ò:tá‘ý•³aÓÊ°5¤”ÅTì^Ó(”B½ÖìE¶º³OéVsþÎŒº3ëO öôMÊÓ@Z„dæ7*”ûw|]5ÊÀÃXµÅÃ×q]BÌß3Ú¼ˆCp
+àzå“A\@
+6ÁJXmŒ/åÀ‡UfÙ³&ô°þÉí•-›%GþŸ$º¥íÝR+‰ú¯:¡0–¸El©v-Zdí¸’Êþ+5õøKEñ/õDz]ºÌoLŠ†0PgG$Ú“nF†}r¯î´P
+Õ	;ü‰C–µL°X‹äú§Ö¢ûÿ·ÆëŠÃéHœ…âƒÎBÿ\žÐ>ãG¡o|…¹˜oÒ|ßšI3åÿ-,
 endstream
 endobj
 
-247 0 obj
+254 0 obj
 <<
   /Type /Font
   /Subtype /Type0
   /BaseFont /DVLYLA+NewCM10-Bold-Identity-H
   /Encoding /Identity-H
-  /DescendantFonts [248 0 R]
-  /ToUnicode 251 0 R
+  /DescendantFonts [255 0 R]
+  /ToUnicode 258 0 R
 >>
 endobj
 
-248 0 obj
+255 0 obj
 <<
   /Type /Font
   /Subtype /CIDFontType0
@@ -2915,13 +2981,13 @@ endobj
     /Ordering (Identity)
     /Supplement 0
   >>
-  /FontDescriptor 250 0 R
+  /FontDescriptor 257 0 R
   /DW 0
   /W [0 0 280 1 1 863 2 2 639 3 3 319 4 4 607 5 5 559 6 6 639 7 7 575 8 8 383 9 9 882 10 10 869 11 11 660 12 12 516 13 13 638 14 14 699 15 15 702 16 16 669 17 17 575 18 18 831 19 19 575 20 20 607 21 21 527 22 22 447 23 23 454 24 24 575 25 25 1189 26 26 639 27 27 319 28 29 639 30 30 351 31 31 474 32 32 958 33 33 319 34 34 671 35 35 447 36 36 607 37 37 510.99997 38 38 607 39 39 447 40 40 901 41 41 639 42 42 575 43 43 818 44 44 831 45 45 864 46 46 319 47 47 575 48 48 639 49 49 383 50 51 571 52 52 885 53 53 864 54 54 575 55 55 692 56 56 575 57 57 1092 58 58 800]
 >>
 endobj
 
-249 0 obj
+256 0 obj
 <<
   /Length 13
   /Filter /FlateDecode
@@ -2931,7 +2997,7 @@ xœûÿ  #ÅÚ
 endstream
 endobj
 
-250 0 obj
+257 0 obj
 <<
   /Type /FontDescriptor
   /FontName /DVLYLA+NewCM10-Bold
@@ -2942,12 +3008,12 @@ endobj
   /Descent -194
   /CapHeight 686
   /StemV 168.6
-  /CIDSet 249 0 R
-  /FontFile3 252 0 R
+  /CIDSet 256 0 R
+  /FontFile3 259 0 R
 >>
 endobj
 
-251 0 obj
+258 0 obj
 <<
   /Length 1422
   /Type /CMap
@@ -3045,7 +3111,7 @@ end
 endstream
 endobj
 
-252 0 obj
+259 0 obj
 <<
   /Length 6051
   /Filter /FlateDecode
@@ -3076,48 +3142,48 @@ e<¥{OQöiLÕ¦Nê¼ÕÛZDX­!æ0³!`¡ÎÒvÍhÅ	´˜™*Ä Ö“l·ÚPÉÙ&Pu÷šÜ¨‚´|”#gOF.£:…Û §
 endstream
 endobj
 
-253 0 obj
+260 0 obj
 <<
   /Type /Font
   /Subtype /Type0
-  /BaseFont /DACQSC+DejaVuSansMono
+  /BaseFont /YAOYKH+DejaVuSansMono
   /Encoding /Identity-H
-  /DescendantFonts [254 0 R]
-  /ToUnicode 257 0 R
+  /DescendantFonts [261 0 R]
+  /ToUnicode 264 0 R
 >>
 endobj
 
-254 0 obj
+261 0 obj
 <<
   /Type /Font
   /Subtype /CIDFontType2
-  /BaseFont /DACQSC+DejaVuSansMono
+  /BaseFont /YAOYKH+DejaVuSansMono
   /CIDSystemInfo <<
     /Registry (Adobe)
     /Ordering (Identity)
     /Supplement 0
   >>
-  /FontDescriptor 256 0 R
+  /FontDescriptor 263 0 R
   /DW 0
   /CIDToGIDMap /Identity
-  /W [0 38 602.0508]
+  /W [0 41 602.0508]
 >>
 endobj
 
-255 0 obj
+262 0 obj
 <<
-  /Length 13
+  /Length 14
   /Filter /FlateDecode
 >>
 stream
-xœûÿÿÿÿ õû
+xœûÿÿÿÿÿ ²¼
 endstream
 endobj
 
-256 0 obj
+263 0 obj
 <<
   /Type /FontDescriptor
-  /FontName /DACQSC+DejaVuSansMono
+  /FontName /YAOYKH+DejaVuSansMono
   /Flags 131077
   /FontBBox [0 -235.83984 602.0508 765.1367]
   /ItalicAngle 0
@@ -3125,14 +3191,14 @@ endobj
   /Descent -240.23438
   /CapHeight 759.7656
   /StemV 95.4
-  /CIDSet 255 0 R
-  /FontFile2 258 0 R
+  /CIDSet 262 0 R
+  /FontFile2 265 0 R
 >>
 endobj
 
-257 0 obj
+264 0 obj
 <<
-  /Length 1138
+  /Length 1180
   /Type /CMap
   /WMode 0
 >>
@@ -3159,7 +3225,7 @@ end def
 1 begincodespacerange
 <0000> <FFFF>
 endcodespacerange
-38 beginbfchar
+41 beginbfchar
 <0001> <0073>
 <0002> <0072>
 <0003> <0063>
@@ -3192,12 +3258,15 @@ endcodespacerange
 <001E> <0034>
 <001F> <002E>
 <0020> <0068>
-<0021> <0066>
-<0022> <0042>
-<0023> <0079>
-<0024> <004B>
-<0025> <0062>
-<0026> <0071>
+<0021> <007A>
+<0022> <0071>
+<0023> <0046>
+<0024> <0062>
+<0025> <0043>
+<0026> <0066>
+<0027> <0042>
+<0028> <0079>
+<0029> <004B>
 endbfchar
 endcmap
 CMapName currentdict /CMap defineresource pop
@@ -3208,80 +3277,81 @@ end
 endstream
 endobj
 
-258 0 obj
+265 0 obj
 <<
-  /Length 7940
+  /Length 8219
   /Filter /FlateDecode
 >>
 stream
-xœÝztTÕ½÷oŸÿÙçÌL’ÉÌdò„„Ibò !` e	Þ„DÅy„Hˆˆ)KQ¡Ñ¢ Èµ)¥¨ÔëåZŠAhDÀ"ŸE‰µj‹\±Ôk#ZI6ßÚûÌäÔv}ý¾u×ú2kæì³ÏÞÿÇïÿÜÀ „`Yew/÷]Øf†8hY•µ«oÓŸ´v O/\²²òÀ¥ß~Ð£€×WU1¿<vH×3@t€áUUóm4ˆþÀuUÕËïñ[ÄxÌXRS6Þ“€˜ry_=ÿžZ~JOböð-_]qv …1g€È×ÖÔ-×ïÑ¿dÈõµµË*jG¾rÄ2Î f?´à¤úîe¡• Zð€¶Z÷§ÇpšZ×ÂN²ìyœÄtâ$Öâæ WØ¬E+€='Ñ„jgýõtoáÞC=ý™åÑó8ÉÞB";‹lèáB­Ø€cÔŠj¥6€Uc7{@ZXVkhÑf¢	§ôÓ Ná<€-ØœR’­eáØMèÀ£ÚÜŠýx/é‰pZ<X.aµ¶W»Q«Ä&¼„&ìÀ¶m¨ÓÁ8ÇÛ´ÁØýØ	`vò6þ¨Äƒ·ñ6þ9vˆ7Z¯™ÌÞR¸ía‡ÙPmÞb4`ÝNwÑ{lž¬¯ hÒ@óp'Þàm†Mf2šŒJ¶RŸ§>R?m…>íÅÃk. ¯Ñ %â%ìTûµ™|Ÿ¦ŸF%vb§úm²~NÑ7X‹‡4Á&êãišÐ OÁ£Ø 5 j(w¢|³õÁ^ìE:ßL[µ–£ÝˆZ%Û„&íN¡†
-0•ˆç±Ží7¼€¹
-u¼ðâ9Óà:iC|®}ZJQù>ÿÍ%¾WKÓ‡\uës™¾}˜±/l¥¯åÊ•%z?^º÷ßG)¶}zJò¹¿÷ð\úÉ3J|-,º° @¶p^AúÉÅ%û´yWPš˜˜>¤°@=“\÷ñ”}<¥hÞ>_Y•o£kcòÈ®Š‘éÐP%¶êU|7&†ÎdÌ{€ÙøZMGæñ3íCá:Ó~¦=+ÂèNIt'Véè¬£~‰­¦óë/–ƒ €¡íÊ‡º¡7 õ~X¨æ‰`³k¦#:a@B~|BŒ#$a€‰MìˆîÝy$¦Ñ­7¦´º·Œw„ègbz?ÃYdÞ¤Â®ŽãííçÝž¼¼¼¼¡pïhw‰//º¾¼è‰Îs{ò²&—˜.çgîè<Sý–&±È–œdDz£°é5’“RÓrXNöðÜa™ZË6<';ŠNMo.^Õpûs“6ln³øÀÏº÷þ/m…?ýÉ»¯ÝºGÏÛŸ‘qsñäIÉÎ¸«öJNnÍÍ-+]3TsØ²úgÿ‘(uewúZ½nL÷GfÁMÛœ­ö£¦Ã0`ó¸ÎoÏŠÌóíg^wç¹ó²ü).¸˜ËíƒùÜYÈb9®,·~6ÎåwÏÀ6Ã5Ãí™Ë,%ÜÉîœÈ›XNvT´¾vÔ½EO8x0ã…µw§•×¿óz×[ú¼÷V¬NºÎÂþØ•õ½±ÈôÇ…n
-;âÂ¦Ø#Qäj´·Òö¸O(Œñq®ŽãÙíA4;$šY)N–ìƒÛ…Äì¨èns²‡ÐS&ýÛLÑ)Þc)L¿yÇ´¢-sÿýùCOÏ{tlÞàÁìæe^vÃõC^;òƒß¾qnÔMRŽÊ+ùúÞBŒ?DÃz%@K ]yÐP¸:Žg±–L+[;/¾ÀÛþV®|¨OÔ‚h$û#ŒFC[=ÛcìžðòDÞãêhïŠ}1‹%Ì–š–íq»´ä$ÍíòhU>Ø¸ùÁ7_øêÒ'.]¢³ï¾ÝöÞ{mo¿»S¼)þKœo±t&#CaèýôD`ˆ?Æî$3Ý­¡GL30)Ìn„Œ÷º:Ú³%ïÌÑç;ÚÝÑyyYÌì–Ú×Fz¿ƒwÞuß¦––¡OÖýò)í@×$íÀ¶?÷Ë®ôyOÎ+;§l´ÐmüqD`¨?ÆÉmát nvÔvÀa±k:—Çéu}¼sôñléô™í£·g»ÓÄÈD·7j‹LNJÍu'æ&ºµJ¶KÜqGýçÞØ+ÚØ`þ¸8ÚÔÕüý[öœÔæ5±›ÀÐèc Âê°ƒB_¢œFÈ»Óu¦½óu‹Wg»bÔ‡‡¶ú¶Òß]øÅ¯ÅïÙY¶õû?Øyæ(ýíA0TzÞ€$üÜŸã	·ë&âûfdh£Zûu™p‡Û¦ÓÜSÃ§õ™W˜ìê˜¼/tÖä}îY·•DÜ•#7”vŽî”|=R€Ñ£ÏwŒ–ÚºóòÜÑyYþ	YzÏ2²Ì,[–=Ë‘2&jLô˜˜1±câÆôÓLü˜„5´F_Ã×kÌ5¶5ö5Ž5!MQMÑM1M±MqMýšú7Å7%$³¹L)–õ2ÜÕÔv'-šô@Í“¹ãgŒz2oRQÞO$–™RA'žg»Vh÷}V×ðQ×jí¾ÏkåUŸ7oô˜ñ€††+êÃú#ËÇáktzmÛ­ì1ŠÖahÜž‰ñÊ³eZhWžl6Çœëd–çdG± k''tkKKÆöò“>y­b‡_¿nÝ¦MëÖ­§ÓÚ¸¿µo.žÃF±Hæf#æˆ·ß}ÿLÛ{ïå)Ñ‰þ(ô§"Š˜c“}³u€aìÅØÆˆÖ°íñ¤õwÙ£õ÷¸²—éÖŠ³ó®‹®‹®Ž‹™»Xdb 'D³EN¶ÇTÉÂÔK:?|á™’#Õ‹ŽÝ&.‹w™ïó·¿jÑZ¿îi—vÇ­Æs¯Þ÷ÜàÁ,E°Pæ|i×Sûv‚aÓ•õIüs¤áGþU½HIŒ”òUµ`‘¿ò>³ÍÍ~…'ôm)[ÝÛ&XÅ"µ_žs¨×ÌKÊèêl?~U±ø^º(ý¨W¡°.¥IÏÚ4Ææú&Lfjdjl.æ^]>ôÞå#5“Éúq¬·¼£iOõ#w¾yD|Ý¹èÌâºSUÛ÷Ö?´ä·‡YØÙÙ­|×©Q£×ÝUV•3ôÍ_·}žþ»¢‚µwûb3[›_ýï4hh³õYzƒò™ÿnŸiungÇèh¼Û2AyÎxi™l•‚\çÏw»MJ·çZù/•Y­¬ÄV<(ÝæÏ¿V¹}þÀºû7n¼Ý›»NŽ¦â9âeñ‰ø‹81‡}ùö»ïµyÿ]«†Lôuú<„à)ÿDm˜†Mº)/\g£hMc!Ñ`pDÛL^B¦Í´GÛlf¾ÃÔ™nÃQ®FZ‘Í(uuï<îŽV~>;hþ™é²¾rÜ÷¾4éYÓÁ0×Ÿ`g†YÉ™w³•¦a2Ó4‘Ž‘ú0Ç­úl‡m.›k×’í,ÙÎrìL¿CÔ°–6Ñ"¶±Qó:ÄÒôy]wµ°Åm¢#³G,]!âõÓ¢„ð_£…éÐ2_W}Žôõ\ýôåLQ=c†ZËöŠ/¨Þð üáÆN<æ3A1™?³eÞ
-Wg{3´H¯':9UËæAõëÖ®]×¼íá‡·žóbÔŸ>#ÿt‘ûà,;Þ†Ü¥¯Ô· i~/~fgÍüg&…jq:úÛâF¨ëÌèöÎÑªÿRƒ@H¶²ÿaö1îIQÀë[DÁ^9ØËƒá çmp Õï¥mº¶¯7±ÍnK6É,ÄuF†‹LCÙ²±KItóÜ”Iœ9ÙHñ›ñÞùê^½~JË¤oÚöZ8Ü.¾ ´ ¦ÄÁd!6Äèž§ëL§*Tr¢<‘^ÍLîÉ¦±ÛÍëÖ®5<íbôÙsbtûÇìåÏ³—e¾*aóô•´Kõ ýü¡z³¡5ÃÆ™›¬†ÙÝý§T>12±DO¼|V~µÐ§µ|)œÆfÒ^Z­úñ~'gt¬·A×]·¹Î´¿¯šÑíÙª|Ë­~æô3¼­«M,¿`l‹8§}Á2ÁeïB?Ç.ƒtCr=¨X$%G°K/í(c™oˆûØêžþ«Ÿ~ÇU½Äv;*ûˆIšÕKtZ]av —ˆpç¸­|ß]Rµ,®ýáÆƒ‡>u×ÓO²'e3![	måå]OÎ/—­„ì™ }&oƒnôGÛìë±-Ü@¸Ý¤ìÐ¡f‚+ËãRµÕJ‰™ííY)¾ánWjb²;B¥ðAÌÍöãÊk'®`^9›Í
-Äa±WœÞs™Md“/_^Á3ÅÃbø¡xDm4¬»ò¡ž¬ú´AXê¿Þa"Înâ@ŒÙèIÜä{!¾ñ:Ù·…±=Öé0B|ºyÓõ®éoÙ–d?ßÑ)Ó˜Ldî<jæýñY²|Y‰YIÍhfÍZ³£9dWTstsLslsœsn¯®4wD¨ÜaÃG±\«åZ­rÓZoüÙÏï]òè3ìàÁQ¿ZóË×/ÿõ+vÿ–;ŽÜVy¨dÓK7¦ú´œ»j+jßz~Ð”®ûö”ïÅ]‡ŽÆß¿rø°–´´™3³·Xø>è†v„!Ãk;€ÐãŽÇpÔÐè4%„|
-&;L§ëÌèóVŒf¶gŸïTí©rÒÜDw"Ë‰Lf`¿cÕKYµ8Ç´´èó:3›š(_wAúM9 Wëó` Â?ˆ¢u®kÑLãòBšƒEF¾F8ÊNãz
-MWG»Ê¨ç³¯™OK“žMÓdþtÊg#›®s-EÓæ²¹9vÙ—¿À
-ÙøÄ²Ïôy³èéËÍ`hôg/Bð’¤-Únã7£ƒÛ£I³E›6Òx´Á5Òôh"-ßÆ5¢£xÌaØ¸N†FdÆooÏdüöóWe|Ûg¦Þïe!6e!žih6[”Ãcl¹Ú0>Ü6^«Ôêµ»y¨l¶XŠÖcx¬gÆØRhŽ¢QúžgŽ°M¢"³Ô(5Ó"}‘±È\I÷ð•ÆJ³ÿ\ÌÈqËºÌLwr{+ûð1‰sbÁ†VÃÛÙÀN‹[»Ækù÷‰1Ðä{½†·ACòýX…(,bnãŒÖÛY¨	6Ý½Îéêì<£ZUi9
-žGõ¦‹Ÿ(M²³DÊqçDÊD“˜«ƒØï?yå•]ðøÎOéTgÎn±“•¿ óê@ûˆÁu »4y\’•ÅrÜÉìBg'*Þ@÷™Åð~ëÌòØµÏ,í×<³¸ÿÁ™ÅðvíV‡‹_šâ7ÌÇ],ÔvÀ`xÌiuh&ìÜé{j9Ÿ-ã Û#ùF&'ñ¬»jÉ¸žvºl*»O¬n‘‡–§~ex·ß¼°¬©3“N7Mk‘¯´@Øèwò›7ú“c±ÍaßæYÏ¶9þs€;$v@„Mãp&DñìþCíHðd%º:¥Úg”Æ*å©&PµØVCMÁAJbvT¤×0U›7ˆ±»þ²oëãOþåÓŸ¬½ïa1‰=ÿÑ×k×nyB\ãµ]hØü“Z¥¸©vÕ]å{^þõ†Ç½Qo4Ÿ|Ub¶~Ÿ>4ûÃ¢aiŽÍ*#ÄíÇî‚¼¸]aÎ°ðh§3,ß§½Ñ<ævp»ÂÃd'ê±yŠœ…2Yªèq©*‘—çù»=“jiUÝà‘a§»îvi6·Í–êL¿Á]ä.ò”†9dk˜šédƒY®L£22rèÖŒ	eIo¸úæÛ'ˆéÇØ6á«ªA|=rÚ´w×§u>LK¬'kÎ	Þ†ló'ÚR¬übp+` 0;K@V¨´†ëH ¿ž¸×¥ÀSLÅ£m©<Õ6\¯Ý¢Í±•ØËµ{ùJ[ƒÝ©ÓMC3å¢4>Äl¦ÚFRM0&˜·Ñ^b”˜sl‹é^ºÇŒ¾*â7œÔV|ÖuH›Ý!bwœäm]UÚ£]wnÖÚwwÉ7É^”ç$•ïÔ¹-&ÔNáöÆÈíá­ý‹…Ç3!&Ô0âzuà½Ïm½ûí^}xZd²;‡¶®·zîõ]y¬òµ/œ,ßžÑÒ¢eníž™%â„ø‹øT¼4§x³|…¨aƒ˜©ÐW(yrüý»åißÞïXìÑx%Íx<7õœ${Ÿ	zŸY¯et®Ì"SX·nÃ†uëÐâÒ·Wœ¸ðñkåÛ3ÔK‘ÚÞ{·kcq)ÁÜ,ŠœSÜô·KVŸíŽ–ý¿=õÊ÷ÂG‰6é	x¿ôúï¯—×w1Þj	ÀM=VûÌjè§/¯¿âå­ŠRï?¦ŸFÚØ8†JùfkÑŒj4 ›Ð*Ï"l/Jp‰Ý.ßš³™lŽaÖáY”£•ìŽáö 
-ð¢ôM¤b'Î³,Ÿý€`Ÿkýµ]Ú'tÖýûúOôVýÅóy>/ç÷óÝü}#Êh4Ž˜†ù#ó¨ùŽÍe›bk¶GÙ`ÙáR§i¡ŒÅ0 Á…í°|sƒCWÿ¢±¦Ûõnß3øÐk°á1õš×{9bð§ÀØ@ˆÀØ†$‡`$‡E¤²»c'ª¼;15¨ÅJ,Ã",D–Ã‡(Ã ø,d!>,ÀJøEXŽ:,Ç2T`>ª1>a)ÊÆb	–À‡™Ý´êÔ]êPe¸(G(@îÄ|ÌF=|(Cæc)ª•>ÌWô}X„¥ð¡õX€%X„2øPŽTc¾zv5bEER˜Š,EòQƒ,ÆlÅ¿‹Ô¼Ô,9Ñgpwpo_Ú•jÖÒhy@{©árÔb$2‘‰òÀú»QÔ¡õX†2T¨½Ë”vXŠ
-,Çø^Ô‚ÚQÿ6Êò™DP®Z€
-,AV`Âüÿ’Ò&Žkr¶›_™¿í5¤ÿÉýÂ}ÿ@çE¥ÍåŒ´±ÄlÃ‡TþCY¤f3½jE­Ç-ÚUêYE@¯…Š‹DYÊ'éTª§ÝÜ,[Þ$Ÿ/G’p©Ú_ðs‹C`yÀÂò»0 KY é ÍåJŠ¾>>ej]5jÔƒäjKvË“*TÔXœÔËK’”åäÞru•º× ‹0? Ÿåƒe¨Gµ¢"e]ÞO%aIÀvËØÃAÆ»”9Vü\rìÁDÎÔbjPŽz%g4åJi±EX€z%OŸƒ¤.q(ÃÔ+*&+”T©˜_@FÚ»¯FAú=^×-m½ÂpH/ëÈ±Ä¥ÇÖ=ñ[‡*5s-=†të™©òŽOQ¶âÁ¢½(€j_ë·ÖAä,i-?³4ìëu=­PxTÿS‚ÑP©ræÒ€†–XÔ¤§HMj”4u
-‰;Q2EÏZÓÛ—²dÐBRs©Á¢n{Ôa¤ŠÎY]ó± 5*3ôØ w.êAàÛ™@ÖIWzY]ŸµÁX©½fè½Oj%cÛ²”Ìó}}ÍBÃÊäó¿Ãž’²•/¤í«Õµ'ü3¶XŽ•JÞJ•$íŒ>H}×^‰ÉÊnù%w‰¹Œå`F“²K?]Ö=cI*1j)íÙÛë‚õKr±ðªÇu×£‘Ü+‘]ðBKß…X¢´©
-Ì-ë•C¥v–$uÝ<®Æ§îêÔ;Ç•÷ñ0©éµ%ønIúò»—kÉh¡¸Tq’šüý¬nYIþJùªûÐÎÔu{f0n®®"|'%îá´BiU®ö']£.&uë}õ¹>Xu“zy›;S®ª3«6e•Þ°¤—%îF]±
-Ü£p¶¼w>jQ¨b2úeµ	îèmKæïŽiGùL^ë2J>ßå/–v×Êáòi½ZÕá¤ïìW’úØðÿ4feŽ]Ò]³{¢.Q²ƒ°bOÖ%«¾\MQî)ÃbÌWk$e«.J¯úvÿñÿ"cý}­¬NËBQÖÅÊn¤&¢Pñ™Ži˜¥øLÇxÌÂŒÅLõ¬Åðafb:f£(D²ËXõD>ORÑ8EŠâtÜ¢hY4fb¬¢]
-Ÿ¢-;Õiên2Š0jo!JB+ªÓ1SÑžŠ˜‚"ÅÓê1§a¦à¨ñÕZü¦aººÊõS•,–¤³0½×¾RIÊÅÝ’ME!fb&žŽE>Š=)¿ä?^§uË9> éX…‘¤,iŽÃ-˜¢îäì-˜‰˜Žb…§¤\všÒa<ft)TX–°$‡é˜Rµb&b–’BršX)ïg)}¤e¦*®“Õ¬%Ùô€•å¸‡Š<Hž–ÿÙÝœ‹•þS0Ea+õ-V
-1S»é}g‚¢ å¶Ð¸Eé'å+RJò™DQâ9¥{åÌ^V‘6«ì&%—û¥&‘âkj¤Ö×:×òŽ IKÚM"5E­.Æbœ¢dÍXþX¤tÀÖ¢iù½åÖZK&iŸiÊ²7ã–À
-‹ÞÕZX"åïÑÂ²ÀØÀï¸^˜õX_R”2å‘Þ,½ìÛ¨Èø“’ÈUÒä]écÒJ–äV¼X<‚v¼%àŸÁÈ›v¾Á8
-®ûgr‡E+È»¯%ž'KB+“Lû§èZ¹«÷¨¼W¨kußªÜ½»Çž®´wÿ9¤W®íÝ	XYx‚Z[}ÕºžY+?[5«çÌÓ»‡»Vå
-ž’‡\Õý»+w[g£ÞÝo¹êÓ­^°®»+±êGMwg"»«cžZäiPÖ—¾ç½:Å×ÒÌâõmZV)×YÜê®æwU¨«OˆR‰‘¤¼Bå»$«c˜¯ÖÈµrþÞ«NÅ–ÿ¼‚ºü#üålª¢²]¤–ýdF€î²îóY&ëíVõUVïñ>Imä·úP‰ÁÂ^’ËóÕcÈ¾Bòtüï×2Þ‹±™JF¹÷d¨.¼™Wu”òý¹ú»òn¼¹îû—`6nÁxx07cŽªD²zG1nC>Bà„¡êM-G8J†LA)¦!nUßSp;2dÎ;¨­a‘Ï><—íÏ"±Ä"±FýÿYbê×ˆ¹ÕØ¥~Ã±Äœjöì§øØ†U ŠA6ˆ9=»ZeƒÄL56Ô®Æºš'5£©æ/$u­¢NA—}“M;D_¯¢¯.5ò¯}uD¿ôe)¿ÔH—Öè_v¤ò/KéK¿Þ‘Jý"“ÿõú"“þ[Ðç‚þ’M½ôÙVjÿtoÔÞrå´ÿŠþéúäB9ÿd+](§ýùOýøŸý©}$èübúPÐ¢sÄòsßÐ±tv+ýQÐ½ÿ^$_Ð{‘ôîVúý;‘ü÷‚ÞÙÂß‰¤ß­¢·GRÛæÞ6’ÎzëMKÐ›:-è·‚ÞØèæoô§ÿE§½¾•NnJá'½&èÄ*zUÐ+‚^ôÒŽ0~\Ð1AG½(èÈæ~ÄK/„RëoñVA¿9<—ÿæýf~øP
-?<—ûõC)ô¼ ƒ[©¥i,NÐ¦±üÀ7ôëa|¿ _•Ó³åôŸNÚç¡ÿôŒðwÑ¿zZÐ/=´WÐSO:ùSÙô¤“žØãæO¤=núÅîtþ‹U´;~.h— Ÿ	jþi,o.§Ÿ>îâ?¥Ç]ôoÚ)è±aü1A;Âhû£|» G3h[ÓX¾m+m}äß*è‘‡çòGÑ#kô‡LáÏ¥‡ýúA?ôÐƒ)ü¡Cô`
-5mJáMcéÇ›Cø½´9„7¥ðÆrÚ´ÑÍ7¥ÐF7m´^Ð‚î_çæ÷Zç¦	Z+è‡î|þÃbºOÐš{hõVñÕ‚~°ŠV%Ð÷58é^A+Ý-¨~y(¯§úÿ»úòPZ~D¯óP__&è.Aµ‚j–óš­´´z _ZLÕi‰ ÅÙt§ EÙTõ-<D•‚*•*[ÀË-€‹/H ù‚æ	úž ;náw8in9Ýþ*Ývk¿ÍK·†P© /Í4[Ð-ýbù-Ù4KP± ™‚n^E3M÷Ò4ASY:Ÿ*hÊ!š<&ÅðI#¨hœ‡ÅÐÄÂ>QÐ„q>¡œÆÆðñ‡¨0†
-ÆyxÁ—ïæã<4®EóûízþØpžï¦ü~»>ÖïäcÃil;â·ëþ1¡Üï$[ã·ëcBí|L(ia~¹~“ Y:¿ñ-hÔ@)(ÏÏóÊé†¡qü†É4BÐðt/.(w2ËŠãÃ&SNVÏ”íÎçÙ‚†¦{ùÐ8ÊŠ£Ìt/ÏŒ¡{Ï8DéC"xº—Ò[4ÉvˆËÍ‡DÐ)îV}ðõ)|° ëíQüú¤äƒ”&(5œR¢òyJ!]NÉ‚’ÂÃy’ D_:O\E¾t0™Üù<AP¼ þýbyAýàâýb)NP¬ AÑQù<z<EE¦ó¨|Šôºxd:y]ð’ÇÏ=‚Ü,»óÉÎ]nrYØ…;Cyx8…[Ø9ÃÜJN»°P;sPXóï×Cí*}k„"ÈaâAö(²¹Èd°tnâ^"m$§oHcé\I.ÎÒ	.b-¬|Ýf6øÿŸ?üOð/þÅã}VX
+xœÝzxTÕ¹ö»ö·×Þ3“d23™\!!@È…„€”!$@¸KŠr!!‘S
+–"·ÐhAäØ”RDêñP´„FäbEô(J¬U[ä€U4Rx!Yœg­=“RÛçïÿ?çyþÌ3³×ì½öwy¿o}ß»ö@VQ¼tIü¥mf0€#€–QV5¯âNmÁ9@kðÔ¼…ËËÎØÐ£@øOÊKç”D÷oˆî	`PyyéÛAM¢§¸©¼bÉ}Þ[œ}èû L[XY<gÉM‹ ÑoÈïsî«âoè½˜> âÍ©(=×‡B€˜1@øO«*«—èéW€ôw ,­Z\Z5ä÷GM c2`ö@#N«÷>ö0Q kµ•Ð:^8ŽÓÐÔ¼Fvš­gÏã4ö §±_0ýžÆj4(ÒpõØ©î¬§PCGðNá=ÔÐG,‡žÇiöØ94b}§jÂz§&ÔR±^¬»ÙÓ jÑÈ*±R«E£6õxM?à5¬ÅZlÆnTâ5eÙjö0þ„g±­xT»„™xÏã¤ž §¥ƒ5ã
+Vjû´[µ2lÄIÔcv°ÕhFµæ€ÀyÞ¬õÃn<‹ æb'oæJ<x3oæŸc7€X£ÑðšIì-…Ûv„Ð&â-æ@-¦Ò]t/½ÇÖèIú2º„z4÷àuÞlxQo&¡Þ(cËõÙêU+ýÓ–é³Ù>\2¼æ\úµZNb§òxV›Â'ò‰ú”a'vªÏzëÓpá5ú«ñ°&Ø}G=jõñx» ôF%€JÊÆ=¨D-ßd½°ûÊ7ÑV­ÖBƒei·b§VÆ6¢^»‚×PIyŒ2ÄòËXÃž5¼€¹Õ¼ðâ9Óà:iýã]ûµä‚’ý¾Û‹â_ž‘Úÿº¯ñ.3~?&ïYßxíÚä"½Ÿ±Ÿ÷ÜOÉ¶ýzrÒù¿wñ|jÿq“‹âYd~ž_lþì¼Ôþã
+‹ökÉò[ÞŒ„„ÔþùyêšÔºŸ'ïçÉ³÷Ç—ÇopmH²ÁU:$ÊÅV½œïÁD¯#Ð™€Á¼™¯Öt¤Ÿ8Û2 ®³-g[2ÂÜ	îäwB¹Ž¶jêÑö¡Øj:¿þb±Ñ š¯]Ð½½Qãó…kÎ È^q6»f:"ãzÅåÆÆE9‚âzéáØÈŽêÞáG£êÜz]r“{{ŸXGP¯&&õ0œ¦áMÌïãj=ÑÒÖrÑíÉÉÉÉ ×ÅÖ—øò²ëËËžÈ·''c\a‘ér~æŽÌ1ÕçŒDžÆ’poD/ÇÂ½FRbJïì8–•9({`º–Æ²ÊÊŒ ×&5®¨½ë¹±ë7µ¼YxðžyG¦Þÿà—¶üŸÿìÝWfîÑsžMK»½pÜØ$gÌÎ{'%5egÏX5@söÚ¼òÿ‘ }e÷ új½nLò…fÁMÛœMöc¦Ã0`ó¸ÎžhÉ€ô‹­-g_uç¸s2|É.¸˜ËxïÎ@Ëre¸}ð±‘.Ÿ{2&³É®ÉnÏ,f9áNrg…ßÆ²2#"õÕCï/xêà¡Ci/¬Î[:ˆ–§ÝüÎ«íoé³ß[¶2ñ&ûã×.èÉz-¢‘î‹	ÞrÔ…ÑG#êÈUgo¢í1až`£b\­'2[h¶J43’,)n2#";ÌÊ4XOûoSD›x%3ýö6Ïú÷ç?5ûÑ9ýú±[˜—yÙ-7÷qÄÞxýüÐÛ¤e×rõÁ¼„(_†u:‹ƒGºÊ pµžÈ`Y,‰–7µ]~7Së¯]ÐÇèµB$’|aFuÁMžíQvOhyÂo‹rµ¶´Ì¾œÁfLééq»´¤DÍíòhåu=T·é¡‡6]úêÊ'—®\¡sï¾ÝüÞ{Ío¿»S¼)þKœo±T&“#Maè=ôZ„¡¿/Êî$3êÜMÁÇL306ÄnòºZ[2¥îôa[[Ü‘99Ìä˜Ò=FzC÷ÜûÀÆÆÆ{«ý¤v°}¬vpÛOŸûuûZ}öÞÙÅçUŒVº?Ž0ðE9¹-”ÂÍŽÙ:lAvM‡áò8½®³ÃN´;‘)“>½¥uØ‰–L·RšžàöFeáI‰)Ùî„ì·VÆv‰»ï®yýüëûD3ëÇÇêÛ~8wóžÓÚìzv ÝaôBR|avã`ðI:ÈÉÐa·;]g[Ú^µtµµ(EÝth+ïœñ‡K¿ú­ø#;Ç¶þðG;Ï£oC WêµHÄ/}½£<¡vÝDlÃ®‹§¦Ç¢]&Ü¡¶	ÆD÷„Ð‰=£&Ää'¹ZÇíž:n¿{êE‡síè-3Ú†µI½iÀ°a[‡IoÝ99îÈœßè=ƒgf†-ÃžáÈ1<rxÔðèá1Ã{ï9<vxÜ*Z¥¯â«ŒUæ*Û*û*Çª úˆúÈú¨úèú˜úõ=ëcëã’Ø,¦‚Íºîúj»ç][¹7{Ôä¡{sÆä<ñDBñðñ¥tyLþq®}™öÀgÕµ¶¯Ôø¼JõÙ³‡h¨½vA÷^¸Ð¾oLÓ[gÛîlbQ¤Cíö‰Uiœ)ËB‹Êd+°Yî¤l'³R8+3‚R;)Ñ ™iÛKN_úä•Ò"tÝš57®Y³ŽÎh#¿iÙT8eáÌÍOAo¿ûþÙæ÷ÞØS¤×"=‘ïKA1ÇFû&#â 3êBØ‹ÑuaM!ÛcIëé²G(èéqùm;!Ë­µÎ.º.».»Z/{díbá	þš¨Y™SS/j»ðÂÓEG+æ¿S\ï²øÏßþªQxÝš§\ÚÝ3ç^¾%ç¹~ýXcÁÌ'þ|r×“ûw‚aãµúXþ9zã'¾[U¿HŽó7Œä^½ârU·`áÏxŸˆÚæfÏà	}[òV÷ö>qV³Hé‘ãà5s3ú¸ÚZN\×,$¾W.Ë<êÒ(¬ÃŒÄ6±Y>‡	“™™›…Y×·½kûHIg²Ü$ûGë]‡î®ßSñÈ=o_·Í?» úµòíûj^øÆrnZßõÚÐakî-.OŠðæo›?HMýCAÞúÚª¥ñÑéM/ÿwohhÓô©z­Ê™,_ÏŽœirngÇéX¬Û4ZeÎ(™LU‚\/v¤MrGæZõ/…Y	­¢Ä–:$Óæ£_)ÛÎ>_»æÁ\³vSû)ÃQ_8]¼$>§¦³/ß~÷½æ³ï¿kõñ€¾FŸ <éÃ#ÓÐ#I7åëLc©i,(ŽH»ƒÉCÃ´™öH›ÍÌu˜:Óm8Æ5ÿH+°ùÁ®Öm'Ü‘j_Ì„ƒfºlþ·wÿ>#ñ€é`˜å‹³3Ã,cóÍ¥l¹i˜Ì4G¸cˆ>Ð1SŸæ°Íb³ìZ’%ÙY–éw‹JÖØ,Å¡fÖ(*_e}Yo}vûÇíìE1\£E‰ìËWˆXýŒ¨ !ô·hd:´ôWÏ‘¹ž­Ÿ¹š.*&OVsÙ>ñÕ„ —/ÔØ‰Çœ!&Èc Ê!ëg¦¬›àjkÉ`†îõD&¥hÙ=ƒ©fÍêÕk¶mÙ²Íð\Cÿò¡ò—ËìøçØ‰0á^}¹¾AèíóâvÖÀaR°££§-Æa»Îki¦ø—ø»@’Uý°ß‰‘{E;¢oyûä`;†+€>Š7ÃŸ—¶éÚ6¾ÎÄ6»-Éˆ#$± ×Y¹\dÊl•Ä.9ÁÍ³“³¤pædCÄÓlò+lPÛËûôšñc¿mÞgáp—ø‚zp0%&²!J÷9]gÛT£òãá	÷jfÒ Oö@Ý¥0hX³zµáiÃÎÃZ>f/]¸È^’õªˆÍÖ—Ó.ÅA{ø‚õCk€36Ù3;ø§t>!<¡HO¸zN¾µà§´\iœÆ¦Ð>Z©x‡‰XŸ“³õ:ÖÙ k†®Û\g[ÞWäcXK¦jßòE+Ÿ>ó4onoÖúÉ7Û,Îk_°tpÉ]è—ØeÎbaHí¯§¤0v¥íäŽb–þºx€­ìä_=ô»¯ãÛìX°äc5ŠK´Y¬0ÓÏ%ÂÜYn«Þw´”ãª~¼áÐ¡OÞûÔ^¶W’	I%´åWwíS"©„äL€>…7Ã7úøÂmöuØj ÔnRfð 3Î•áq©Þj•Äô–Ö–ŒäøAnWJB’;L•ð¾ÌÍžÅµWN]Ãì6å‰#bŸ8³ç*ÃÆ]½ºŒ§‹-b•ø±xDnm4¬¹vAOR<­/ùnv˜ˆ‰Ž
+5q0Ê¬ó$lŒ!¶î&ÉÛBX”ítÁyñº~ÛÍ®V™o™V~¤Ÿ¸ØÚ&Ë˜,dî"ó¾ØŒ^ñ	‰h`Zƒ£!hWDCdCTCtCŒsVVš=8 TöÀACY¶Õ„²-ªÇ´¦[ñËû>ú4;thè3«~ýêÕ¿}ÅÜ|÷Ñ;Ëm<ykJ¼–uoUiÕ[Ï÷ßþÀž’¼¸ëð±Ø—ØØ»÷”)™›-| zžá…!HóEÛ"ø„ã13´ƒ:bqÓé:;ì¢µFÓ[2/¶)zª’4;ÁÀ²Â“ØXEÛ"V!Î³^úì¶ôúzÊÕF^’ySèúl(õõ¥HëZ$Ó¸<fÀ`‘€‘«Žqƒ“Æ¸^€|ÓÕÚ¢*êÅÌÖÓ‰zk²~:eƒ³‘M×¹–¬i³Ø¬°,»äß%/°|6ê±ø3}vÛTzêjZ ý€áENú†Ø"í6np3Ò0¸=’4[¤i#G\#M$Òrm\#:†Ç†ëdØ™aäAVü––LÅo¹x]Å·}fêõ^6bS6â)†f³EhQ<Ê–­äƒl£´2­F[Êƒíd³ES¤Å£3ÊÖ‡zó>æPªæ9æ`ÛX*0g3Ì4_ŸoÌ7—Ó}|¹±Üì9³Â²Ü²/$1ÓÔÒÄ.| F3q^Ì]ßdxÛjÙ1³}”–û€M>×Ñ+y34„ ××‹…PˆBrAAæ6Îh;gÓÐà›œ®¶¶³ŠªÊÈQ`?ªŸ2]üÔŒD;K ,wV¸,4	ÙÚ9Ñ—ý!á“ßÿþTûZÛö)½Ö–µ[ìd%/Èºz	Ð>d@pÄ.ÅBn—dFe°,w»ÔÖÆˆ×Ñ±g1¼ßÙ³<vã=KË÷,î°g1¼í»Õ¦…á4 »ô¹°£È×“"M›i‹Ôdìâä6‚Î
+`ä;ä~Ý¿Àe©éˆ¹ÊÆ[l2Êáƒè[>µM§"[)Ýc«¡ûmŽYa	áL.–pRÛWh«Ûk«ÛÑçîm{ë>J¶ê˜¢÷Ò—!ÈâKQÁvªµ×…7…nïq<úXlT°aÄŒ†Çs['ËîÊ—º²jÖ…mGfK„Ç¯]³fýú5kÖj1©ÛKO]úø•’íi‡iý$?j~ïÝö…3Ø`æflÈôÂúo®¨X\ô"Þ;nò…²ÏbþgLŠÃ@‡«­%³í„ˆërGûr']¢Êö»´ÒöÇNóæ}bÌ¾öÁÊÇ%oWëOí#:|ÜÚÔã±hx<£•—]a×}DWþ×…öOrgÑÖu\×~¡ÿce¯||étÉö´ÆF-ÝO µû¦‰Sâ¯âSqrzá&ùHËâçøçˆFš/&úˆØF!Ïpm³o•2ƒ1ÀÈˆ‘n¶t%Ý7x¤`¡=h°>`Â®;Åyqœg±wîš0vß´“'Nœ,z² »o_¶•U±El{ß¾¯ßêoˆ×ÄŠ7|·vä}o•÷}1ÜÅ‚mV‡ÇœÆ1‡fÂÎÐ î»ç‹™²gz$:áI‰F,ë`OòIÞûLñö€XÙ(7ÏO>cx·ß>¯¸¾-ÎÔOl”VAØè÷úûl<nõ%Ec›Ã¾Í³Žmsü¦—;(ºW˜MãpÆEðÌžìˆód$¨¸·œU+O­…‹ÚêY)HArBfD¸×0Õv£/c÷þuÿÖÇ÷þõÓŸ­~`‹ËžÿðëÕ«7?!®ˆoÄ(íTûŸj7ýl½V&n«ZqoÉž—~»þqoÄë§_C¹˜¦? Ï†¾üHgˆFš#H³ËJíŽôÀãŠuAÜ®gHh¤Ó’ë
+Ó^gw;…¹]¡!rGä±y
+œùa²i«*îRl%'Çów¹»ÚZ©r~‹G.ôÝµÔ¥ÙÜ6OtptHŠ3%ôw»À3#Ä!÷Y†©™NÖeËŒ:‹f¦.NLÛp×–ŠÛï-&gãÙèã¬¼æñõ‰wÜ}BŸØ¶…Z\KrŸS¼AØæK°%[}*ÙàVCÂ³þ~Äì,Á2®£þvØ€tö]<Þä<Ò–ÂSlƒ´QÚÚt[‘½D»Ÿ/·ÕÚ1Ýä04SNêÍûýÌÛ* ÑÆhóNšÎ‹Œ"sºmÝO÷™‘×užõ§µeŸµÖ¦µŠè§ys{¹öhûãm›´–ÝíÖ^ÚÝ“¶|ôáB‡}‰^6é%ÞŸqóÇ«ëÚo²`ƒ¦.«ûÌ
+èg®®»æåMJR×?¦ŸA9šÙ=8Ž2ùëV£¨E-6¢Iî÷Ø>á
+»Kþ2Á¦°Í8ŽõXƒ(AÊØ%õËÆz\Â‹ØˆãØƒr‰>€ìÄEÖ‡å²±ƒìs­§¶Kû„n£#º¡ÿPÿ™Þ¤Â#x.Ïå%üA¾›¿oDuÆQÓ0b3ß±¹lSmÛ^²;íSíÙ/:f:Žù±¸YF?,€.l‡àÓ™ºúiL·ê÷kÌ&ÿXƒö©Ëy½Ë˜#
+ñô„ðmHd1þq†°aþqHX
+[ê;QîÝ‰‘¨D–c1æcÊ±ñèƒbôE<2‘d!s±ñÈÅ|,A5–`1J1èx`Š‘†xŒÀB,D<¦tÈªVßJQR,ÆR”¢ip ¥¸s05ˆG1Ê1‹0OÍŒÇ%?ó±ñ¨Bæb!æ£ñ(A%*0G]»^N¡’"%L@%¡¹¨D%`šÒ_ùê¼ô,YÜíþÀÝ{»Ë.Sg-–ø½—.A† é(ñÏ_Š¤¡•¨Áb£TÝ»Xy—†E(ÅŒê"-àm õï¢,¯Iå¬¹(ÅBTbú*Ìÿï )câ¸¡f¹9ˆïfów³ÆÔá%µÿodbü?ðy¾EsyFÆXb¶J”ýC[¤g“•¼
+%­3-ÙåêZ©ß¯yJ‹DYÚ'å”©«¥Ú¬[Ù$¯/A¥²p‘º¿ÊŸç–†JÌÅ„å{žß—b?Ò™K”Ýs|ŠÕ¼
+Tù¥$ÈÙ–íV&•ªUcepb—,IT‘“÷–¨£ô½Å˜9~ÿ¬,F*”ië’|Ê0ýyÜ§ÃÆNr½Kû—`™?Ï¥ÆNLä™*,F%JP£ìì´¦Dy #6sQ£ìéÄáïkÒ%ÅXˆ%ÅÂd™Êrµæ—ø‘‘ñîîQ@~g†WwX[£0ìß%:r,qéŒuçú­F¹:s#?úwø™®êN¼’l­Kö|?ªÝ£ÿý^³¬µòÌò°{Öuz´LáQñOi¬†2U3ù=´rÄ’&3EzR©¬©VHÜƒR+yÖœ®y¼Ð_%’žKæwÄ£CÔêœê¿kæ¢RU†Ît­E|·È~!åÊ,«î67°VªnXºÞ'½’kÛŠ”¬óÝsÍBÃªäs¾'žR²U/dì+Ô±³~ü3±X‚åÊÞ2U¤ì´nH}ß½“åöKís¹–MÚ.ótqÇËR‰iÀKÏ®Yè_R‹…WªoÉ{%²óüYhù;•7åþs‹»ÔPéeIu‡Žëñ©þ‡>u­q%Ý2Lzzc¾ß’îú®ÇåF6Z(.Rš¤'¿ª[Q’ŸÒ¾Šnrgª;23°n®ï"¥þz'-îÔ´LyU¢îO¼A_Lìðûú;äü@×Mì’mÖÚ]Ÿ‘¸X½)`«Ì†…]"±•˜ÄJqŸÂÙÊÞ9¨B•¿‹ÉÕ/»MàŽ®ñ·lþþ#ã(¯ÉcµßF©çûòÅòîF5\^­Q³º#œø½|%±[ÿO×¬¬±;zvçª¬(É ¬µ'û’Õ_®—(ï)ÆÌQs¤d«/Ê¬ú.ÿøQ±þ¾WÓ²P”}±¬©1ÈWz&a"¦*=“0
+S1#0E]+@!â1S0	ÓP€<ä#OÅe„º"¯'ªÕ8Jâ$Ü¡dY2¦`„’=ñJ¶dªÕ·q(ÀDä©{óQ¤tä£PI„)JöLÆx(Çœˆ‘;§Æ£µôMÄ$u”ó'([,K§bR­Ý­’’;,›€|LÁHŒñ_\(yÒ~©”Oì°s”ßÒ
+#)YÊ‰;0^}“gïÀLÆ$*<¥ä<¿µ•£0ÅïK¾²ÀŠ„eÑHLÂdÌP3Fc¦*+¤¦©þ™òûTåŒÌ¥uœ:kY6Ée9î”"÷R§e‡ÄZ‡æBåÿxŒWØJ•†|ŒÀ„¹Ü­$H»-4îPþIû
+”‡R†¼&Q”xŽï˜9¥KTdLG¨¸IËåýÒ‰Há=	HëeG@ƒ”%ã&‘¯fb2ò1RI²ÎXùX |éÇÖ’iå½•Ö\Ë&Ÿ‰*²·ãÿKÞõ^X+DÚßé…þÏ‘]0ëŒ¾”(mØ#³YfÙwQ‘ëOZ"gÉ,ß(È“Q²,·Ö‹¥#Ç;üùXy¯Ã7°Žóþ™ÚaÉ
+èîA‰§ÄÉ²Ðª$ÿ)¹VíÊÇ}ªîUùûZõw:wWöØÉJ»òÏþ]jmW&`UáÑjnÅuó:ÏZõÙêY{ž®îF+°Kîû°«v[{£®ì·Dñt‹Vw°«Tv0Éþ-ÆØµÈÝ ì/Ý÷{ÕJ¯å™¥ë»²,~)çYÚªo€æ÷u¨ëwˆÒ‰‘”¼Lå³$‹1ÌQsä\yþþëvÅ–ÿ|¾ü#üåÙjÕE%¯–|2Í/wqÇþ¬‰€õt«âº¨wfŸ”6ä;<Tb0¯‹årgqÉ+¤NÇ¿ð|-]á½ ó‘®l”÷Þ‡4ÅÂ«~£”¿Y©¿kï`¦ÿém÷¿›åàãŒ‚Sp;¦«N$»Ç âNä"Nx¬žÔr„¢½‘‡ñ˜‰ˆ„ã0SÑùHA’qÒ€CÚ*~`Ë,>¢'ÇVÇ*õ¿ËÄÂÔ§s«±K}†bˆ9Õ8äÀ§£ùˆd‚ ŒdB&ˆ9”<»šeƒÄL56Ô®Æº:OêŒ¦Î0ßABPû
+jtUÐ·™ôÍaúz}u¥Ž%è«£ú•/gð+ute•þek
+ÿr}éÓ[Sèo_¤ó¿}K_¤Óú\Ð_3é²—>ÛJ-ŸŽæ-‚Z¯ñ]Ó?MŸ\*áŸl¥K%ô± þÒƒ$è/=èCAÐAÿu˜ÎÍÏKDÓ¹­ôgAôþ{áü}Aï…Ó»[éï„ó?
+zgS'œþ°‚ÞBÍ›‚xó:+è­7ü-Ao:èŒ 7½¾ÁÍ_ïIÿA¯	zu+Þ˜ÌOzEÐ©ô² ßzIÐÉ!ü„ ã‚Ž	zQÐÑMAü¨—^¦¦ßæM‚~wdÿÝaúÝ*ýÈád~dñé‡“éyA‡¶Rcýþœ ƒõ#øÁoé·;Bø³‚ž)¡%ô'í÷ÐzZøÚéß=%è×Ú'èÉ½Nþd&íuÒ{Üü‰>´ÇM¿ÚÊµ‚v§Ò/íôA?æ%ôóÇ]üçÑô¸‹þÍA;=¶#„?&hGm4oôhm«Á·m¥­æ[=²eä0=²JßòP2ß2‹¶øôÍ‚~&èá‡’ùÃ‡é¡dªß˜ÌëGÐO7ñŸziSÕmLæu%´qƒ›oL¦nZ/h µ‚\ãæ
+Zã¦ŸZ-èÇî\þãBz@ÐªûhåVð•‚~´‚VÄÑÕ:é~AË-T³$˜×„RM#ƒï]}I0-9ªW{¨Ú§/t¯ *A•‹
+yåVZTÑ‡/*¤Š>´PÐ‚LºGÐüL*ÿ–æ¦2A¥‚JÏãÅ‚æÂÅçÆÑA³ý@ÐÝ3ƒøÝNšUBw½LwÎâwzifÍTä¥é‚¦	º£G4¿#“¦
+*4EÐí+h² I^š(hKå?LãúÐØ‚(>v0Œôð‚(“ÅÇ=ÒÃG—Ð¨ü(>ê0åGQÞHÏL#sÝ|¤‡F6j>Ÿ]ÏÊsÝ”Û¨Ág×Gøœ|D(hdG}vÝ7<˜ûœäkd«|v}x°¦áÌç+Ñot+Kå·~KÃíCCå¸syN	Ý2 †ß2Ž”êåƒe£1|à8ÊÊˆáY‚2Ý¹<SÐ€T/C1”žêåéQ”fài‡)µOõRj£&Õöw¹yÿ0ê/ÍÝª÷»9™÷t³=‚ßœL}µ!¼¯ >‚zJ	¥äˆ\žœO7…R’ ÄÐPž((!>•'¬ øTê5ŽâÜ¹<NP¬ ž=¢yOA=àâ=¢)FP´ (A‘¹<rE„§òˆ\
+÷ºxx*y]ó’ÇË=‚Ü,•»sÉÊ]nrYØ…:ƒyh(…ZØ9CÜLN»`;qPH#ó=«Û)XæÖ`=HÃÁ‚ìds‘)È`©ÜÄ½DÚNß’ÆR¹6„\œ¥\ÄYÉšM¬ßÿ?øß6à_ü‹Åÿ ŠŸÆÊ
 endstream
 endobj
 
-259 0 obj
+266 0 obj
 <<
   /Type /Font
   /Subtype /Type0
-  /BaseFont /GIBJKH+NewCMMath-Regular-Identity-H
+  /BaseFont /FQCZUE+NewCMMath-Regular-Identity-H
   /Encoding /Identity-H
-  /DescendantFonts [260 0 R]
-  /ToUnicode 263 0 R
+  /DescendantFonts [267 0 R]
+  /ToUnicode 270 0 R
 >>
 endobj
 
-260 0 obj
+267 0 obj
 <<
   /Type /Font
   /Subtype /CIDFontType0
-  /BaseFont /GIBJKH+NewCMMath-Regular
+  /BaseFont /FQCZUE+NewCMMath-Regular
   /CIDSystemInfo <<
     /Registry (Adobe)
     /Ordering (Identity)
     /Supplement 0
   >>
-  /FontDescriptor 262 0 R
+  /FontDescriptor 269 0 R
   /DW 0
-  /W [0 0 280 1 1 659 2 2 778 3 3 389 4 4 572 5 5 278 6 6 490 7 7 469 8 8 389 9 9 681 10 10 485 11 11 622 13 13 444 14 14 500 15 15 394 16 16 278 17 17 556 18 18 500 19 19 444 20 20 681 21 22 597 23 23 389 24 26 500 27 27 278 28 28 500 29 29 833 30 30 529 31 33 500 34 34 458 35 35 828 36 36 581 37 37 651 38 38 648 39 39 579 40 40 451 41 41 458 42 42 298 43 43 557 44 44 530 45 45 878 46 46 440 47 47 546 48 48 715 49 49 640 50 51 778 52 52 643 53 53 500 54 54 339 55 55 528 56 56 500 57 57 332 58 58 569 59 59 500 60 60 750 61 61 392 62 62 556 63 63 539 64 64 849 65 65 675 66 67 875 68 68 500 69 70 523 71 71 570 72 72 572 73 73 970 75 75 477 76 76 278 77 77 438 78 79 569 80 80 1014.00006 81 81 681 82 82 544 83 83 1089 84 84 778 85 85 500 86 86 778 87 87 738 88 88 278 89 89 833 90 91 778 92 92 569 93 93 601 94 94 667 95 95 722 96 96 567 97 97 542 98 98 718 99 99 490 100 100 521 101 101 465 102 102 510.99997 103 103 554 104 105 736 106 106 872 107 107 778 108 108 569 109 109 778 110 110 361 111 111 437]
+  /W [0 0 280 1 1 750 2 2 595 3 3 778 4 4 440 5 5 778 6 6 833 7 7 361 8 8 759 9 9 659 10 10 389 11 11 572 12 12 278 13 13 490 14 14 469 15 15 389 16 16 681 17 17 485 18 18 622 20 20 444 21 21 500 22 22 394 23 23 278 24 24 556 25 25 500 26 26 444 27 27 681 28 29 597 30 30 389 31 33 500 34 34 278 35 35 500 36 36 833 37 37 529 38 40 500 41 41 458 42 42 828 43 43 581 44 44 651 45 45 648 46 46 579 47 47 451 48 48 458 49 49 298 50 50 557 51 51 530 52 52 878 53 53 546 54 54 715 55 55 640 56 56 778 57 57 643 58 58 500 59 59 339 60 60 528 61 61 500 62 62 332 63 63 569 64 64 500 65 65 750 66 66 392 67 67 556 68 68 539 69 69 849 70 70 675 71 72 875 73 73 500 74 75 523 76 76 570 77 77 572 78 78 970 80 80 477 81 81 278 82 82 438 83 84 569 85 85 1014.00006 86 86 681 87 87 544 88 88 1089 89 89 778 90 90 500 91 91 778 92 92 738 93 93 278 94 95 778 96 96 569 97 97 601 98 98 667 99 99 722 100 100 567 101 101 542 102 102 718 103 103 490 104 104 521 105 105 465 106 106 510.99997 107 107 554 108 109 736 110 110 872 111 111 778 112 112 569 113 113 778 114 114 437]
 >>
 endobj
 
-261 0 obj
+268 0 obj
 <<
-  /Length 12
+  /Length 13
   /Filter /FlateDecode
 >>
 stream
-xœûÿ  h¥ó
+xœûÿ<  wxÓ
 endstream
 endobj
 
-262 0 obj
+269 0 obj
 <<
   /Type /FontDescriptor
-  /FontName /GIBJKH+NewCMMath-Regular
+  /FontName /FQCZUE+NewCMMath-Regular
   /Flags 131076
   /FontBBox [-401 -1245 1140 1745]
   /ItalicAngle 0
@@ -3289,14 +3359,14 @@ endobj
   /Descent -194
   /CapHeight 683
   /StemV 95.4
-  /CIDSet 261 0 R
-  /FontFile3 264 0 R
+  /CIDSet 268 0 R
+  /FontFile3 271 0 R
 >>
 endobj
 
-263 0 obj
+270 0 obj
 <<
-  /Length 2382
+  /Length 2436
   /Type /CMap
   /WMode 0
 >>
@@ -3324,119 +3394,122 @@ end def
 <0000> <FFFF>
 endcodespacerange
 100 beginbfchar
-<0001> <D835DC99>
-<0002> <003D>
-<0003> <0028>
-<0004> <D835DC65>
-<0005> <002C>
-<0006> <D835DC66>
-<0007> <D835DF03>
-<0008> <0029>
-<0009> <D835DC96>
-<000A> <D835DC63>
-<000B> <D835DF14>
-<000C> <0307>
-<000D> <0063>
-<000E> <006F>
-<000F> <0073>
-<0010> <0069>
-<0011> <006E>
-<0012> <0031>
-<0013> <D835DEFF>
-<0014> <D835DC3F>
-<0015> <0028>
-<0016> <0029>
-<0017> <0074>
-<0018> <0061>
-<0019> <0032>
-<001A> <0030>
-<001B> <002E>
-<001C> <0035>
-<001D> <006D>
-<001E> <D835DC4E>
-<001F> <0033>
-<0020> <0034>
-<0021> <002F>
-<0022> <0028>
-<0023> <D835DC4B>
-<0024> <D835DC4C>
-<0025> <D835DF13>
-<0026> <D835DC65>
-<0027> <D835DC66>
-<0028> <D835DC5F>
-<0029> <0029>
-<002A> <D835DC59>
-<002B> <D835DC53>
-<002C> <D835DC5F>
-<002D> <D835DC5A>
-<002E> <D835DC3C>
-<002F> <D835DC67>
-<0030> <D835DC36>
-<0031> <D835DEFC>
-<0032> <002B>
-<0033> <2212>
-<0034> <D835DC39>
-<0035> <0036>
-<0036> <002C>
-<0037> <006B>
-<0038> <0067>
-<0039> <0020>
-<003A> <0032>
-<003B> <0038>
-<003C> <004E>
-<003D> <0072>
-<003E> <0064>
-<003F> <D835DC60>
-<0040> <D835DC3E>
-<0041> <D835DC62>
-<0042> <0028>
-<0043> <0029>
-<0044> <0037>
-<0045> <0028>
-<0046> <0029>
-<0047> <D835DF0B>
-<0048> <D835DC62>
-<0049> <D835DC40>
-<004A> <0308>
-<004B> <D835DC54>
-<004C> <22C5>
-<004D> <D835DF09>
-<004E> <0034>
-<004F> <0033>
-<0050> <D835DC5A>
-<0051> <0032>
-<0052> <D835DF03>
-<0053> <D835DC40>
-<0054> <002B>
-<0055> <0039>
-<0056> <00B1>
-<0057> <D835DC38>
-<0058> <007C>
-<0059> <0394>
-<005A> <003C>
-<005B> <2212>
-<005C> <0036>
-<005D> <D835DC91>
-<005E> <2208>
-<005F> <211D>
-<0060> <D835DC97>
-<0061> <D835DC92>
-<0062> <D835DF4E>
-<0063> <D835DC53>
-<0064> <D835DF49>
+<0001> <D835DC34>
+<0002> <D835DC51>
+<0003> <003D>
+<0004> <D835DC3C>
+<0005> <002B>
+<0006> <0394>
+<0007> <D835DC61>
+<0008> <D835DC35>
+<0009> <D835DC99>
+<000A> <0028>
+<000B> <D835DC65>
+<000C> <002C>
+<000D> <D835DC66>
+<000E> <D835DF03>
+<000F> <0029>
+<0010> <D835DC96>
+<0011> <D835DC63>
+<0012> <D835DF14>
+<0013> <0307>
+<0014> <0063>
+<0015> <006F>
+<0016> <0073>
+<0017> <0069>
+<0018> <006E>
+<0019> <0031>
+<001A> <D835DEFF>
+<001B> <D835DC3F>
+<001C> <0028>
+<001D> <0029>
+<001E> <0074>
+<001F> <0061>
+<0020> <0032>
+<0021> <0030>
+<0022> <002E>
+<0023> <0035>
+<0024> <006D>
+<0025> <D835DC4E>
+<0026> <0033>
+<0027> <0034>
+<0028> <002F>
+<0029> <0028>
+<002A> <D835DC4B>
+<002B> <D835DC4C>
+<002C> <D835DF13>
+<002D> <D835DC65>
+<002E> <D835DC66>
+<002F> <D835DC5F>
+<0030> <0029>
+<0031> <D835DC59>
+<0032> <D835DC53>
+<0033> <D835DC5F>
+<0034> <D835DC5A>
+<0035> <D835DC67>
+<0036> <D835DC36>
+<0037> <D835DEFC>
+<0038> <2212>
+<0039> <D835DC39>
+<003A> <0036>
+<003B> <002C>
+<003C> <006B>
+<003D> <0067>
+<003E> <0020>
+<003F> <0032>
+<0040> <0038>
+<0041> <004E>
+<0042> <0072>
+<0043> <0064>
+<0044> <D835DC60>
+<0045> <D835DC3E>
+<0046> <D835DC62>
+<0047> <0028>
+<0048> <0029>
+<0049> <0037>
+<004A> <0028>
+<004B> <0029>
+<004C> <D835DF0B>
+<004D> <D835DC62>
+<004E> <D835DC40>
+<004F> <0308>
+<0050> <D835DC54>
+<0051> <22C5>
+<0052> <D835DF09>
+<0053> <0034>
+<0054> <0033>
+<0055> <D835DC5A>
+<0056> <0032>
+<0057> <D835DF03>
+<0058> <D835DC40>
+<0059> <002B>
+<005A> <0039>
+<005B> <00B1>
+<005C> <D835DC38>
+<005D> <007C>
+<005E> <003C>
+<005F> <2212>
+<0060> <0036>
+<0061> <D835DC91>
+<0062> <2208>
+<0063> <211D>
+<0064> <D835DC97>
 endbfchar
-11 beginbfchar
-<0065> <D835DC67>
-<0066> <D835DC70>
-<0067> <D835DC86>
-<0068> <0028>
-<0069> <0029>
-<006A> <D835DC79>
-<006B> <2297>
-<006C> <0031>
-<006D> <00D7>
-<006E> <D835DC61>
-<006F> <D835DF0F>
+14 beginbfchar
+<0065> <D835DC92>
+<0066> <D835DF4E>
+<0067> <D835DC53>
+<0068> <D835DF49>
+<0069> <D835DC67>
+<006A> <D835DC70>
+<006B> <D835DC86>
+<006C> <0028>
+<006D> <0029>
+<006E> <D835DC79>
+<006F> <2297>
+<0070> <0031>
+<0071> <00D7>
+<0072> <D835DF0F>
 endbfchar
 endcmap
 CMapName currentdict /CMap defineresource pop
@@ -3447,80 +3520,85 @@ end
 endstream
 endobj
 
-264 0 obj
+271 0 obj
 <<
-  /Length 13455
+  /Length 13882
   /Filter /FlateDecode
   /Subtype /CIDFontType0C
 >>
 stream
-xœ›	|SeÖÿ[JÚG Q!ÜpAAQQ@A‘}§”î{›®é’¦Ù“_ö¤é¾¤M›6]¡”Ò²VVAFe\PP·Ÿ[ŸÎ¼ÿÏmÕq>ï¼ïûÿ¤Ÿ$Í½97÷É¹çœß÷œþZLîâW_ÌŠŸµ:&.;9RÆ¿º„»››‚ñnj°äÖ )0z?>ìŸÍSnŒŸ2ñ§)®	¦ß1‘¿Ï½}jPÐý×øü?ãïå6Œ¿/($88Tx>:mgÌËÑ1©Y	Yò™‹œöøì9óg=>ûñ9ÓžOÍJKMÈœ¶63-9-%!+!óÑi·®OÈœ–›&Kš–9M“™=-;5:F6-+>fÚÒukÖN[’–š5mEBTLjfÌ´Y³¦eÆÄL‹ÏÊJú±Ç²²ãM“Å=›–š•ùXòè>™ño›µdåkkg­xyñK¯­yéÑ¬¼¬i±i²iÑ1Y‘	É™	
-JªÄý(Îör‹«i*<þP¶Ó&¹uìÚ´ñ·8ÆßŠñãznõºí6[™Ý1~|Ï¸G…Íî°ÙŽñB‚‚ƒ‚‚‚ÒùEœdÌü¢M
-
-z†_“»ÃƒÒùCŒz7Xœ4æ‰1¹!¯„ì+û©`GèÜÐu¡Â$aï‘ÇˆŸüpË•[•·^·tœ{üÜñí˜ðÒ„Ÿ…¾‰¯Oüé¶Wo3Ýöõíß‡5LŠ?+~ÿŽ'î¨¿sá'}×Ž?=õ§SwÇÞÝq÷¹)íSNÍ’„K§J§IÝÓ›Ö=}útÿŒ¥÷¬ºwê½ê{¿¼ïµû:ïŸpû‰3WÎÔ=¸èÁˆ‡]|8ï‘ÊY·ÏR<*{´ÿ±×k™]>ûÀœ±sæÌY;çúãŸ˜1÷Þ¹mÞúäŸŸüø©ç…Í«ž÷|åü/ž¾±À´àÔ3÷?Sóc—„ƒê.nrWø.*dÁÜ$*\9 ºÈýÀ‰¬ï|M²±;rYïšÚÕ ,|)›˜XT	·´NØÊ[¾z¯uv¡FŽ$ä­UÅ‘6UPøZ\JtÈBn%]é*­é€xóãcS7¯?JrÝ{Ëk|‘GóŽÐðwèÄöŠB¨¤ÅÐ@¯H½8e'b ¯AêË¸»I'"¨<Ùè„¨+$¢‹q%òÈHvuf»¤³»å€THïê¡öÅÒïÅ•[)ùGh¨R¥R*Ý*t(4Ôãv{¤lýØÿq›%ÿ0B?e*1¬F«ÑrÏ¥%t+è\ò×0Ð¹çèÖ¿_²X,VXa×Ùu0Âh2šØ˜y3ØV°Eä©0°E7ØV:fžÅd1Y`‡Ý;&*½åWhä•roxËÕ×|ô§«k|¢Ÿ¹Fn¼øðë	’Uˆ__œ%;»®4äžÕL,+)¤.X-wÇÍ³¾Ô¢S…UHÎ_Ë¦¼-²SNDC>»·~Òœí*L‘e$m;˜Û'9‹®w­Ž²Ø®è“ ?£b_©
-©
-F½Q“8mif¢QÐ†x^Oé SŽ¦†«ïÂŽFÔ+ˆèç4]®™¤À“×,ñ¶ÕôH…ì#Ü¦/{Ch„Y|V¶;:1W––^—Ñ.)C¹­ÔmµXÌ `1¡ÏÇ¯LLT*a„hìz»ç£‹ô‰…±Hoï½^n^®ÛÞâ×\‹?ã9I—ŸÝ<Â)¸™âš"w¡¤ZU¡Q§NÖËIî‚íl™@_¸ã¥—±Ê>t£¿úÍŽ/ªöØ<¨#¢¿Ù—Ô½é‘XvŸŠ_8I)Ì{Uó×=­p¡H‚¬$C“5]¾[ñøé” »ÑQí÷+6oŽZŸ‘“ºEØnÍß]…rT”ÑOGJÝ¥å¨%t[IVbÁæM}±oJ~ÂO_ù©€\çÂ¶
-Xà$B6Eé¥ÚèopïYÚq6dÒ§ÜÎ >+§Òû˜”=Ê:™|VùŠN§Ðš%yùM16«7fÎ$,&´úLÝG=ç›tÝ‡p,Çj²“ˆ•ÛržŒY¿4fó$"§×Ðë8Þô7"dÉT1B÷Ðh1ï™‹fÐ­lÌe£Ùh6B:,‹ñïÏñž9wÄ3ç.a[ïYh40@g×ÙaÅl1Ó1—oð^¾ˆ?	êÜð¶½?§üH‹†î¦3ÅüÕ)QBÎh„Q+Ë]˜B¨KÑŒj[Uiñ~ÙpEàô—í‡õÉ(@¬JAV³<6K“j”Ë3£wnÄë0DN.ùß#¢J›¬NT“ã«ÚÖNßÄ¦äòF2`ÚiÈ`iœ(rUœ¦/&¢Èyk°,ôû‚hAŸmðPÛæãÚFt£¥¾¾‹øzÊù‹ŽWz¹YÞàÿá3¥'é+{C¸xŽˆ3ªä²ÌŒl	v­GYŸ[ž8ù“³[6fu–àhó…Àegµ½µ„÷«Y1ÿîW-?ìmhù—_¥käŒ(¶aaA_ôÓgŽÑ¿–«•ïqãsÃË4óìú#4o¯è÷GÄhÒyËµµU…b(´%%ªJ”ØÔN/»<ñÅ&…¡8köªÇžÁ$îR.÷—¶:[-n‹.Tê<E ¢oóP"ÓeÑu²>Å”š¸nKôZ¼†Œƒ8:kƒÝ[y²ëè®#V›ÅCo×YÞ´ÐtÚ«eËV”Äè¢§[^ýä4÷ízÓójgÄÛø;NSq+@<{Ë¢‡‡äÞ¹ÌÎÿÂâ†ÆŠ›³šRrÓdé­u~ŸDÈþ¬ôÑö«Ý¾ðŽËtÃÕÂ&Ñî	:N\Zƒd$øhS}¥8dý{éŸéSŸô‘ºqÚÔGDÜNƒ6
-’Q“ëoª«n}gÑîgÙí± v›ôÝLJ$ôOmt|©T8Céãf{ƒý—iëå.‰&Šé¤n²	ìö‡X0»‰ÿþ0½…NøáoT$™ç#ë²#²·G¤nÂDÔ§÷Ëúp
-]ØÁÆ¾æþú>ìÍnÚÑ´«C„,Néåž¬oß¿¥™Z}YûEWè0$Æ‘”Öâ²Ä¶hW¤kgY9Ž£³iÏg ¢ktìs,Éf• )‡½VúCX5œJ	Ÿ*Å}‰JoˆñïD!˜1Ë°ñUiÍÙm~í{EDtÁ«ÿ¤ ‹±1>j!žBÜ±¼Oå&[	ˆ¹”MË‡Æ#±Ãl®­µX`©©í‹Ügª¡aýo¿7Ÿœ àÉ¥â›áŸþüôYÑŠ;a/ëí»¥àB¢lšÉ‚·ÜÚÍRæÛ®Ä2	’é« Æ•¯å~ø·/VÂ³RáæÓJo8sŽÆœíãÚî„m€¦VB×„á3’»ŠªëVálÝ‘ö*Áè"›Îð]—f³”Õÿ~@•Ž5  X¦Ä>)]&Ú÷÷óGÏœö¬[-aEØK œ ×8“LÓßážº#6Çàé–rÇÃaÉ’¼ºü	$$‡Õá7‘áÊ°8CñIRrh§õsô Ÿ£Ó@x×ôrÃg‹ÚÃ÷žú¾ù»s¢¹C‰Q®.UX‰è@¬;²4*¨LjS‘¡P_¤R¨•Åš"U¡!yXXÞº†ìTEåÄ§lÚ‘°ºh•6Ç˜‹\ÄºjS›#2Žâ¼÷Mãßˆ»ÃÞ‰vT™*•ªœž´Îˆc+þ‚}p˜V»Ýír»íÄc/5{°ÏèOÚU@DÛL6“¨t;Ë‰ÕaqÀA˜px†4MzÞqÏ¬ÀN¤4v¨kôõð¢ÙÑâô—®;ÒÓK›u7±êuq51®H[9ùDø!CÁ`î—–¡;)Ä6ƒS%QÁ¤Ó$<ÁBÙó ³B‹`„Ö\b6˜á‚{¡wsÝw—Õó5H«µeJè¤l¦ÝehŠ‘«t£V
-Ô£ÚXct› €Þd0ö§áAI´QýH~ÉÈ~5R.*´f8ªÉ_h²Àæ B5]ú^×õñbØ6ƒ•- ·3B¿ÝM¨2t7%ôkº€ÞnµZl°Ã¥u¨a€Ád0±Ål2{’]$L6HŸd×éb6Ùj²š¬pÁá€‹?Æwï…pOÒÉâ‹ƒìIz-¦“fƒÙ 5´Z¨¡³è­º€ÝN	ûl÷¨ÅÝŒ°¯Ùv»Á`ÔCµCË/ŽÕl5ÓÅt2}’^äs±ÒÇÝHö†ÿýœÌGÿä] ŸÒÛÄÇdkÃžO‰‰]†¯ª%4@ï	„‰Þb÷Ð²PÑÓü”iêIö§¬%ŒM¼VÜ%9ï?†kÞü Mªo¾Úïo»¸å*}êÜŸ¨@Éå^•­	[%Ó*õûìº5½Ø×½{SÕùK¶¾œR—ßä¯©k’¢L×¾ÍÜÜyÀÓràXôãÒØ°†—+Rˆè ò¹ÙDàéoe§qý=µDT ´E5G€ÔŸªøXÊ‹*Yœ°}óÎÎƒ¼Ñ{™Îwá\¤7nü?xƒF|%ó‰npëèbY¨.EQR¨Q¿Œl¶7ˆ8:›JNâ{BCç|Ä„Lðüc¯9kugÙž&yS¼DÍ‡¦†·»ã+ì}ó±`Ó3k_%l-KŒÔŽ™„ÎÈöMöï¾L]—C¸ô‚é>ŠÛõùU‘X‰2v>š´D·ðœmÎžE{Ÿ¾{ dÖ÷}ÓvÎ~	!óÊÄxK•ËY²ÑxÝ'¿®<‰«838ë¬¥ã>pû@ÚqV^;³ta­y?»B×·d6¦¦ff¦¦6f¶´46¶H„3²ýtÌßè
-/½órøÁï¶hÞÑÏÜ:ºMLÇÍÿžI¶`GA\<¡Âê´íš6:ñÝ¯Ê»F
-¾3äª6ç.C¶9·Ö«­z>w”@] eÂäPWHœ°XmOU÷àÇ8ß6—¼*ÖMˆÇÊÌÈÌèØŒm /`õ‘ü¼ó{@D¿´Wûó}‰Eñšm>÷+¥äÇëT$Ò¼ã4æÜ¤)¢Cƒÿc0
-+ócŠ>Þ³ýýãÿÏÀ~à?ößë
-þ‹FK¸žó´ò|§£÷ˆy#)Io(ÊEþúN¤ÃÐ„:x-.Oñ~ÙE§	œ~X`Cuqi>2Q˜mÈ–w§6oa·°ÛØìþYo¼|IZ‡ƒ¶“ç]‘‰ûÑ‰††ª¶ê®òÓ aSé*1´F­IG6±ÆÂüˆµ;Ò°	Eo`7¶Ñ‰ýûº{ð*æCKxWø†Ð{›hØoúÂ{éØ'¤®.úIÄ)¹mt‘Ÿ¬¸tO=± Oš¿‹¿Ož8úðý‹V.Jôæµê¼-·¢P8p¶¼{ðF6æ Ø¸*#"eK‚AfR›2¨MJˆÒ‰jI_¨hXùI÷ÒÙ”%©Òx®:þD§.àÅ.Ò•^—š™T1ûÚË4XB…_}õ£”O¥ôO.;7˜9Ï—MóÅ¸-aupHT0@]LØÉá$ÓZ`® Î¨|^’“ºÇz½èÅì1@NØóFO—ôó°bf 5p·„3Žî¦gv‡p«†RGµ·
-AMØÿ\+0a€¼Ö†N»ÕEè¿¬˜-|¶!Bö ½óx'eWÄ°ñº›ÿr>U€®"tRèªO¨‚ŽÿrDzÛàÐÙµ¼=^z‹fã˜la“ÂÀ¶ÑqLAEóêÛ
-¯¾DH3G³àÐÕ¡¹bÀ£¤ ÑŒXÄXã …È…ÆnpšÜ¦€i(R*Ô*Âžd/<E·èÊpT×öÚJÍ¥fT£¬ìÄC$dxÕ*Ñòù°åÒ“p”¸³	½•µ±8–+ÐêL&­nóú­
-“
-È ,G+Ú­tc·¡ÄQ†ºÒb3¤*s²~TUV••“iÐ—û©íE¨óò£õJ“Ê„|RìMBÃ­N| Î2Ô–•@-]f6Zó{Ó7ï¼{ƒŽkó·4îj<i-7»Z"üm¬COˆ]:›Z’TC:oMÑ*§,5Ù-Æ)ò³2ô:Â
-YC
-´#»ñ J+JQç)†AÂÂ‚ßÎ_ñûùÛTn¡Ù'³Áªä“uû³N®Xk2,0‘<5r•€”†[é$ƒÀY†:
-yR^Þå[r,ZÊàtwÚëI'.°×š­.7¡fº«¢BÐÚÚÞñŽÝÃŸNö³9t£—{ØKí¹á-þ7ÎÚOëéå½¢*‡&rD|4½"_&Ñy­[íQú2°Ë7Ì{âñåˆ¡ó‡î˜mì(Õ˜u(É¨—öô?,rÇtã,êÐ4H§ÙÊœÕ¨#ÿ2|ÓÓò;dÈ(‘)â·°pd \Úy]KÔq0­'¢(ÊÜ§a À¿NXlV‹Ãg­ »èƒ‚n|¯ÞÓ_ßçi%nŸ÷sôáÞ?'õ‡ïÿöù.î¶ë«:E¹¸±â£Ë«£$›•˜#ß³­u»œMLQTÀ*-‡Ùf/÷]:½÷ ÚÑ,ÇäoR%Œ ¹’„Äua@
-r*ˆèÊžrkÄ›_™•–š»éhÖI?ö´øz×¿!ïáeÅ)z»¿\ƒ´&¾8gÉÊk…œfìBSãW~RwqŸ¯@;ê‹ˆèb’ª8r’]]Ø ih¯í•
-3Øûµ?7'×âè´»óÃºù}ÑÍç¸cÜ=âº‚²|‰y:ežA«NÒå’œyQìÏlŸ»p)Þª‘`°átëE"úöHY›½ÕdÿÎîu÷ogSòùS–TÀl·z|—÷îîA5\Jd"K•­SÑÍç¶0aI,"­»“½ºfô «²½U±V¹)=9*q=ˆ[‘ÓND??7èÀ€´¥:Jd‰¹Û6î=/ùtâ¥ ½|Ã	G™ƒÙ£¥9ô“/Ë¼Á--t×µn7AÜ™ÔºQò
-"6ç¥©÷ÅµmÅ6äE«äòÅJF¿÷R˜Í/©>_·¿Õ¨P#9¥bYÅ
-†BmtW¨*Q†—³Îbë Sl5¤Þ!°•û½.gKÓ^4¡ªHÑeg"cÑ5ûº$|(õ¡Ñ×Ä#¡sGLtgC¼è×é …žgCtüœOøÐ¹j4t®šÏlüœ<¤‡Ö®sð±™ÇC¢ëtŒ·!;©ô‰{ƒûÎÜl
-¡ž¡E£á4/¨3Œj“Ò„<¢,Eå~³J-1ä²ðaƒÀ 4jP€Õ}ñh‡¯®º«fWÙI~%øŒ3šÉIþ+y¯G!hCÍv{-na;üÜ;]Ôè¾ð-ýòÛî‡¡	âþÍ¾’l–¥oÊUoÏa„<š«@vQ9j¤ïã‰á.;Ñ 2ä•ýÁÇÓS²b¶d”œAßÙ2o×Ût¢¥Œ¥oþ‚ºrx+Km "W¿«ÅîõÖ7ð£¶x§ÂíˆW7·6ì’ŸóäpüÁ»éåë!œ›+>¼¶~£d¶çDl’Ÿz­4±e¤eE­‚¼£¢f«³™TžªØ&8³‘Ž<U¬&dÏIb“z…V²kJªP‰:·«Îâðô9|¤™	ÌŽ†/-v‹«å`[£ÇÕ\·¥ð™ê¸àøëM"¤M¿r¯îý“•gšC†®ü«p‚AWX¸>éÅµÈ‡¦ð¹ÝÞÚÃ½4ÇðVTïs ÏacDìzS¹¡#­QVŸd—a6/ÏÏÒ‹lÝþ«Oy¼âõwêQŸ®BåÿåÓfKÙ€ÃG¼_
-^‡×Þ@Ê
-*G¾úûàŽE"dš4u
-IcDPkÒªõ¹ª„ßLàð¹ÚÈIªXËÐñ4{áI@VG²ÐÜõªL½¹dkgüÀ×Ýô~—DÈæÿª‚µCOˆË”ÐKØäQ!Ë'.7j{›ù¤ƒÑ¨"ìîá.*ÖPòH–
-¹Ê2X¥ôN+ý“Aàâ“­ÙR9tÈµäXô6xà²¸,NBÿÄµò‚¹ô/ .ÔJ…¯—\Òø©Ã¯¹N§wÒžNÑ®†{^\¦€ž¯¶Œ:5=’¼-§0Å(4§´Ñ”„ŽlgÈ‚usST¥§´Œ/þ=•G-Uh@“¶Â@Dío;áCFº\þÈ¢…¯¦ËòrW¾žŠËaC),»‹ˆV4ï
-4t •¦f™)u…m ?¿M't”)ÍZi1Œ:½2oÓë™›‘™]æ ¢­ÛJÕÈ‡ÖÔÔTSûé;õÕœlñ“S'wBÒ1Ù¡Yàƒ_qÙ¾êö!óÐr±ÕèTI0™”JòÒ³UÅ¶XËdÙ,ƒ²ùôVLgI?Ç‡=Gú¯}Rý¬(-ød4ªU©Y/.YµdÍŠü s¦¦³¥8VOŸüžÞrêü×¯àGœxŒ Ê`B	J<°¡#¤BØ9êî{Þ§ûßþÜÂ}Ç‰Ä0•*G]._‘¸hëëäÍ0:çÑÏ³©l2»‡Môä¢%§ñ^Ã‡§Ê×·'ï9x£Ê©µj¥|s€dàß¥´ìkzk=½…×kY·ø‰gŸUFa%Röá4Ñ ¶Ck;ñÀîÄBÄb•%Ÿi~O0'è	Š¥ÖÑÊ˜õÓþPþß’°~Öö{'Šö³þPþß’Ð~Ú6Ú™âÍüËÄl^íB€h xH94]lmÖA2¬Íå0µÝ~È¥ÐÃ¨“6y¸éwN£D^ñˆ›O¶Òwj]Z+¤³YÈ†2KªÕ0²äpÙ*É›Ôò-¸
-R¥Ð X“bÔ™´ Ô½ƒ‡õV{yƒ¦¬ð%>Œž>Òëô9³äO‚ÌÆê¸;Í¶>:9”NlH|VŠ,èéFO ³jÜðÀì°ÔŽh+nFÃå¯z|á½WéÎ«¯|)ú…ÛFwˆ©èñë,D²±s·Æ0ê ·u’4¢WëM ¢áÂ(lOn,ôVµºwŸŒØ?Mbw31Ë`u”¼xMJC¾ùšN–Š~™cc6åÇ¥¬Ü¦ËÂ
-¤œÔVÊðjp©íû/Q…~^%5±ØˆÍDÈjAÃ‚iœ?„ªâ73¶%ff$'5dt6VWA‚µ%Ë—.×ëèˆÆ¥qT|ú'>;"¾iFÀ“~ó¬è"çº#‹lÄ!LD—
-L–‘Äk;²ÔuúP¯¥ÞLa©Ò‡W-Ef’Vk*UBÜ¢bµ†°éL.K ºÆîý]Wÿ®¢ƒ­tÌïJ?yCpqzïÈI^¾>ß!È*hA‹©ÅH„3ØÎºúÄåŠ¥7Ü8÷ƒ×[iÄ‡#Ž‹¾©çäÜLquq[´$ÚÈDô“2²=ÒšG±d	žE„7Æ—CD_+…òDÄ#¹<&Ë—m+ó“v Š,þn-Ò[ÿ~è’E‡6ú×ûWá5È°3}]ŸdË	 64T×íNÛc¨Å5œ;‡‹è.è–5tutÙk@øÚÙjRêuJ“üòâ*Ii­³AÊ^dAb¤›’
-eêâ¬´(ðo.¾o¢ÙÜVés•5øyŒEDWŽÐ1ÃãÄë^ÜôàýK‘ WwŸ•œýŒŽÅŸ¥BÖ$ŒÃ§ôÛ›×ºÂOß¤êo:D78}EœjÈ.y]Q¢Ö>‹"¶"ôÆµNÿÉ"âÞ?qîM|Cè„éï³Iì¶§æ>¶q¯®´±¥º«FÓ¹A8ÿŽw ßãðB<¹¯.IŠ#LËT‚ŒH#Ülžsù‡&úÂ{fõÑ¦¾¬ƒ¢cÜ6úŒ]Ê}1½yõ¥Ë{ˆèâ{Ýã,¹úø±Ù<ýü£È-Û{·zŠ»e¾|"º²*õÏk0“LÿqÙ	|sùg©èâ‹ôG1VGoYOØm	¶µê;PMN½Õ{^ráÌ†ÅRÑ•úa±øùç6Ìÿóâ7/Kp¼íÌ§„N\(ðç¤à5"¤÷fQ:ÅÏÍ÷‡íš&F€Ýb`·X‘,ø	[Ó¥^ÄnrUU™ÉœÂžMn	­D©ÒÔ`0óÅápmX:¶ÞËûÝ-Vzï˜÷b YÊU‡Ùuf“MK¸G†¿¸‹Í&'HœµRî@X3~’YÂoäêæÙ›Ÿ‰öqAÜíâ¶ä–’·¬hÃ÷¤ÿ	K…Z=@Ï¿ø}4L´ï»Þ+ò€“Á”[Œ’V_è•ÔøÊÚ¤ÂÍJ¯2ÀÝå¥±üåÚq™V¥rwÂ^R;HÁý] Úû‡«Ž%‡¥víhZÂnñ 3ÑßfÒPéìëðµ‘—Ã¨x,ä0*óS¶lÏÞíˆkÊÜ•±Çp{Ðm9Ù²¯>°«}¤½…íž|!'Â—Kü½_Ó{þÒí?ÿmáºðÌk‹nr‰ôgñ[‹½¯±Ùi,,Y‚ØúÌŠâ¦Üý¹b"ú¥^¦›¯Œ‰”EgoF1¢°ÚÕÞnóúà'>yYNjjVÄÊ3±ßÒ4|·Wï¯‰uª,2›ÖBD7cr¾ÇÐPÓì­h®î´T£‡Þ„mArIVª\RºËqH*¤†Q¿øeÂÐ\¾¿ –dCfÈD¢­q|vø®xnŠ OÉÒêÈðŸØ‘èûw—¥ôˆÏ:·Ú¢•²I&)ÍòŠÝ¨“–£ÆTfª2:Pþ§Ãï¹Kd=cxá5Öƒ8ËGÁBlj¤p:¼ÖJÒCçÐ)¡„yeé|Çƒ¤ì0©”ÊQ&!éA¯µ^¼ vÞ€*éN³Â]ØIØú±ÀdÕó ÔTz\„.¦w¾>·ÛÖjuñ`¨†ß-ù]ãžäî»E"ôqy’"˜ôšôâ­y+#‘MšPíêr6öÍ>Oìà¥0b¡IU'‘,Z ËUÅMyÉQë^Åà-Ôà„ÿ¼ÿíuÕ9*QEGtl|`;›Zð)ÜøI_Ïîß¥°:§$‹ˆþ²ŽIŠtäc[wRKænu'N£££½Í»ümc:ÐTWÛN¼»+ŽÃJ„´¶þ2tf
-›'†ÓàÐÚ˜‹®eË¸>pñ„3„‹§Ë¸>ê¢k6«NxJJ•ÐAo4Y=ÛÎŒÃýVaC†Ô8ÜOëÙv«Ñf´ÃƒÒRxø£pšC¸oî1¨`F®ŸÕÓí‹Þ¢ãâ%PBcÕ:ôÔÅÖÒeÃ}Ž5Ï–÷1[«Õ´Ð@YZâ6‹ÕBëévjäúÁ)ˆp†)‡ûìbðQŸË÷æÕN>4YÌô¡Lc¹¾–ÈÈvú °V¹O——9—PB£ÀÆ²ÇsØÝ‰LŠûH	¶÷÷c_©äPÞ°¾á´5T|Ö÷&¡wÓÕ|±dA=Î§³Ï„p‘Ã<Â´,lÚ‡i 4ŸÐçÂ@ó¯Ó vÃj±Ø`ƒSëÐŒt²ŒFö aSY˜ž°çÂÀôt*k£°‹‘ïd9ùN–“·ôLBç‰GìéÙTÚÆ !/ì5|'K½Eo5Òi3®³ Xþ¨½ü‡Y€M›a0õÐCãÐ:G„½ÕB !t*mÕa|i7éx8½r0ò¢èSî÷°¸1yöEh6b±5>:ct£ôÊ‹Íá:pñ8ê@Ž…&±	ëØ„ÈÙêB¡A^•šGœ.YwE?,åÉQšA$²™ªXFDçPˆtWBi„G[‰:Ô× X´Dôiê{x~qzZÞ…)?@õÛ¸Ð¡3ž“¢¹žï­É[‰””£Þ²W'ñÓ µ²t—­ÒÞPºðsEÐ!Ã¤N Ï±AIµàl@É>tã¨ÿ/MçÊZG†>Dþéó}¾«{Ü¨2!	™ÊTmaìÌœW±œ“‚œE×¾j¯gggÆÞ_Û	ä×~‚þ5D¶Í{J/a“C3`Bq~{!wZ`h0"ƒï=„æ)ÿ—Ð'vJ¢ò“ž6Â$W9.i:­íè@—¡ý÷È¥‘®6+ëÐ 'ÂõšñÙ?‚–b³²8<v'áfM0ƒÝ3üî§·Y{°×°ÄñoÑÔ6Ú¾kDîZJ? ià?,?òþ7ÁÃ÷}ûñ·!ìØ@Ü˜Óž,—eËê³š5¾	]rÇ{MÈ&±HoéçŸy¹ÞðÊ«	ç©ù“—ÞýÄ¥rR1ßÁ‘ˆn– ]£“wÇ7E°Pv›Æîyêõ÷¤'00Pê!fS"›,Ð«fNGÍin"ú¥ÕíiB5©RÖ¦g'É£vvç^—ÐÛñÞ¥Ê“„†p¯Ì‹N2ÿ51tF­IO¶°5mF–,;/Gž,Oý¼©ðpû[è­Í‡šìíéÅYT<ß¤›~mRëè²,ÒË%{+¼4Ñ[á½”ÜpÈÿÑ¾–7B¸ÕÜqS„9Z¢@&2t·ÑÉ³@{@\:»FŽm	r…fý´”¥ð,bk"Ò‰¢DÀ‚gÏB¶4§Ym‰nýi'3-8‘U©©Ó Yò”d$6*]Z›É¬Q5úâ#qGßì=~@Šý±5J;y­AëÊuå8ÉÊFÁöš”ôbÏîÏÿÚÛ­hE=Hëi|;,ÑR9R[œÑ¤oG-Žv]ü »&» ¾3H3Lbµ¡D<Cé®²×ÃƒØL5:²”ùÄj}‰~² ‚ÜÕàð¢£…qè¢“ºÂégŸ.¼$:Ç5Ñyâ.Â­«‡3[R=JŠûëðÄ	DŸÒù¡	(~Z’J²Ñ‡õèJ‡ài”uH?	[Ø%fÕ ÕÜ0.·í]B§7Óæ–ðA²à'ºùÛE?‹~ä<ôy1.-¿ÄÆ4ÑÏ7víú §È_fŸ`!,äÉu¼y­º¿-¹õÉ–Î¾sžnìÃélÌEdÑ¶ŒäÄ˜4ã&ƒÌh„ÎDPbT¹Q-]:ºn»mqì*ižðDž°xÚQOÚ2’ÓÒòwÎúûkt‚„J¯_û^*äf`ýàÝMhñZtÁüÁ!¿lâ+Åh¥ Õ+³ìØ…è+P{yÍ¾²Àž›8Š*ôÆ¶üòÔŠ­˜ƒµ¯'Eª?}±j#æaÍÆ”(Í¹×½;±YÉŠ,’[´úßácå‰Úÿ'{¬AU¹Ýmw»Úìõÿ¢tž=WËÏÀápæÈƒÌ (ZC"Ù3|¡Âºÿíí{a©´8xìŽÂº™X¹ƒ…D*Óô*ä“õ}‰‡¾ï£’J‰ðC\çúÂ¿¢·ÐæŸ#{E×¸Ïè:qd¨!¯äÕ‚µö)‚°¡g¼ôdýðå›=Ž›„NbÎ³{ØÝ3>¸¡OUÑÜV³G‚®Œºd«ßñÖ·ñ->^…ñÔªåÏ¾B˜E	JT&˜4$…‹	¾Vâ§gºèðéè¡ø)NW ¾EÇ>ÈbsY=“³qý^¥ÐÇiÍ’<wBŒhõªœ§+=D“?û†% A‰a)â4œµ.esò†¨­XÕ‡ÄÙÚK¥ÝDÈå¡‹£]ÁSÆfÍWC.aSBSa2)òÈðÃoÏäN
-tM0§€°{F	w¼Ò*ØPc¬3ZŒ( Ñ>l¨
-ˆZaÊ¹¨BÚŠ^[q\ßb¯„·\aVI—[Ð„
-Ø`·Uñ1¼ÅŒŸ‡o¬r‹ªpyœÂÍ
-1›ØôáÓu‚Q½D^Œl ¨JZ‹kÈi³Àóz?ˆ£ÞŠbäJù"_nÉâiO)ÖR³ƒÐÉ\£ÀÝmq½R_Žz©æöscúcaeJ	ÛK÷†zŠÝJe1ÏÂö²½aJU±Ré.öHé^¶7TY¦òxÊx¶—îó¸Ë<R^$w]ýkw¯/¼÷ËW®ÒèQô‰˜zYØ;KÖb³|ÇöÛ³"ñØí_<HÇâöô6'IaLqÏ¶U’|¬³¤wÑÏ}®–ê@fevAŠ*zÙàÎO¥TL…t
-M’>vU</á¡'$Ø†äÓDô‹¼q ƒ¨ïn>¸«¼ýhO¨Þ^–d[mDøTmþõ-ÿõ5ó°ÏíöðÿKÿô×ÌÃ¿ÿÆõè]Ð“ÚŠl
-²ýîYþÿà?¬ÅU…6ÀlvV‘«4Y`±[Ýü¤6<ÅPÁ¨5j_a3c—±E ìþÿ4ömú‚O‘#ûò$¶iùT«ÝVIŽQ…À¡³køAO­¡8g‘<ë1YàYýo¬oz(¶¦Î—"F}:´&?±üGÖÇ>¢ãzBè,_üËÚ°ßWëŸkÃ~£üË‡ÁCM.1 «ÎMØWCO4åF{>òaÔi„}õ§:¾Å¢v J2ôJh•.)›üŽx¸´ë‡^R‰‡÷Ñ2n-4zò»dJ2|‰ùùjdV«	Ç?÷)«»2yµ’Ûÿƒ-SHþ1&T1êªåÒ¡1¡å#®—ÛÆ‰ý4¶%|ð;ªúféuÑÎ3‚)ïÿšÝ"Y€ˆõÙÛñ‰óý]§:»Ï =êºt"âdÆœ|¤YuvkkM]ËñÈÃ3Ù½ì6™%±2*\HÇH¨ðæ5z§Ttãá;DV#2=:3>)o36!º%§¯°U}'ñíñ>âY¥ÜKcÌ‘XE„z¶~€JùÙîà¶ÃÜ]TÂ]¦=b:ñ±Þy’±!º 0fðe(‹Ôœœ8Y”btà'±Á“v»ðÓ¦_ÝGu>xP¦G"
-Eú"ÂnŽè‹ŒF@kTB’/GšÒ¥öH[ÐnmE'v:@œµh©.0—H‹P …™ì¥/*‹Ú³€Ðh}œN•2Á16$°‰ÑÉ/l–íy=sÀ#µTœ¢6AKÇ@`?Þ„}²‰ðÍ=´ˆÿþx¨ÿšõë·.”ÝüS	½ƒp«B›žtáU¡¥ôü½„®ûÃ¹.”=Éîdw²'Ù“ôNv'}Rúëv©Þ‚NÚÖI;ƒot^ë¤«:ì¡õômqèC¬PPZÐí)t[ù‚ˆJBk*ù
-Ù¥uª,±®Íg3Û4¥›Î.£AWª>Û:ŽP){`?»UÂÞ•@ž_×1»f“tØ¶I§Y­ÎC¾¼
-5Ú<bª:ÊÕz×)]GÅþnëôa¿öHÒž=ªï’q?^IÙxoaëh‘¸ío~ÚÏneâä<ö¸„Mao‹]5ðÃM8KJÑ¬®á•¢ ¹($ÃŽ0” Ý%'§mb§Ùfv¡^K¥¥2“±%—ç‘‡B…1£¿jèû9ùGúâÑný§ø«¥@T\d‚iõÅn]¯Ì%G.É^ÅÒØ-‹q²F‚ãþmÑ·®:«Uÿqº¿)¯ù×tªAMD7¶1R¸[ÈôÏÒ>—Ðç.ÐîÏ¤Âÿòß}¼óöpKÄv}y‘XY”œZT•Ðü:{±ÇÙT6ñjäeé~ôÔÖ—“öˆ@_h2iLJc”|_:­NkÈç›O¶â*t ÛÚ	Ò]ü8ÎˆŸæ›U¿ùi9gCoÒ˜d%+èòaT–$%EÊãñ*tƒðâpXµ;pá€oN q+”DHj:&Ü{„¦Ý|ø:Íz[tmh)ý§]ªÖ´jµ½ÄªäOYY«,ÒòLÌUP©òË3@ …Ö¨‘¿°tù‹ˆ@\uŽ¿²ÙÓâlµ8ÌN8ÐXT—	"º˜ŽÌtM
-]ÓÈ2dñ§eÖ&¦FÊ#ñ*vöâJÍ«§òÔ®c{‰ÝauÂ	·Î­¶ë-º‘a¥N£ÚúZÊÒü%štC2È£}/|%97ÚöîoØÒ—t4ŸÑñ¿þ ` »Éè¯wj®pézß•oð‘«ô«!Ü¡ÛÄýÛvJ°Bž2S›c(ÉdádÉob¶VzÏKò‡ògo€žïÌ×ô[Ý]¨$ò²¼ŒÔì˜í}™{$o çDÍ®¶Ót‚ÙINÒw?ƒ Ž9*A¾t^¨ç¸Éè9n«¯8ï(s×VWÖÃ†&ÔÊ#ô%ñ($Y5ÅµM-Þ]áSî:|=˜®¤a!ÜÜƒâÝq¼êþ$4;°~K|RôF” ˆÂ•0›Ýž]gQò%â¦G³029o=”HóøàÄ!”ž%t€¾
-A=ÊQUYW¯ìÙ4åÛ./-óºÞ¦·ûhYSÇ½(.UßãU¥lÉ)ÈD&Š+«óòëAžÛöhŽÎªuKÝ°Ø-ŽÚþãfêQ«iP÷zÐ„¸O-Î+ sž,]¿šÑ.»‹ÃÓÐÙÚÜ†”ª|©Õ95- ß§¢f»Þ®æÞ¥5h²^Yž—ÈdŽgBy¡-€*Ãàñ_W€ ovu}sÍ»6"œ…îÊ@0wzh¶¸¬ÄQ,‘!Ã(Y`šgd Ý"QÊ‘Ê&i=ŽÙ=Ãoô&Sž©Ø(‡$'47©
-Î#õ¡ÉâùØ|Ù$hB“ÑRZ‡–š|äKsB5H4+Ì„ÎàÎ
-lÕfs¥Ò\ŽJúÐz˜Ív›Ãf­à§k6ª»èê.údWðJ}'C8×U±« F%ÑÂhÐ¨×­^˜½‹‘Ñƒc¨µµ{ö¾Ð·ñ–£·âÓ–Šch#Ç×îšÏ^f“Øíì1vñ:YÒ„sæ“Çzö Œ,¢UâûÙÃxHRs¡±¹ºª³³ß éÚS°]*¤wÒœ/B†žýç\1»ÞÊè\6“[	náH¸qt&·’&Ð¹6«ÕJÕ®èGá§Œ—þÃ«1<•“0O¥‘Ã«©Œ-àá'ßŸw¹PJ„ôNîé/B8çñˆÅ©,’[ÍdtO?õ(Zh­:›&°¹tæðJµ8ŽÍ^ÉØ\½ÁÀô”¸Ô¥°ÒO]@#¹Õà¦!­ËïÊ .çÐ™ìV:5ŸÎPî=>´š;"ônØPT´=ùFð-Ø*,Àaéƒä«¯1O*ê§K‡·‰käÐJòaÐéQq11¼‚ôà *ÍUåQ–¥ÌZ7vçì{¥‘ˆdtéþ¶opˆ|?í{HÂ¾qy9Z¤õ¨5Õ›ÈïŽ$7æ›rQ€¡7óãBzÀ,¯Ç¯îtÁLg.¸`wÚí–j 5EHGòÌ9frŽ¶Ð	ˆö´¼«yNŠ"UœFFDý%‘úB{èŸÔ‡%7»¿¯’
-ëá~è	àïC†–R«‹Ò^Úºž°-tä&Xï	‹È½4WÌ¶ð7ºEpdà]ÿ‡øï¦ÙJX.Ý$Øz$í]|ˆýï!Ü³ÃÏŠ×o})má%ÿú2bŽ~ãÓUlÅV±Uly¤³Ø,ºŠ®¢³è,ºJÂ³Î×L‡p)wtÅ„=€òv)w(¬ÙhN“,_1Û´$.¬gñ†Ÿ;Ã¡x@J—ØÂ¡±•b—åjaQtä&p¹P®vj\
-¨Õ„Eñ7%P»Ð¨Õ(\jBG^eQµ
-—Æ©.‡ËEFßÏ¢.u9œ."d¥—»+|út½ÌÍãñ¥\òDhaç¡íÈŒµi&U<‰fOÌ‚ ·yÅ.ÔI¿]Ìºõù“u»b<Fïw•ªGF_LrÇ=ë3~¶§­š¼O÷=î¥BöŒ;‡¦5-!œëwÝš‹hDlMŒKÛ~âà4úÏ­.ãAö¾@_¬ÍJgí°û­•ämú}‚Qœüÿ Ú|>v
+xœ•›	xSÕÚ¶)5íB0jCDâ€2© "*
+(ó<SJç¹MÇtHÓÌÉ“9i:iÓ¦MK[(¥´Œ•I@ŽÊq@@ñ8‚k×Õs¾ÿÚ­z<×w¾ÿûÿ+½’4ÙYÙ{çÝïzŸû}VÐˆÛn¶,:gþÒ¥™qSVEÇf%EÈøWppã1FÂM’Ü>B
+ß	ýgÓø›cÆßùÓø;®&ŒtÏü}ÎÝFŒø¯ÿ3‰ÿ'|ÌÃüÃú1"¼•º#úõ¨è”ÌøLùäùMœ>uÚì)Ó§NŸ6ñå”ÌÔ”øŒ‰k2R“R“ã3ã3žšxûš¸øŒ‰9©²Ä‰ñeÑIÑÑQ³R¢¢e3ã¢'.\»zÍÄ©)™—ÄGF§dDOœ2ebFtôÄ¸ÌÌ´çŸ~:3+ö©TYìÓ1©)™O'o“ñ4ÿ±)–/[3eÉëó_[¶úµ§2s3'Æ¤Ê&FEgFÄ'e<5bÄÈA#ÒjÆr?Š³¼Üü*š?„í0‡Jn¿mMê˜QŽ1·cÌè®Û½n»ÍVjwŒÓ5ºËQn³;l6‡cÌÁ#‚FŒ1"ƒ?‰cÍ€™?iFŒñN‘ÁÅm#A™A{GN™9ò@ðŒàïo; +ø$dbÈÏ¡Q¡ˆqÔ¨QŸŽúçíÑ·Ÿ]0úâ˜cÊï°Z„?Ü9÷ÎOïZ{×¹»¾»»6liØ€¨RôËØcâ²{bï]<îîq×îSÜ÷Éý¯ßõâñÎ	ñ~•”IöKK'Nž>ñ“È¤Ñ“Šºÿ¡Ê‡Ç<ìüËôG^x”<šòè¹É³'—Oæ+}|íÏ?‘þäãO¾1%~ÊÑ§"ŸÖ>=85~ÚÖi¾és¦»f¨gøg\˜AgZŸÙþÌñgO>·ì¹ÿšuqvÑìkÏæÌ›sè…‡^ÐÍ-}qÊ‹‰/žš÷(»$¤A€n	µÓ§ƒ¢kÅžb($K§¡™,Œµ°å!z¶˜°?D.Š*7™T@.´vMXýhC»¡ÄQ†Ê¬‘fZ2\ð¡Ôáq•;KÍx—Bm!–ìr6Å$y½!§°9Êr@²{­{àÃiƒÄQŠZ)[Kub&ÝH/„ÅÅ~Nê§;ú‚Þú„{`W0÷þÀb»Þ]$ÉÁ,µÌ¨6šM
+ËQºµ£Ö¨"«X® »-¾q3Ëîa²‡{ÁçÒ~ìtí®Y~¼¸ðy«ÞÝeÇ`C™Â¤×¤‘¢Í¹+"M¨±¸­e„J¹#³ÅZ6‡ý"†Þ¨1È¶\ IÍÊÉÊU©#·#±8#Ítd}WïÇ‡*üx5ó $Bz_}ª+h †~/ö¨ÜJÉ?BB”*•RéVy¤!!·Û#eënûß²Ù‚8íÀq©z	g`÷Yr”nÔt7!W
+ŒFavT1†â@2UÈQ–Â*¥÷Zéý«5¥jdIåÐ!Ç’mÑÛàËâ²8	½Ÿk¸;¬%ip¡F*¤y]Aœ +x †Z‡÷œõÒÞþ¿ÖËzCÿØ[ÚËzCøgü>Kh/íÞ{š‹‚]b V›°«Ï4eF{ò`Ôi„]ýÇó
+€¨¨”¼Ré€KÊÆ½+ì ­ç:BfPz¹ûA§OÓËÜ,>nå’!t’½T•äÁ€T“*ŽD±S È)Fn‘µÒ/Cæ³N}ädí®èþÑG\%jè%*˜:åö‡ÖeÄ#ÅehCƒÅi«"Ðý_CP[‚Z©>… =ë¥»aÜ­ë1WE×\·øƒ×Ï°1v%$—h7j¤@ªŒÕF·	
+èMCa÷îGÕ/€äoW-¥!¢ètz;½ýïR¼¿òøãòsÍÍð]ŸjÏxæI&”°GpŠšîv‹u/‡|Y·"\*úa5ûP<yúãìv	R#´æb³Á¬°Ø«É9ÚJWBp£æåíRa¿ºƒ×¶‹
+YP7–
+—÷‰.r?p#ÄGÖµ/“¬BÌv…\Ö½ºf[ÈîL(¬€[Z
+'leÍWßoÙƒ]¨–#¹…kT±$žM,‹MŽ‡™È© ¢+%Õ;á#Þ¼†„¸˜”MëŽÄ½%9†Î½eÕ¾ˆ£¹Ç@hØ»ôÎ¶ò¨¤EÐ@¯H™:?y¢!¯F+êÊŽ¸;I;/¨8Ùh‡õ¨- ¢‹±ÅòxÈHVUF›¤½³ù€TÈ’~è¦Ÿ1•V£ÕhyèÒºt&ù[(èÌstËÏ—,‹VØuvŒ0šŒ&6rÖ$¶ly.lÞM¶…Žœe1YLØa·ÃN„	JoÙq¥ÌÖ|m™þtmµOô×À^Q/Y‰¸uE™²³kKR@ZÅÄ²âR@ê‚Õbqï¼uÖ·5hWa%’òÅ°‰ùKã"Â¡E&²ËˆhÀg÷ÖÁOš²\É²ôÄ­sz$gÑñžÕQÓuä§cTì+QÁ UÁ¨7j&.ÌHDò[±^‡×ÓCvÒ	Gcýµ÷`GêDôKª.G†’ïÉm’x[«»¤Bö1nÑ×½Á4Ü,>+Û•#KM«Mo“”¢ÌVâ¶Z,f °˜Pˆ—ã–'$(•0Â@4v½ÝóñE:J"d¡,ÂÛýe·—›•ãö†5û5×ãÎxNÒÅgD·Žp
+n²¸ºÐ] )F¾VU`Ô©“ôr’3g[$Ðlíul€²è­:µóËÊ=6j‰èïGö%vn|2†ýEÅŸ8I	Ì{eÓ×]-;áBYqº&7òAù*lÁôÓÉ'@vcg•ß¯X_´)r]z|tÊVb›5ow%ÊP^JD?)q—”¡†ÒlÅ™	ù›6öÄœ’ü„Ÿ®ú©€ÜàÂ¶rXà$B6^é¥ZéoP÷YºólðØÏ¸ÍœA|VN¥aRökgò)Í,ø*}>I»h¦äõSblRoÈ˜LXtHÕ™Ú»Î7è<ºàXŒUdË+·f?=?naô¦íH@v3®£Ûq¼ñïDÈ’¨¢?˜î¡Qb>2çM¢[ØÈËF³Ñl„:t0XãÏsÏñ‘9s(2g.`[šk40@g×ÙaÅl1Ó‘—oòQ>?º˜Õ9a­}{Iþ‘öõ<@'‹ùkK¢„:Ñ£V–37++P— 	U¶Ê’.âýªþŠÀé/Ý'êòë“•"|h¾ÔfjRŒryFÔŽXÓAÔã­À%ÿûDôaI£Õ‰*r|eëš7²ñ9|z§‡6Ü_R	'J€ld¥ê‹ˆ¨/bRîjlù>ÿšÑcë?Ôºé¸¶h®«ë ¾®²~þ¢cc”^nŠ7¨ÙøLÉIúÆÞ`.Ž#âþôJ¹,#=K…]ëQÖå”¥#–D,cr6jCfûa	Ž6]\vVÙËQCø¸šýïqÕüÃÞúæÅUšFÎˆb+¶6âËü^úÂ1ú·Ãa•ò}nLNXY€fœ]w„æîÝä~àˆ:oA™Ö¡¶ªP…¶¸XU¬SB‰b›Ú©ñe•%!Ž È¤0eN]ùôX„]ªÃeþ’g‹ÅmqÃ…
+§Dôm.Šeº,"º©NÒ'›RÖnŽZƒeH?ˆÓ¨µÖÛ½';Žî:bµYì°8ôvÕ`á@A§Ý±J¶8Iq´.
+qx¾yéG §q¸g×)ÏÒöðwð3NSq½ƒxö–DþÈ½{+ˆÿ%˜ÅÜ&nÊlLŽÏI•¥Õ§·ì¬õû$BöŒÒGÛ®uúÂv^¦ë¯4Šnr3èhqI1’¡ä£Myê¢u3öÒgèsŸv‘ºqÚÔKDÜƒ6
+’^ão¬­jywÞîÙÝO³ì.6ö»É”Hèý­tL‰T8Iéã¦zƒü—iËå`.‘&ˆéØGo±;ØÝ³ v7ÿüEïøáïT$™å#k³Â³¶…§lÄv„×¥õÊzð:°ý=M½}u] =Ø›Õ¸½q;V"šY¬ÒË=[Ö¶sµú2÷‹®ÐA:VŒ#É-E¥	­Q®×jÏ¢2G{ãžÏAD×éHØ§Y’Ì* R{ô‡Ð*8•~ªPôÅ*½!Ú¿`BD/ÂjÄU¦6eµ¦ûµïÑ¯þÓ|ÌÇ†¸È¹x±Çr?3”™lÅ 
+häR6.4Ä³¹¦Æb¥º¦'bŸ©„†ö¾óþP~p‚€'‡Šo…}öËógE{(î	„¾®·ï–‚ˆ.°‰J$	Þvk7I™7t›‹$H¢#­‚v´wšˆ¨l÷Ã¿ý°þ—•
+7­ô†Ñ‘çhô9Ñ>®õž@èzÈ`j!tu(>G ©£°*¡v%^Á–í©K	n
+DÙƒü¾çÒl’²º?¾P`¥·,RbŸ”.	íûùüÑ3§=kWIXáŸ¶'!ÀuÎäÑ´‚¹çî	$†N3x:¥ÜñÐX2%KÏ@"HRh-Nàp#¬5M“$&…´[¿@ºðÚ„M/7x¶°-lï[ß7}wNô	·aài1ÊÔ%
++ˆqG”ÄB•Im*4èU
+µ²HS¨*0ä!ë‹[V“ªÈì¸äÛãW®Ôfsƒw|MJSD_úQ|‰÷¿iø;qï´·£•¦
+c…ª/»+µ=üØ’¿bf‡Õnw»Ün;ñØKÌì3úwåÑ'6“ÍdE9*ÜÎ2buXp&œ#Fº!U“–ûJìK°Éõ;ÕÕú:xÑähvúË×éê&Ú€›Xu‚ÚØêhW„-ßœ‡<"üè·ªþ×æà{)Ä6ƒSÅ×¤:M~üÓá,„½2å?Õxô®“/Õ=_ƒ´¸PSª„NÊ&K‚¢ÿÏr”‹i€Ž*òWš$°y`ˆPM¾ÌuücŒv£Í`esèÝŒÐ¯AwªÝM	ýšÎ¡w[­ìpij`0Ll>Çže7Àú	S†‚õÓgÙ:Ÿ³š¬&+\p8àâ¿ã»÷ƒ¹gé8ñÐˆýìYzƒÍ§ãfƒÙ 5´Z¨¡³è­:‡ÝM	ûl÷ðˆ»a_³9ìnƒÁ¨‡j‡–?9V³ÕLçÓqôYz´ŸŸ‹•>îž@’7ìçs2½ß'º@?£w‰ÉÖ„¾œ³W«$4@
+„ŠÞfÑ%²ÑÓìä‰éIÖg¬9”Ýy½¨CrÞþŸ×¼yšX×t­×Özqó5úÜ¹>Q¾’Ë¹">*[ºR¦U&è÷Ù%tK(º±;¶3j÷ÆÊÍ ³ly=¹6¯Ñ_]Û(E©®m«¹©ý€§äÀ±¨éÒ˜Ð†×K’‰è ò¥xÙz„ãùoe§q½]5}D”¯´E6EôÔ½Uþ‰”Í9$T>9?~Û¦í%x³û2í ÂI¸HoÞü!vð&¿*ó‰nrké+bYˆ.Y^\ Q¿Ž,¶·~ˆ8:•JNöã{BC¦}Ì„LðòÓÓW„µª½tO£¼1N¢æ‹CSýÛýÇq{ŸÇlÌÙøÂš¥„­a	‚¡Ú1ƒp¡!ÂIYÞqÞ Ý—©ër0·^ãcÝÇql½1»2ËñJúŽ§èæb^²MÛ3oïór€ôã£ºžoZÏÙ/á¯dV©/a¡rqÁ“«’·!
++|òÊ“¸†8ƒ³®þ:úC·¤gå5“KVc–áš÷ó[ÁtÍqsFCJJFFJJCFssCC³D8)ËOGþ.ñÒ{/‡üns€æ^ýÂ­¥[ÅtôìïÙÉflÏ#t}h­¶MÓ
+Bï|ïj™Ã`×HÁb†Õ¦œEˆÄVç–:µUÏÏÅPçKÙP9Ôå',V›ÃSÙÙÿ	Ã·Õ%¯Œ±Da#â°<#"#*&}+È+Xu$ïüÑ¯mU¾††<_Baœfë3ç§·I)ùñIåËã4úÜØñ¢ýÿc2áËó¢¿xÙ³íÏ‰ý“ÿÇÄ~à?'ößêJþó†K¸®ó´â|0§£‰y#)†Io(Ì{C¾bÒ`hD-¼—§‡x¿ê N?,°Ëõd²ä)MÛ@Ø(v{”=2åÍ×/IkqÐvò¼+¢=a?ÚQ__ÙZÕQvš‡0èJ1´F­IG6²Æ‚¼ð5;òS±…ob7¶Ò;ë{'öuvám”Ï†–ð¡ð¦7ÒÐNùÂºémÏþHç\›÷“ˆSr[é<1>]ré¡:"b#>m:þþJ>qô‰Gæ-Ÿ—àÍmÔz›nA$pàlYöàÍ,LC‘qezxòæxƒÌ¤6e5P›4&¥U’žÑ òÓÎ…±ñRÂ¥ÛñRUÜ‰v]À‹]¤#­6%#±0|êõ×i„
+¯^ýQÊO¥ôþ —•DœçË¦ÙâÀ£ÜæÐZ8ò%<Qvr0I´˜)ˆ5*_–d'…ì±F7ºq{$ú²ÑÓ!ý"ôÕ€˜@Ü(pÒÑÝôÌî`nå@Ê0ÇQA£3¨	ûñŸk&#0‚'7pÃi·ºýñ×5³…Ÿmˆ=Jï=ÌIÙ1l¼îfc¾šM +	
+ºòSª c¾’Þ68tv-?/½EO°ÑL¶•°±¡`[éh¦ ¢'xõm…ƒWß"¤Ã³àÀµ™bÀ£$#Á„D[c¡…ÈÆnpšÜ¦€©(T*Ô*Âže¯<G7ëÊpTÕtÛJÌ%fT¡´ìÀvCdXj•hùù°eÒ“p»³½µ²X–#ÐêL&­nÓº-ùŠa´	(ËÐ‚6k Ømè“%EfHUæ$ü¨¬¨,-#?Ò_ýý¦¶
+ ÎÍ‹Ò+M*òH‘6	³
+|x‹ÇšN·C-]d6ZóºÓS‚wß»IG·ú›v5œ´–™Ý@þ~¬3Ä.M-IGŠ!	ˆ³&‚hÈU–˜ìÎfc¶y™éza¬–¤Úò¡»á JÊKPë)‚AÂÂ‚ß_ñÇñÛTn¡w²OfƒUÉOÖ‘ì\±Æd˜c"¹êa2+¥aV:Ö p–¢Ö£â¹"²‘gÉ¶h-(…ÓÝn¯#íôA½Ælu¹	5Ó]åå‚––¶ïÚ=üáTa/[’M7x¹'¼ÔžÖìó¬ý¤±Ž^Þ+ú§ràNŽˆ¦•çÉdC:Ï¡u«=J_:6cñúÙq±3¦/F,=ðÙfqÀŽY‡b˜Œz9aÏÿã1Á<wt'Î¢ýt¢­ÔY…Zò!Ã7]Í@†ôb™"n3C:òðä¥7´Dcá:"ú‡Ò Ìyžçà?',6«Åá³–“]ô1A'¾Ä×¿ìé­ëñ´·Ïûzˆpï ÛÿíËÜ]7V¶‹.rs·‰.®Š”lDdBV´|ÏÖ–Õ ì¶ÅìÎdE9¬Ò2˜mö2ß¥Ó{ MrlFNÑFUüX+ŽOX»$#»œˆ®ì)³vÀA¼y™©)1fôbO³¯»aÝ›ò.^V¼EïöóüZZ“N_”½`ùúÕˆDvv¡±áªŸ×^ÜçkÐ†ºB"º˜¨*J…œdUÔKêÛjº¥Ât¶Ýßv½ËÏMË±øÃúÚíßîøÐpnú@të%î÷¸6¿4O¢D®N™kÐªu9${V${F€m3ç.ÄÛÕô×Ÿn¹HDß)mµ—¢ŠìßÑ¹ö‘ml|È’r˜íVïòÞÝ]¨‚K‰dª²t
+"ºõÒf&,ŽA8ò°ewb ½[×„.tT´µ(Ö(#"6¦%E&¬Ñ`²Ûˆè——ú8 ÖG±,!gë†ý1ç%?€Þy)@ï&ßpÂaæã BöTI6ýô«RoPs3Ýu=˜[ÄÝ!nOlÙ yá›rSÕûb[·`+r£Try¼b9Ã¿{	Ìf‡—T¯Ýß*”«lƒR±ž¬dùC6:ÈËU(EµËYk±í¤ãmÕ¤•Þ#°•ùû¼.gsã^4¢²HÖee }Ñ5ùë;$|*õ¦Óeâ¡Ô¹•¦
+&ºÁ³!^ôëtÐBÏ³!:fÚ§|ê\9œ:WÎf
+6fÚÒóŸ›y<$ºAGóÉx+²“Jï€¸;¨çÌ­Æ`ê˜7œN3ñŠ:Ý¨6)MÈ%ÊTì7«ÔC4J£ùXÕ×‡6øj«:ªw•žäÏ?ãÏä$ïÜ‘HZQŽ³Ý^C„›Ùv?÷n5úƒ.|K¿ú6˜ûaàqï&ßI86ÉÒ6æÄ¨·e3B^ÉQ «°ÕÒ0c0Y ËÊ›·€¹¥Šñ´äÌèm}é%gÐs¶ÔÛñN=½ÓRJŽÒS‡ ¶ÞräÒ§Bê©ÈÕëj¶{½u ü¨)Ú¡0ÄB;ÕM-õ»$Â—<ÙÜPßnzùF0çæn^S·A²Û²Ã7ÊßZV’È2óS3£
+WB>PQ³ÕÙD*ÞªéÛF8³†\UŒ&dMKdcz…V²ª‹+QZ·«Öâðô8|¤‰Ž˜õ_YìWóÁÖ«©v/Jà3Õ*þtÁñ×›DHã^ÍÜ'+Îô5\ùWáƒ® `]â«kM	êás7¸½5‡»i0ŽáíÈî—@^Â†ð˜u¦2ÃÎÔY]¢]†iØ´8/Sw,¢eÛo1MäqŠÿÔÃ1]‰Šÿ-¦Í–Ò>‡x¿8¼¯½ž”TŽ\ýûàŽAdšTu2IeDPcÒªô9ªøß‡Àásµ’“T+°–¡chöÂX¬Š`!9ëTz%rÈ–ö¸¾¯;é#.‰pEñ%Ÿ:üšKaôÁvÚÕ.ÏUs/‹KCƒQ§&¢'“¶fd æäf"¿3Ë™	2gíÌdU‰Á)-å«pOEûQK%êÑ¨-7QÛ›ENøž&—?9oîÒ4YnÎò)áP¡¨6”Àb±»ˆhIÓ®@ýN”¢ÂÔ$#"s ¹¶ ä—wè;K•f­´F^™»qEÆ&dBf—9ˆhËÖ5ä ò 556V×|ön]Õ‡'›ýä­“»¡”éÈ¬ÀÀ”@ÐÁ«\–¯ª-xÀ<°Xl5:UL&¥’¼ö¢@U¾õCÂ2XKgl6½Ñ)Ò/ðQ×‘ÞëŸV]…%E ŸŒFµ*%óÕ+¬^’·dÚƒ‡éT)ŽÕÑg¿§£Þ:ÿõÁ+ø'^#ˆ4˜PŒbßßÄ2¶ÇÝžèþw¾ðsßq"1L%Êá¨“Ë—$ÌÛ²‚œ
+¥Óž:ð2›ÀÆ±‡ØƒOœ÷£ä4Þ¯ÿè­²umIû@ŽÞ¬tj­Z©ƒA#ß 	¸Ä÷%`))ýšÞ^GGñ…úÖ)žñâ‹ÊH,Gò>œÁF:¢õPß…þšv|°{11XiÉ#C­Æµÿct´/@{AÊÅÖ&d ƒŠœßp~È¥ÐÃ¨“6n°ñÒ¡DnÑPtœ•>f¸KQãÒZ!5˜ÈDtYR¬†¡s—­‚œ¢–o!øÐ•Ÿ"…Ešd£Î¤ vè<î¶Ú«É›4Y`õ€/’aôó¹R§ÏÏž›)d*ÎP§ÀÝn¶õ€Ðq!ôÎú„¥È„ÞfTðº:«ÆÌKÍ:á&Õ_¾Úåë¾Fw\{ã+Ñ¯ÜVº]LEÓo°`ÉBÄlÈÙLB©ƒÞÕqHÒ€n­7žˆ"±-©¡À[ÙâÞ}2|ÿ,6–=ÀÄ,ÕRòêu)þæk:N*úušYŒÍØ˜›¼|«.K|R[!ïÃÇ¨Æ¥Öï¿B%zXJªc°›ˆÕ€†ÑX0U;Ä§2ú¶&d¤'%Ö§·7TUB‚5Å‹.ÖëèˆÆ¥q”ö1-¾8$_izÀ“vë¬è"çº'ƒ,D!LD
+L–¡©Ëvþd‰ëô¡nK™BS
+¤"K-…f’Zc*QBœÂ"µ†°™\¦@t=ü‡¢¬úC‡YéÈ?´*~:ó¦àâƒÝ«!'¹yú\~ƒVA3šMÍF"œÄvÔÓU'.×SÔ+½aþÃ9®h¡á¶?.ú¦Ž“s“ÅUE­Q’„k#vÑOÊˆ¶kžÂ‚xáÞh_6}­TÈ‡¤²è@_ø,ÏKÜŽH2ÿ»5THoÿùÐ%	Úmð¯ó¯Ä2È°3}]—hË 6ÔWÕîNÝc¨Áuœ;‡‹èÌï”Õwìì°WƒðÕ§Õ¤Ôë”("yeE•’’g½”½ÊFˆ‘fJ,©‹2S#ÁïÞL|_/E“¹µÂç*­÷ó0"“ˆ®¡#G‹×¾ºñ±G:"Aï®Î+9ò9½ÏH…¬Q‹Ïè··®w„¾EÕßÆïÝä,ôq|ˆ!«x…¢X­}… lIÈÍëíþ“}DÄ}pâÜ)|Cè~ÀÆ²»ž›ùô†½º’†æªŽjMûzIàü»Þ>|Ãsñ<f.]K˜–©Å*‘J¸©<)òÜéë>˜ÙC{2ŠŽq[ébt(÷EwçÖå—,î"¢‹ïw8Œ³äÚôcS}þå§$[¶uoñuÊ|yDteeÊ3«1™<øã¢›*øæò/RÑÅWéb¬ŠÚ¼<Ž°»>lmÑïDyëíîó’gÖÏ—Š®ÔŠÅ/¿´~ö3óO]–àxë™Ïú½s®ÀŸÛ—ŒedÈÃK0:ÞÏÍöl˜(F€2°QV$	~Â–4)ç±[\¥@Uj2ç‚°“šC*Pkª0ÕÌ|y5Xš†-óq7ÊJGñù0úš¤\U¨]g6Ù´„{rð[»Èlr‚”ÃY#å„6¡ï'‰ÅÿÎ~n½õ¹h7‚»[ÜšÔ¼]ò
+bn' #yb/ýO`'Ä*èBºþE èS¡¢}ßu_ùˆGT°˜¦œ"¤“Ôº¯¤ÚWÚ*nRz•î>/á/×—iå9Q
+×pO ô5µó€ÜÏÑÞ?]u,)4¥c{ãZvû¤Ç˜˜‰þ>™†HÏ`ßN_+y=”ŠoƒFe^òæmYÛ±±»Ò÷Ža:-'›÷Õvµõƒ´£» °Í“#äDøz±¿ûkúÐ_;ýaç¿-8CçžYö‰è—@¿=ß»ŒMMe¡IÄÔe”5æTëÏÑ¯uú3EØˆ<et„,*kŠ‰UîÌ¶6›×?ñÉK³SR2Ã—Ÿ‰ù–.ÙIÃvKpí‘ê§Ê"³i-Dt+Æ)ç)}}u“·¼©ªÝR…:6xãÓµùÙÈ!™µª2IÉ.Ç!©†ãâ×;fò„^-É‚ÌXDYcùÙá>á5ºu(„<9S«#ƒ÷³#ÓîKÉŸµnµE+ecL<dÜÉ-r£VZ†jS©©Òè0@ùŸ(ýs—ÈzÆ$ðÂk¬q–Kó˜TTKátx­¤‹N£QB	ó
+JÓøžIÞnR)•¿ù­ºÐmí‚ý/ˆ@	•t‡Yá.h'lýD`²êy†Žê
+‹ÐùôÁ×çvÛZ¬.­Tá{Å¨Ä“¼F|s·è¯„>$.+„A2l¡*Ú’»|ÈAUFT¹:œÃg‡ÏÓ;x1‰hRÔ‰d=‹èrTÑFSnRäÚ¥X ¼jœðŸ÷_ ¢½®ZG*ÉáðÝÆ&äÿIL6|ÚÓµû1©Î.Î$¢¿®e¤ yØÚ™Øœ±[ÝŽÓØ¹³­Õ»øc)v¢±¶¦xw—‡•i=mù1xàÌx6K§Á¡µ1]Ãq=àâgGq=ÔE×8lVœð—(¡ƒÞh0²:¶{1¨ ƒ†P*¨q°—Ö±mV£Íh‡%%ððßÂi~æ¾¹gh@3r½¬Žn3XôßR.†«Ö¡§.¶†.ìÁ`Üð€qlÑ`s±5Z½A”%ÅØa³X-´Žn£F®œ‚'™²¹Ï/õ¹|§®sòqb¦aBËô5D†¶ÃµÒ}º¬Ôé¸„2	v›.˜ÆH`Rü…c[o/ö•H…âMë›®~[}ùç=§}€®â‹%êˆp6z&˜‹ç! Í`ao>A y„¾
+šwƒèÄ›V‹ÅœZ‡f¨d4²GY0›ÀZÁô„½
+¦§X+}”[Œ|/ÈÉ÷‚œüøGÏsÁt–xh<=›@[Ù£4Ø`á¥±†ïi ·è­F:qÒ Ë/ï	`'ŒF=ôÐ8´Î!ilµÐGi0@[AõDW’Í=F¯Œ¸(úŒ;Ã=!nÈF®„}’…h„o‰‹Jß
+Ý0ÿqÁbs¸\<ŽZc!‰ìŽµìŽˆ©ê¡An¥š‡„.igy/,eÉQšN$°ÉªíXDDçP€4W|I¸G[ZÔUƒ÷§Y´åDôYÊûx~qö{RÖRÞ‚ô»áæÐÏIÑ'\×¿ÓôÂÕ¹#~÷¨yKû\íÄOG¬%»löú’]p€wæ@‡t“:ž¼Äú&}äœW°ÅûÐ‰£þ¿6ž+m²Mˆü'VæûbWç.¸QiB"2”)Ú‚˜ÉÙK±	Ož“õƒœEÇ¾*¯gG{úÞß€<ùÈ¹ ßRdóÀLÞ•—'aãBÒaBQ.|g.wZ`¨7"§÷!¹ÊÿKê:Å‘y‰ÏˆNa’«—´íÖ6ìD‡¡íÌ¥‘®2+kQ'ŸÏu›ñù?F,Efe)<pxìNÂM¸ÃöÐà{ÿ=ŸÞeìÁ^Ãž!ûêŸ²©m¸ÃzßÒRò!H=¿³¼¹âƒo‚ÿòí'ß³cqCv}Z’\–%«Ël
+Tûê%tÁ=ÿí5!Ë"¼%_|îå&yÃ*®ÅŸ§æO_{Oô—ÂIÅ|D"ºUŒ4>VÞ×	ÂBØ]l"{xò[+Þ—ž@__‰‡˜M	lœ@¯ŠŸü r‘`NuÑ¯-nO#ªH¥²&-+Q¹£3ç†„Þ÷/Uœ$4˜[!0;,v8ÉìebèŒZ“žlf«ÚôLYVn¶<Iž"úecÁá.)ö7ÓÛ›5ØÛÕ³(:¾³F7þÖZ£ÖÿÐ[csX„—Kò–{i‚·Ü{)'¨þÿã/}Íos«¸+âÆps”D¤ën£“§iöz€¸tv[ä8
+Ìú‰ÉçàEÄTGô¥E±€ÍÏš‚XlnJµZÜúSOfXp"³BS«A
+2åÉI áHhPº´6“Y¢6jôEGbžê>~@Šý1ÕJ;YV/Èqå¸²dyƒ`[ur3º±g÷ëîT´ ¤å4¾í–(©)ˆ)JoÔ·¡G;.~ØYUzß¤é&±ÚP¬G.Š tWÚëàÁNØLÕ:²ùÄj}±~+2¡‚ÜUïð¢íÃo
+cÑAÇv„ÑÏ?›{ItŽk¤³Ä,˜[Zg–¤zö·Áíˆˆ>£}³CâQô¼$-6„>n£OèÑ‘Áó(Ý)ý4Ttnn‡˜UVq#ÂØœÖ÷h0}°‰65‡õÓà9?ÑMßÎûEô#ç¡/‹qiñ%6²žˆ~¹¹k×‡x‹üuê	Ì‚Ÿ];'Þ›Û¨­÷KÐœS—diï9çéÄ>œÎÂLDnMOJˆN5n4ÈŒFèLÅFe¡UÒþÑÀ¥£k'²»æÇ¬”Fb†'âDŸÅÓ†:ÒšQŸ”šš·cÊÏËè*½qý{©›2Æƒúv7^ Eháó‡o¶ÿº‘¯Ã•‚V¯Ìœ³}G$²¡/GêíeÕûJ{ná(*ÑÓLòÊRÊ·`Ö¬HŒPöjåÌÂêÉ‘šs+¼;°™IŠL’S¸êßñ]Å‰šÿ+½«Fe™Ýmw»Zíuÿâ\ž=WóWßáqæÈ…Ì (\M"Ø|¡Â3®ÿÛÇ÷ÂRh=pðØ%…u+2°|;ÎP¦êUÈ#ëz}ßC%áG¸ÁÕ÷„]¥£hÓ/Ý¢ëÜçt­8"Ä[¼4¿X­} lCÈÙ=ÙED?|uêoÇq‹Ð±ìŽóì!öÀä¹­ïQ•7µVï‘ #½6Éêßw¼å|‹OVâ1<·rñ‹of`‘‚b•	&Iæ¢C…ËŠýôL=ã:ý!=ô!ïƒtqùâ›‘ô¶ÇØãl&«cr6º÷±kôI:6ÒLÉK'ÄˆR¯Ì~Ž°üC4éóoøf<X0rI4K§² ÌµÉ›’ÖGn	Ç¨>B?ÎÖ\*é$B.í[æÀTqEä¼_9&“"—Þ3øÎdî¤@×s2{h˜—Â+­„ÕÆZ£Åˆb }aaƒ&*¾ ~Ž¨¦l˜Ë¥-è¶µ¢Çõ ö
+xËf•t±(‡v[%ŸÃ›Íøeð¦À*·¨*P—Çé!Ü¬`³‰=8xZ Ž7ªç‚È‹VJkPo­9møq^ïqTÀ[^„)_äË-™<í)ÃZbv:Žk¸;-®@êÊP'ÒœÞ ndïï~ùR¥„í¥{C<En¥²ˆ÷Ëïe{C•ª"¥Ò]ä‘Ò½loˆ²Tåñ”ò~ù½to¨Ç]ê‘ò"¹ãÚßê¹‡}aÝ_½qFÃ OÅÔËBß.YƒMòíÛvlËŒÀK`wù½oaOwýq’Êm])ÉÃZKÚN"ú¥ÇÕ\È¨ÈÊOVE-êßñ™”Š©Ž§‰Ò§¯‰gÅ?>C’­H:MD¿Ê;qÐ¾ºÎ¦ƒ»ÊÚÑ‹¶øªm¥‰¶%ØJ„ÏuÑ¦ß×,þc9@¿ ÀíöðÿKÿ—åMüÿÆõè}Ð“Úˆh°ý	îYþßàowâ*Cêa6;+É5š$°Ø­nÞëOT0jÚ7Øä˜El{ä?YªÞ¥ßAð²eÿB~CV\›–·tZí¶
+rŒ*]Ã[%µ†¢ìyòÌ§A¦€§Ý¿³¾C¨°%e¶0êÓ 5ixÏïŸYû˜Žî
+¦3Xžø×5¡œ­®	ýcñ„pà5•xp-åöÑRAƒ'¯C¦$ƒ—˜_§FF•špüsŸ²ª#ƒW9½¿³ÓR…ä#CÃ!V&R6R±9­œØOcšÃú¿£ªoÞÝä<Cxñ‘¯Ù(É„¯ËÚ†Oìzkgç´ K]›FDœÌ˜‡"«Êji©®m>qx2{˜=ÊÆ±DVJ…séH	ÞºNï•Šn>qˆÃ*D¤EeÄ%ænÂFD5g÷´¨â$¾=þáÇ<c”ûbHC´9+‰PÏÖõQ)ïjj=ÌÝGÁÜeÚ%¦w>Ý=Kò*ÖGåD÷¿%b’+‹T¬…¼<Ú¶Û	ï³tøj?®¯õÁƒR=P`,Ô6j0Z /4­Q	Hž©J—Ú#mF›µíØeØ	â¬AsU¾¹XZˆ|(Ìd/}EPQØ–u„¾BGÐét‚”	Žˆ±>žÝ™•ôÊ&Ù}©¥ü-j4ïììÇ)Ø×"‹Omï¢…ü_Ð'{øû·Ìß®”µ!ì>° ŸŠé=„[Òt¥®)¡÷Ð Ÿè} tíŸ®¤µ!ìYv/»—=Ëž¥÷²{é³ÒßÞ—
+é(´ÓÖvÚßt³ýz;]Ùþc{0­£ïˆ;@g‚’ü†(O³ÈÊ2TR]ÁW¶.­Se‰qm:›Ñª)Ùxvq¥òó] £	•²G÷ó+JÞ	‘çCžW×1»f£tÐºQ§Y¥ÎEž¼ÕÚ44TU”«ô®Rº–6ˆýÖ#èÁ~í‘Ä={Tß%á¼‘¼áá\ÂÖÒBqÚN}ÖÇngâ¤\6]ÂÆ³wÄ®jøá&œ%%hRWóBH‘AG(Š‘æ’“Ÿi«Øi¶™]¨€×Ra©È #Ø‚Ë³Èã!Âèáu-­}=¿$ýH_=#ºÉí¢ÿ_]DÆFÄKZWäÖuË\rä¬•,•š“Õ÷_hý˜ˆ¾uÕZÝ¨ü¾öV:âHYõ¿|í)5ÝÜÊHÁ6l&~žú…„¾tv~..ùWüîãƒ·‹[ ¶ëË
+%ÀòÂ¤”ÂÊø¦ ì6‚MgØ×".K÷£«¦®ŒD³'ú“IcRó¡äIÐiuZCßí±Ub':­í ØÅQ†â4Ï¬ú=NË8³z¿m9+èò`T'&FÈã°º~xqx'½³rwàÂßœ@Ã–¡¥h5æ=BSo=qƒf¾#º>°þSŒUKj•Ú^lUò‡¬ÌÏQê
+x–åÊ¯Pùåéˆ'ÐBkÔÈ_Y¸øU„#¶*Û_Ñäiv¶Xf'h(¬Í ]LCFš&™ˆ®kd2ùÃ2kR"äXŠÝ8†³Çê©xk×±=ýÄî°:á„[çVÛõÝÍC©Ó¨¶,K^˜·@“fHE:yªç•«’x³uïþúÍ=‰§AGàs:æ7ë{v“áu+ÕW¸´ ýË•joÐ‘kôÝkÁÜ»Ä½[ëwHâ±Dž<Y›m(Î`adÁï"´Fz/JòÇó¦®‡žïIW÷ZÝ¨ õòÒÜô”¬èm={$o¢ëDõ®ÖÓõô³“œ¤ï}>¼:Œ»ÒY!žã&£ç¸­®ü¼£Ô]SUQQ#×Ç¡€dVÕ46{wI„Ï¹³éà ºœ†s?p‰wÇòjùÓllÇºÍq‰QPŒB^ÀVÀlv{võEÈWˆ}0Š…
+”I¹ë Dª7ß'¡ä,é£}t)u(CeEm|¼"g•ï¸¼´Ôëz'ˆÞí£¥Á\,÷ª¸D	H4|SU•¼9;?(ª(¨Ê­Ï«M yiëSÙ:«Ö-uÃb·8jz›]¨C¦^ÝUàA#b·?7?7ŸL{N°pQÜ*h†ûË.X,O}{KS+êQ¢ò¥TeWç7ƒ|wœŠšìz»š_Ø¤5h2ßXœ›ÀRŽlg|Y-€*Cÿñf_G€ §ú;:¾¹îÝNAw¥/ˆ;=0U\Zì(’Èn”Ì1Í2Ò‘f‘(åHá“´GŒì¡Áwú|“)×Td”C’’“‡…Gç‘úÐhñ|b¾l4¢Ñè)©Esuò¤Ù!$˜fB'qg¶*³¹ÖRa.CH]HÌf»Ía³–ó¾’êºªƒ>Ût€†PßÉ`ÎuMìÊ¯VI´04êµ«æfÍÅ|¤wájlmž=¤'ä¼íè.ÿ¬¹üZÉñ5»f³×ÙXv7{š…^|ƒŽ“4âœùdýñú®=(%óh¥øö—T_hhªªloïõ@:öäo“
+é½4ûËàÿ9S‡Á®·²x:“Mæ–ƒM8
+n4Ì-§ñt¦ÍjµÃµ«úah)ã%ûà*N ƒ$ƒhÄà**csxhÉ7Ä].”!½—{þË`ÎyF<4âÁ­b2:‡§–zC­F1´VÍ@ãÙL:yp9G8šM\ÎâÙL½ÁÀ[YŠ]êØ†©¥ŒÎ¡Ü*pˆÖæuäöÑ@ô…qèdv;G')÷‹¦¬âŽˆýcë×nKz„¼MË¶r‹pXzà¹ú5fIE½táàVqµZI:}"26:šW~D…¹²ìc"Ê´”ZkàÆîì}o4‘Œ.Üßú‘ï'aKØ÷CA"/C³´5¦:ù#äÆ<Sò‘#ôÆ"Þ(£Ìò:üNÌtŠAà‚v§Ýn©P]ˆ4d#×œm&çh3½Ñžæ÷4/IQ¨ŠÕÈˆ¨·8B_€|ò½_}Xr«óûJ©ðé.î‡® >þ>x`!µŠ1/õµ-ëÛL‡n‚¾uþ×0<LsÄl3£›GúÞó„ð^ê‘-„å°á·[Ž¤¾‡ð‘ÿ½¾#„{qðEñº-¯¥ÎÃ<¼æ_×G††£ßøÅt%›B§°•l%›Â†é6…®¤+é:…®”ðƒóuQç'Á\ò=Ñ¡¢¬MÊ
+m2šS%‹—L5í ‰mÀY¼é'ƒÎÐ(•DÇ†Ð6pà¶
+±Ë‰2µ‹°H:t¸\(S;5.ÔjÂ"ù¨]
+hÔj.5¡C¯²HZ…KãT—Áå"ÃŸg‘—ºN²ÜÙœøx­næ\àÜ¶D!|KBlêfð-û?áÜc<ø¹ŒÇØ}‘6z(ù^´Áî·Vwè7ô†yìÿ¼–e`
 endstream
 endobj
 
-265 0 obj
+272 0 obj
 <<
   /Type /Font
   /Subtype /Type0
   /BaseFont /AQDNYY+NewCM10-Italic-Identity-H
   /Encoding /Identity-H
-  /DescendantFonts [266 0 R]
-  /ToUnicode 269 0 R
+  /DescendantFonts [273 0 R]
+  /ToUnicode 276 0 R
 >>
 endobj
 
-266 0 obj
+273 0 obj
 <<
   /Type /Font
   /Subtype /CIDFontType0
@@ -3530,13 +3608,13 @@ endobj
     /Ordering (Identity)
     /Supplement 0
   >>
-  /FontDescriptor 268 0 R
+  /FontDescriptor 275 0 R
   /DW 0
   /W [0 0 280 1 1 386 2 2 678 3 3 358 4 4 562 5 5 332 6 6 460 7 7 256 8 8 307 9 9 460 10 10 743 11 11 510.99997 12 12 460 13 13 409 14 14 562 15 15 486 16 16 818 17 18 510.99997 19 19 537 20 21 409 22 22 755 23 24 510.99997 25 25 716 26 26 422 27 27 716 28 28 307 29 29 897 30 30 460 31 31 307 32 32 729 33 33 743 34 34 510.99997 35 35 525 36 36 767]
 >>
 endobj
 
-267 0 obj
+274 0 obj
 <<
   /Length 13
   /Filter /FlateDecode
@@ -3546,7 +3624,7 @@ xœûÿÿÿÿ ïõ
 endstream
 endobj
 
-268 0 obj
+275 0 obj
 <<
   /Type /FontDescriptor
   /FontName /AQDNYY+NewCM10-Italic
@@ -3557,12 +3635,12 @@ endobj
   /Descent -194
   /CapHeight 683
   /StemV 95.4
-  /CIDSet 267 0 R
-  /FontFile3 270 0 R
+  /CIDSet 274 0 R
+  /FontFile3 277 0 R
 >>
 endobj
 
-269 0 obj
+276 0 obj
 <<
   /Length 1110
   /Type /CMap
@@ -3638,7 +3716,7 @@ end
 endstream
 endobj
 
-270 0 obj
+277 0 obj
 <<
   /Length 4349
   /Filter /FlateDecode
@@ -3667,11 +3745,11 @@ Aòôºñ$6| :#Õ4æ"•»ñÑÛ×ñ{¼µÂ=Dú?¯Ch«
 endstream
 endobj
 
-271 0 obj
-[/ICCBased 272 0 R]
+278 0 obj
+[/ICCBased 279 0 R]
 endobj
 
-272 0 obj
+279 0 obj
 <<
   /Length 258
   /N 1
@@ -3686,378 +3764,359 @@ F§ëMkŠIˆ¹‘RŸB|êê&Ø¥Žn‚à¤‹¸º(¸H¹rëTÅ³üË9ð`ùÕ¨a”&åÊº»ãî:Ùl
 endstream
 endobj
 
-273 0 obj
-[297 0 R /XYZ 70.86614 520.94214 0]
-endobj
-
-274 0 obj
-[297 0 R /XYZ 70.86614 355.09534 0]
-endobj
-
-275 0 obj
-[297 0 R /XYZ 70.86614 257.45416 0]
-endobj
-
-276 0 obj
-[297 0 R /XYZ 70.86614 152.16797 0]
-endobj
-
-277 0 obj
-[302 0 R /XYZ 70.86614 701.00964 0]
-endobj
-
-278 0 obj
-[297 0 R /XYZ 70.86614 391.49973 0]
-endobj
-
-279 0 obj
-[302 0 R /XYZ 70.86614 292.05865 0]
-endobj
-
 280 0 obj
-[302 0 R /XYZ 70.86614 328.463 0]
+[304 0 R /XYZ 70.86614 520.94214 0]
 endobj
 
 281 0 obj
-[306 0 R /XYZ 70.86614 643.84827 0]
+[304 0 R /XYZ 70.86614 311.10632 0]
 endobj
 
 282 0 obj
-[306 0 R /XYZ 70.86614 680.2526 0]
+[304 0 R /XYZ 70.86614 213.46515 0]
 endobj
 
 283 0 obj
-[306 0 R /XYZ 70.86614 396.26602 0]
+[309 0 R /XYZ 70.86614 781.0236 0]
 endobj
 
 284 0 obj
-[306 0 R /XYZ 70.86614 296.14966 0]
+[309 0 R /XYZ 70.86614 661.04144 0]
 endobj
 
 285 0 obj
-[319 0 R /XYZ 70.86614 664.6956 0]
+[304 0 R /XYZ 70.86614 347.51074 0]
 endobj
 
 286 0 obj
-[319 0 R /XYZ 70.86614 635.8812 0]
+[309 0 R /XYZ 70.86614 252.09045 0]
 endobj
 
 287 0 obj
-[319 0 R /XYZ 70.86614 585.8422 0]
+[309 0 R /XYZ 70.86614 288.4948 0]
 endobj
 
 288 0 obj
-[319 0 R /XYZ 70.86614 550.4662 0]
+[313 0 R /XYZ 70.86614 599.82623 0]
 endobj
 
 289 0 obj
-[319 0 R /XYZ 70.86614 500.42722 0]
+[313 0 R /XYZ 70.86614 636.2306 0]
 endobj
 
 290 0 obj
-[319 0 R /XYZ 70.86614 450.3882 0]
+[313 0 R /XYZ 70.86614 352.24402 0]
 endobj
 
 291 0 obj
-[297 0 R /XYZ 236.96822 182.67096 0]
+[313 0 R /XYZ 70.86614 252.12762 0]
 endobj
 
 292 0 obj
-[302 0 R /XYZ 384.96033 668.1914 0]
+[326 0 R /XYZ 70.86614 632.48663 0]
 endobj
 
 293 0 obj
-[302 0 R /XYZ 524.4094 259.24042 0]
+[326 0 R /XYZ 70.86614 603.67224 0]
 endobj
 
 294 0 obj
-[306 0 R /XYZ 227.92964 611.03 0]
+[326 0 R /XYZ 70.86614 553.63324 0]
 endobj
 
 295 0 obj
-[306 0 R /XYZ 136.71214 315.94965 0]
+[326 0 R /XYZ 70.86614 518.2572 0]
 endobj
 
 296 0 obj
+[326 0 R /XYZ 70.86614 468.21823 0]
+endobj
+
+297 0 obj
+[326 0 R /XYZ 70.86614 418.17923 0]
+endobj
+
+298 0 obj
+[304 0 R /XYZ 236.96822 138.68195 0]
+endobj
+
+299 0 obj
+[309 0 R /XYZ 384.96033 628.22327 0]
+endobj
+
+300 0 obj
+[309 0 R /XYZ 524.4094 219.27222 0]
+endobj
+
+301 0 obj
+[313 0 R /XYZ 227.92964 567.00806 0]
+endobj
+
+302 0 obj
+[313 0 R /XYZ 136.71214 271.9276 0]
+endobj
+
+303 0 obj
 <<
   /Type /Annot
   /Subtype /Link
-  /Rect [236.96822 169.09595 248.58423 183.75891]
+  /Rect [236.96822 125.10693 248.58423 139.76996]
   /Border [0 0 0]
-  /Dest 286 0 R
+  /Dest 293 0 R
   /F 4
   /StructParent 0
   /Contents ([1])
 >>
 endobj
 
-297 0 obj
+304 0 obj
 <<
   /Type /Page
   /Resources <<
     /ProcSet [/PDF /Text /ImageC /ImageB]
     /ColorSpace <<
-      /c0 271 0 R
+      /c0 278 0 R
     >>
     /Font <<
-      /f0 241 0 R
-      /f1 247 0 R
-      /f2 253 0 R
-      /f3 259 0 R
+      /f0 248 0 R
+      /f1 254 0 R
+      /f2 260 0 R
+      /f3 266 0 R
     >>
   >>
   /MediaBox [0 0 595.2756 841.8898]
   /StructParents 1
   /Tabs /S
   /Parent 1 0 R
-  /Contents 298 0 R
-  /Annots [296 0 R]
+  /Contents 305 0 R
+  /Annots [303 0 R]
 >>
 endobj
 
-298 0 obj
+305 0 obj
 <<
-  /Length 4411
+  /Length 4826
   /Filter /FlateDecode
 >>
 stream
-xœÍ]Ý·ß¿bÒØN.‰y"©O 8)Ð¢)ZØoI|n.MÑœ[çŠ¢ÿ}¡½i(inGÞöÅë»›Ñp(òÇOq¯¿|wÿóíë7÷ÃWß¾8üó€ƒÔð§À[‹zpAÛáÍ/‡ë7jxñò †—/þx áß=|{ˆ7ürÐ†ÁhæA?¼<üùðÍ·/×/ÿñúnøüóÃ0\ûâw_êðÅÃW_'OBåÀ)gÝà´ëLõæ×ƒ~}swøêÕA¯Þ®oÕ€È¯nçâÇ«_ß}ü½Rê{¥ðjð<Œ?Ñé“¯òÓoõéÓœ>íxÕéÓ?oŽÿÞÿ½{ø>\q›¬þnqB›=ÙÔ(@—<Q‘:}ârM¢=ãµ'ˆÊ¦N++ŒÏã«áùLÄ% {õÃðê÷‡o^ÙbÐ‹½Û%&ÿ÷‡×w?ÿxw%ÈYíÑùÁDÁÛŠÐà€Ø’¦µÄd²Â™YËŠR”30E’ÞJ#Ž/å	”%ïêšP}©I\J.+‘üéµøAðS*!ã:Ìéu¹ ŸÖ½IWQ™¢k1ˆÛnl°n°Úƒ÷Œõ]gP¡Â#I¥ß¥JŒîjà	LN<}×¢]‹0Ç'U±Ä€¤pÇæ*ÌdóD.=|Þ_ÏC RÁã$Ö¦`ÒãÆgˆ1îä(ÓþOp·€¹ÛY·Ù{”Éa}>
-ËdoÄÃ2['AÉ¤íLÿv"¡ö°Ó^Þ·äÐrÈÁ‚ÒÚÒ9¤Áƒß$ˆçfn$o’»ï“¿¥Ú:^‰-X: h´Ù£‹¸¿^ý­òxW‡åA‡fðÈÚñ³ ˜'!%tÞ^é[§Ðæ:?êW"¾ŠmâØÔD|T–L*&Ò\‘„Ó%·’ú?<rØ@ëm†KYž:Í¼ÄËwð&E£öÛLÆ“ÛŒ‰]©Pj°Å};.ñ›°3ÞíØ’+'ž\Ù¥ct»±|U]L`pAï±œ¹ôOÜ•µ&ÇfUâÐÞ¹0™_5Ãz~iÑ®×L°o’¾,àxxÒ‡[Mãê)ù¥PÜ´É¤üF!òoìgL·y„Ùä¯.‰jjf[Jù|{
-ÆE_›!2·:×ÏãÂO2alèX¨ë˜€ŒçëØÓ„àT¸#Œ1 -ªÙÑTÉpPg×Ùâ3n“ý¯\!8¢+zWúa³-Ë¶J–E¾ó'¥2U€¢ÌÎa’8L|ŸU0Q¹6ÃšÛÊªëd}œ)àÚ¬µ]¢ßþ@Ã³4~©òoyÿËÜNK©PÕµÊjÐÖ£Þô¥ø;îtÊçF*ëj@†,[·3Ê×ÉhÉVé±+LW^Y², ÔPç[)‘A²™.Yü[‘W2ëÄ·Î#¸&‹lé‡ëÅ/7×õ53 ,Ùû572Dole[	±®„:€W†Î×Á•±¼
-dMþJ5'¡à‰SiÑ¢HŸžEK™[µ-˜}ÛÕcÄ\ÌlïêJmá²Ó¼¾tGœWzîM‰òãQ
-ÄÒòÓB¼u‹msÍ•…×$%+d´§oöAá!mÔ:)—^™06€šve8¶Å·fci$aÍÊÍíkæm&¤Ý§Afn¢²=ÊÀúv‘eX¬VÐþdeùšÜxï›¢mšeËVäf!¥DýT2J;çjÛÑ0èrŠM6’l(%Ü½Ö¸›†©ž’G'vY4"ü4!`òÛÌ3›W:ýÜ¬‰ ©ñZ;µÛ¡jQX<§ N£›óQ=áþ	ÉÔ6DÂ¾tÅJL—=zÞ°ÂV¥ [ìÖ¶I9hbŠ}Ø¶o­D|šöyÕ,T¡”ž&ã€b ƒ@‰û¼²Üéïg‹¶x5q×²H¨ ¬ž%½WA„í(TRÊ:3^c™_¸Ms÷¤l©FRZ¹.rµ(„fš0þŒ2<F@|nœC?û,¦öG[“äl{Æm“=ÛY2t“‡¡
-©&@0¸…#žUˆžY¯<áêE™£šùãS¿º>7;ÄÌ†ñ@Ì›ÔLÉÏ%£A3ë9­#f¯Ÿ&Ö)oœ1¥ÕRÔÈ’Ê§ÛE"Ò $¿qùÕÒû‰à'å»Š"ÛžÖÁbe*CÛŠ%fvÊ…ÇÜˆV8TLL¬/Ý÷Í‘g‚µ)¤¬ÌGYKŒiiV±E ïïiò)d«¦”´”…È˜$:{íwƒ>BðF[·éåÚÀ™Åá“c0‡S-*¥àµÖ:ôØ(,: “Âð·$½¥U1ÉPVÓìÂ«ÔþÈõA1}xr½¤·ë“…Î–ý$þóiüç³âƒËAuµr&f<ä4.’âL­Bˆîr™Ÿv`Dùœ†…3ÔtîIŠµFPÎõ€Ÿ'e‹Î¢8e¯4åûáRŽk5!yÒd­¢3+°dö¡s¦±™peŽn•“uYrH¼¡Œ·¾V6Œ®nMŠÊ¼^¿Ðu Äìë{Ë¾ÀêÚ<NÏŠñÉJJ@Wè4hTíB¦°hfìÓ5Ì®›¯jkf~J'okà‘YüÈ>B’ÒZ‡¨!è7éJø6ôúMâ™ç(3g@¥IŠÝFÎ›.`°µ;ƒê)–Üž:ò¤4¥V(!‚€JÍ§*j	ÂgU@s…5Å"ýÔÓ˜Ê)¥•lMráóÓÿÅ÷¾pƒR’†ÊI)–Êvñàøî×3½ªH€X\Ë[Ó².€µ •œ:Ìq5em…1£ç´j)½÷¹á«ª¦*
-aŸ¦ŽÜ¡ågr2¨–[ûÂ#K´Y›~Ž]Ó1r}ÒŒ¤ –‡Øòææ™¥)ÈîKÉ¸pD¥½ÜØ$"
-lR›ŒqA «eA‘‡[zšgµÞR@<£º¡ÀÇÕ,;óž«F©VàÛGCžmX|¥’³ŸìŸâµRõ NÊ†ÊW«¬kIZaƒÔÎSŸ’zÔ<XÁR04ÚÐ‰¤Q‹xÙÆž‚ÄÆZë@%åh}Æµ¦L¥TÍ½™Üù'ÙÚIÏïx!·B<gz2wA­/y¶H¥r÷Qs[ª5bŽÕ!çÐžm•Ò
-¨ÜÁÔ"QŠ¼C ãÝF¹z&çx ³Ž'ò±œ > ëBµ(O:‚Q†l¸E‚ØNœ×dúÐ 4h±¸ÄÊY2]H0-Ä¦A¶ŽgÑ{`[$ˆÉtM`­éDB“r¦Ü16P\‹ñØ¬!ð6t!á¦E€h ö;`gê,'!m–)»ÙàýÕ[üZm©ÿ›·ØQµ‡3;p²»!³uœZ²L¬‰'göFë§–ÌEôpHi}{¡%{ÁÚG¯è"öBKö‚
-®	wŒd,ØDŒb¥/“F2§QhÍ]$!Fmu$cÁ6 Ëö0i$SÁŽãì6ÝarWH„Éásk'¸–ž„È³û…L†…i¦ dýˆ\lDv  Á;ƒtö¶Þ¶¶U²~D
-|]h{ƒFn”T@ÚìBBgØ©¼Eå:Ð9	èI@£ô®çŸ”k=á¤%™î“5ñ0¸3]v¥åZ	ù)N¦Bíöqe+ò[	ù) Xe»p¡¥ŸVä(G¶¡§Xq(O`ðdù"êi%”de@sðæêiÅ™*Hà(Põ\uÚ¶3qVö=(§_FAe™=›Ëè§è Ç&ck#¬¯ÎyÙ©¢s¬hÚ'»Ç<*e/¢žNvè8A°MïØI(iPÔ]ìçœ%>RZêéª¹{rÂÎ@µÖŸx˜C)ÖqoqM€ò£WÇ ××¬Â"™SOÌ–^áA…é¬µLhüÉé­–hÅ²®•´Œ´ôÁYÖÖMZj–!ÌX•ÒS˜RÙ˜ìäLv¢¼ÙlYàÃù-äEW}c-õÔUõ´tµŽÕTO·è‹%åQaFÅ"Š}öèÓ¡éšÙ¨©¤b\:‘U8»ISÈ¤÷ M)¦:¶qÊ†cTã@™xÄxËfµÑÆ~ž8êá]©}wšÝ8F Ò~— Ž›Þ4ß®ª
-ìCÌ„w«2³j2Å×ªÌ=Hú¸G5÷ê%ÜE%9†c¡ùéÕÀ!&[NÊôD:Sœ4¬F-ØM5bWí1$Ô`ÙT™úÞkÄ^ÕjÄ[HÜ[#öX«÷  ¥Žžª5â$´ÜiÏõqZYA¯«5â$´‚Koª5â$´r/ÞVkÄá‚«Öˆ{ÐŠq½¯Öˆ÷“Ð*~øP­ïÇÎË•Uƒ˜TU
-¼ã.¼l•Uƒ˜REMJ_bƒ˜T%ÅZñE 6ˆIUrÀÈ]Hh¥4ƒXybgC'´%ˆ~=;°VqI æ6ˆµ'MtZÈäÊ“Â“gû‘%/«ž_]÷CWàIîvÎŸ¢êã1³Ð3ýkK
-Í)²=é©•üð@KÅQš!nÜ¼– ·Ü¤ Y&m4RÌÁïŸSá°5…IÉÅEGÍò€ÇÜkú½%áQ‰E)0šºPÐöVQ‰&å7(ô]hhY5T²M‰‘;Ý†–MA%·3xpÕ>.œ[ÇF%Zmâ4€Li»¯¨D+cTleÓØ…†–­E%‡@:hºˆšŠ=VƒCÓg#ZÑ*±©ÁqœÒìe´Tœ|¬è{2t	-¦R `‡~Î/g£8P’ã×„!ÓeôTœjÈñ…Èvñ¦žŠScM]«p¤!–´õûÔSqÞ “åõ¥6BNŠÐ†_HOÅæí@YK]„ÚÂ ·7pFù“î=B…Üý«Á1ó€ÞsLôspKß97?4j -?}éœ­“ïs 6¾tNtÆ–Iw‘4jZ%qb;GÚî³ŒÓ™âñìv<g=±QƒëÂ™VtŽâ$§¹¯£gÆLÛT¶ùR­£#°Nû^;¬¶±æY6™Oµ/ËËÖÚäq&[R¹ÙÀ–E§@~åãúUš[&'šb"ßuØ³#cŽ$û61rÊÉƒñš¸‹ ÍƒR¾^÷ÿê&§ÄÄîPÄX®Úò:{s (raÅ`nÛ~ÚÞ‚8À…Ñ 9Ã]ØÐ¬ã£8š‚IëFC±Å¹Lž™]šâ Î`&Þpyà¦ç&ÝgM±b´‘†öÂ5§o’žÍ;‚õ.™”Òp­9ÙÊ…Êß[QÀø|üvá+
-_/Ò²1ÙÐžUÓ4dãT,äºý7”ŠÏ‡ïÇ|?`žA_ÍM'“,ý…¤•,ýZ€ÇlAmÓÏoú»¯çÈºÚ¹çÅ‰
-±‘X‹fÓ>·GRæƒfßˆ“²qº:0xFÓŠÃŽQOüRö]R¼Ý\UûÎ££ýN}gŸ´™Rí:ëAÐ§nûLl…eaí‡“å‹¥Šãkò¡þí7r—¯@¦ÍÛjóYl°bÜÿ´ùuµûl{»ÏPWÛÏzÐTK]ï?ëACÓ‹Ô´D4ÝH]ï@ëACÓÔõ´44ÓSºÞƒv>Ô›ÐöÓÐÌ„Š£Ð0(Œg /Ã…RZPº“D6Sóâ8ŒmêèºÐÐê˜AqÆãfa«^þ¿4ã¡8Ö!6Ãan¶ºñÐ”šœuþ2G‚p<FÛh.bqL½­1ŽkÐ g´}hhCLa‚?=Hh'ýåY†Áš.$´Fìˆ0{,|¨óñEn©šJ^D|yÿúÍ_üËðÝõWoïïßþòCüíËÝÜÿç?×¿}ûöþÇwñW¯Ž?ÿéõO?ß½¾ÿùí]!`õÞù!ìAm|­VX¥:5ÿ†
-îã
+xœ½=ÛŽ»qïó­£‹Ï:Q-«ŠWÇ0p$;@‚Èˆ!½Ù~Ð*gícX+[žÀÈßœ¾]${§©yÙÑ®ØduÝo¬¹ýáëñ§ûŸŽÃ›wo?à 5¼ÆÁ)ðÖ¢œCPÄvøôùpûIoßÔðþío4üó ‡w‡øÀçƒ6F3jøëáýáw‡ß¼{{¸}ÿ·Ã/y†Ûwoÿã×ƒ:üêWÃ›_''¡rà”³npZu&ŒG}úÇAÿøôpxóá †_·÷jÀ d†÷óñãÃçÃï¿ÿƒRêJáÍày£ó'ßä§¿êó§9ÚqÕùÓ>ïN?§Ÿÿƒ+î“Ý¿.Ö)´ÙÉ¦ºäDEêü‰Ë=‰ðŒkÏ0'M;œwwÏã›áõÀ%½ùãðá?¿ù0²Í&Ä ´ÛÅ&ÿõ_þ4|ÿãÃÀ3d	´Gço+Lƒb‹c˜Ö“ñ
+xfÍ+JQŽÀüIz+`8¾”'P–¼«KBõ¥&Fr)¸¬Dð§×âGÆSL)‡Œû0§ër>ï{—î¢2&E×BÈnl°n°Úƒ÷Œuª3¨PÁ‘$Ò_S!Fw3ð¤LÎ8ýÚ‚]‹jŽÏ¢b‰Iáâ*Ìxó.=~o†×! ©àqbkSQ`Ò#á31Rrä‡‰þ“º[¨¹ûX÷Ù{”Áa}¹
+¶ÁÞ¨ËhE“¶#iü¿3µÃÎ´<¶øÐ|ÈÁ‚ÒÚÒ>¤ÁƒßÄˆ—)ÍÜHÞ%O“ÿK¥u\‰-X: h´Ù#‹8ÞþR9ÞÕUò C³CðˆÚñ³ ˜g&9t&¯d-‚Shs™å+a_Å6qlj,>
+KÆh®ÂyÉ½$þG`½ÏôÃ’—„S'e3oñlù®“¾IµQûm&ãÉmDŽÀ®D(5Ø"ÝN[|—*ìw;H’êÊIO®ìÒ1ºß¦±|U\L`pAï±œ9÷OØ•¥&×Íª„ ½sa<2¿jVëùÒ¢\ï™è¾‰û²€ãñ¤ç[Mãê”|i¦(îÚ`Rþ ùˆö3¦[˜¼ÂlòWK¢˜šYÆ–\>?ž*ã¢‰/²Í¨!2·:—ÏÓÆ/2flÈX¨Ë˜€Œ—ËØËà”¹£!c@[T³£©
+z$W€«€:[g‹gÜ'ô¯¬Ñ¼+ù°É2RÉ¼(¨ïü¤”§
+ª(ó„sµFI&¾Ï*˜¨¬ÍtÍ}e×uH²^#§D
+zm–Z.Ño„áU¿Tñ·|þÙ2·Ó*Tu©²´õ¨÷}©þ)â¹‘ÊºÐ€!ËÖíŒ„ò}rZ¢U:ve€iãÎ+K–¤“êœ”$›é’Å¿q%£N|ë<‚kâ±ˆ–~Úa½yâåæ²¾Æa¦Kö~L£7HÙB¬¡à•¡ËepeG,¯Y“¿RÍI(xâTÚ´ÈÅÓ³h)s«¶E ³o»:FÌÅÌö®¨Ô6.;Íë¥;â¼Ò¹wyt&òw®RE,m?mÄ[Il›{®,¼ÎTR²C{úfÏ
+‡ül£ÔI¹lô
+È„Á°Ô´+Ã±-žxº5K#	jVÞhn_3o3í˜™¹‰Êh”)ëûE–a±[Aú“å5¹ñß7Õ¶i–-Û‘›…”õSYÈ(ìœ«‘£aÐå›"l$ÙPJ¸{¬q7S=%Nì²hD:ùmÒ€É_3ÏlÞéü{³&‚¦†kí4XÔn‡¨mHDMÊâ5pÝœ7xŠè	ÏOšLmÓhBØ—îX‰é²£g‚H•*…Üb·È&å ‰-(öaÝZ‰ø4í1âªY¨B)=MÆÅ@†é¼²Üéßg‹¶x5‘jY$TPVggIïUa;2•”²ÎŒ×XægÓ¤ž”-ÕH@J+×…¯…ÐLÆßQVQ!¾6Î¡Ÿ}SûO[ãäŒ<#ÙdÏvæÝÄa¨ªT Ü‡ÂQŸU€^Y¯<áê¢ÌQÍüñ©‚_ÝŸ›
+bfÃx æMj¦äçƒÑ ™õœÖ³×/ë”7Î˜Òn©ÖÈ’ÊçÇE Ò $p­1òª¥÷3À/ÊO2E´½¬;ƒ•UVm+”˜Ù(s#ZÁP11±^º!î›#ÏD×¦*ee>Ê|XBLKr°ª[´òÞñž&ŸB¶jJIKYˆI¢³×~71è#o´u›^®­8³8|ræpª¥œ öÀZ‡ˆÌ¢0)OpKÒGZ“ì€²˜foRû#×ÅôáÙõ’Þ®O:ÛöçñÇ¿ÄÿZ<¸TW+gbÆC> ép‘gjÅBt—{ðüDQË'ÊiX8CMçž¤hQkå\õó¢,rÑYd§,ã•¦|Ÿ/ù¸Vã’'MôØªvf–Ì>íœ	Cl&\™£»'ådgYGV o(ã­×Ê†ÑÕ­IQ˜×ûº„˜}ýlÙX­Íãô¬Ÿìô\Rt…NƒFÕ^ d
+‹fÄ¾\«ÙuóUmÏÌOÉâäm<2ŠŸØGHRš@ë%ý&Yi)¾½~{æyÊÂªRŠ¤Ån#çMe°µ;ƒê)–Üž:ò$4¥V(ß] cµ™»q+ÂWUæJ›Šeú…ZO£>*öä°–Ý¥låëóKœ@ùÝ¯Ü¥”Hò
+–bÁl'Nï;ƒ¬Ê0ˆU¶¼G-k8ªäÞa®aSüÖ°3:Q«N’A«ª,*
+a,VhÂ‚3vQaX²çø‰åjY‡±c¬xˆ¥Üu;ÿúÔšõNÖ¶à‰7‰™« ÇnX“1GÉŸyØ°ëXÔÆÔ%Îf”ÞØ¼"ÊW )´nzÁwRpKWvæ6å4®DÅGžÔ®Ä[½š©ao!¶­ìÉ e5¿IËeöìqÝ³ÝŽ‹iŽ¥åÌ¦7ÛA€6zJEežö¹§HXe±lyç¼HTkûXF£ž(´z†´T˜àÊ2 iøóª~á®ö¶ëÆ#Ó~OYJ±eÞzêÂ÷’x,e]8(ÐÎ©oÇÃO-g“ºµe¨LÖ6{ÔÕèÖäªÍì‚c·£¹®Tð³ùæ<‚Wž0mYÊþ\v´²u¥¢mÞZ,:¥û½’)“ë‘Þž+‚=÷^øZÙí„<rÎ^§‡D UkpŽÓvb•Å‰àÁx³‘¹¶vH$E¼ÑNeÁÆÝâÚTû*7KÙÖÈ:cúHÆÆäKy6Ê{»”'všLŽKR\{žÝöæÙNCÉT>zû//¸-šEšè%eX´cšw ×‹äâÀ>Y<¯ËØ­ü «,ŒjOZkCMýù®+áí[µŠÛÁƒ"ƒfÓësõòïirDµ3Q‹þ·E ÷‚¸ê»ðàÀÕ` bÔ0>ø.Xàâ@@Š¹!tÉ{A@¹ÐÓA4rJ&CWbG±ßOù8v§¶‚d¢xö¤»€àZ H€bï‚
+Ä=Ôâfm$MäÁ°ê‚».zS™Â	€+((#ÃÑ`5ûpeÄq3Æ§Í5è ©H²¼G­¯"™FR‘ät¢íU$Óˆ*ÒyPh6ba«d¦ÞGiüAæ­d©M)"m7ô´T‚NXy#¾Q·¸£O€dlêdÙ—¨V©¢åi<[óœ›á©`™,my×…V9°ªv¡eybn5èkLNpö{Ræœú“JsCFÁr×nºØjBž2X½TvÿEí¾ì3cQ{d¥‚B:”(¥ïÄ2ÕÆ»ESr¥tÇ¸×{I·—æ´ù‹lï$‹5'ÏŠ0ÕzÉ«…ÖLùîgM²TïŸ‘õ±ËmÇõÃ4•oì¶@”l{ˆñ—Û"ïšAeÅØGð]‡óÛî•µ…na£Ù <´ çp‘ç5™œ’£uÄáFL œ%Ó„û âä—X`=M]ÝÀ×Ö04ñ*‰&°Öt …'f„´cl .\Ðò²˜2Þ†N ´¼l'&„ŒÔ>p9§èNz]™¦’ÚÁ¹~rÁUöÖøÙGÌ›@ä¢˜èî<Ð°N,t’kâ„¨¬A-ÇÓ‰##ÙÆ+…ú:¶ÂI¶‚µ^Ñl…s¥"Jp] h_hwr'ê)VúŠR2§.kÍ]ø€ZY!/¶8X¶WQ”^2ì8¦KÙtW”»î;fá—Üõd%š-ù“÷±OÈ=‹®ÂfÁ‹é>rñÊ]°ÞÛêºoµtŒÓ}¤À‡Ð„¦7èÅ„+ íö ¡©i½˜ðÓÞ¢r]ÑRt^Løé h¢žÛÁÔí>¶¢Mj“?Å"‰5qø©3]˜£å$z±H¿‰µÛ‡—múß‹%’€`Uì´º†Œ±4â(G]@hE+A,O–¯" AÒ”¬hÞ\E@ƒØ"ˆŽb´ÒC@§ñ7g›¤šLe?ÙƒrÊðU4È~2ûè|sù¢“GjXÏg°Ñ~Kñ”»žh×"‚ì%ð¨”½Ž„Ê~²¿2§‡€¶ÜdT’ž4¨€M¬vÑ‡ü?ÚÃPëé{f{‡¡Vn»ÆùEJù‹&œŠlºó.-4pçk¤fyÌéè–ëŸÂA…± ÙmjáÒFoó&Òê¬Å-­$-ï<Û~w®†õs8õ°ŽeÆÂ”›â•
+a²vþlˆjs¾@—OM)¸ºªÓ”OªÊ'àXÌÚ#ŸÍï©¤¤H*Ìe^Ä³¯ž<1ï¶O(&Í¦Ê¿|•¤Ö‹>ÇÞx|òX*d›'KË½)”‰s5·P«Õ0jøù¾Ê«„+Jw7v_PB%:sŒ@¤ý.VÉÞ¶ Õ›tü²˜€ýŠÍm•­U›{Àô}ªîÍJ¹Ë‹XsÁùåÍÀ!&^ÎõBš¥™4¬Äí¦Z1*W¥´S`µ­bõ›‹QùZµxŒûªÅ¨B­\¼€¶Wò4ý©^¼†V åQâsÁ¸š)B”'+Oãý0´ÂL§ûÎ%ãý´’0(ÎökÆ×À©{pB+ÒEq„ì\5îC«‚â°Ø¹l¼_{^¯ÒŠâèÔØ‹ï÷Ág³ÔŠâèQBMJ_IÑŠÃ=‰kÅ×P´âÄXbä.l.3$&p6t¡©cÄA…Ä¬UÜ…Ún°8ÝŽ4AÐ`hëqfi„·YÝ'V\//˜®ÇmT•ø]«STýŠv‹¦ÿ›—BçÊ†üO:¹)›³á‹ Ä/ÛÔp#õZ\ÜÖhâ¬2ƒ ‘x›Ï¤öy,â01R.zm–Œ	Ù Ãä<ŠSÄ¢}3šúÀÐö^ÅéItŠ#ú0´í›8Ø%^õ2ŠîB‹¦ug°Ä;^.°Ú‡‡Ë‹Ü(Îþ mâhÜ.ˆi;µâ`X¯°Æiì CÓìŠ3-btÐtQ•gXMB4õ•8¿€Ç/¬öJrêKÅ~O†®$§rÏ;ôûðpy­Å+ü¬8dºŽœŠ÷èã=zÛE‘7åT¼FËíZ…±Þm}K9¯Ñ39P^_‹r®Ü€6äø:’*^¤ue-u±êÑoÀ w?pædP=0»ð-tQ¼IoK;fŽÌr1ßÓÓýáëñ§ûŸŽÃ›w…C£èêß¾?¨áýÛßh=üó ‡w‡øÐçƒƒ›þzx_~C±»Â20é.¼Æ­	(^ÔóYi»Ï6N§trä,ÞÙç8JÂPp]0ÓŒÕÅkûsÓGÌ<,Ê-:>Ä;üse…<XU‘¼¼ãÃZ`K¡fxeû	}
+òhï-Ülxù¢… _ù´F–&ÉäœSÌí{¢4ñÇ/âk#'Ÿâ0MÜ…æi·)^o3BåäXÎ6ÇÎ5_G,â©€µáuvgBÄa
+¬ìÉkÛBÛYg ‰ãbBh/Ïš ˆFŒ¸> |×@4aÄà™cRu/ Ï[ ˆ£˜	‚7Ü^4£M±l´€öøÎ\SNéÝ$3+Îâ¼o˜‘Ò—KÐº…,Û¡ü½Í½žÏF+|asáëµ[v%›W¿êiš¦QnüV´u›újPÖRÙùÜàò—”‡l¾°wé#$meé×â>…5¢_Þx¬çöº$Ú»ÿLœ°@±)X4›èÜž,Žƒ\Mq‘O’¸üK’PÎp
+sœrv?B[ŠäáøáxüøéÏ?þÏðûÛ7_ŽÇ/ŸÿÿúþïŽÿ÷·‡Ûÿòåøã×ø§§ßÿûãŸ~zøxüéËC,Þ;?Äëª¨w—Âý‹èÿAt"Y
 endstream
 endobj
 
-299 0 obj
+306 0 obj
 <<
   /Type /Annot
   /Subtype /Link
-  /Rect [384.96033 654.61646 396.57632 669.2794]
+  /Rect [384.96033 614.6482 396.57632 629.3112]
   /Border [0 0 0]
-  /Dest 287 0 R
+  /Dest 294 0 R
   /F 4
   /StructParent 2
   /Contents ([2])
 >>
 endobj
 
-300 0 obj
+307 0 obj
 <<
   /Type /Annot
   /Subtype /Link
-  /Rect [275.00125 639.9534 286.61725 654.61646]
+  /Rect [275.00125 599.9852 286.61725 614.6482]
   /Border [0 0 0]
-  /Dest 286 0 R
+  /Dest 293 0 R
   /F 4
   /StructParent 3
   /Contents ([1])
 >>
 endobj
 
-301 0 obj
+308 0 obj
 <<
   /Type /Annot
   /Subtype /Link
-  /Rect [70.86614 230.96942 82.48214 245.63245]
+  /Rect [70.86614 191.00122 82.48214 205.66425]
   /Border [0 0 0]
-  /Dest 288 0 R
+  /Dest 295 0 R
   /F 4
   /StructParent 4
   /Contents ([3])
 >>
 endobj
 
-302 0 obj
+309 0 obj
 <<
   /Type /Page
   /Resources <<
     /ProcSet [/PDF /Text /ImageC /ImageB]
     /ColorSpace <<
-      /c0 271 0 R
+      /c0 278 0 R
     >>
     /Font <<
-      /f0 259 0 R
-      /f1 241 0 R
-      /f2 253 0 R
-      /f3 247 0 R
+      /f0 254 0 R
+      /f1 248 0 R
+      /f2 266 0 R
+      /f3 260 0 R
     >>
   >>
   /MediaBox [0 0 595.2756 841.8898]
   /StructParents 5
   /Tabs /S
   /Parent 1 0 R
-  /Contents 303 0 R
-  /Annots [299 0 R 300 0 R 301 0 R]
+  /Contents 310 0 R
+  /Annots [306 0 R 307 0 R 308 0 R]
 >>
 endobj
 
-303 0 obj
+310 0 obj
 <<
-  /Length 9623
+  /Length 9177
   /Filter /FlateDecode
 >>
 stream
-xœÅ}[—$Çmæ{ÿŠ¢†3ÔHLà7‰+[¤$_é•—³ûbùÃÕØÚ³"½ôìññ¿÷AvÝ2™ˆîˆJ½°9ÝUÈàûðöëûæ»ÃçŸ?o¿úòo~}¿üåá‹_ùðÿðáðX2„c9äX@0§Ã·zxûm8|ûïáðïß~÷ðÅ»‡px÷ÃÃÛá€xx÷áòmýñîO?þ}á÷^ÞýŸ‡ß¼{øÇ‡ß|õåÃÛåðh 
-Ž>q S€
-¥Tä# P@ˆRíà;gx1‡/+êþŸÇÿáq0æ×ÿ|x÷·EK ŠÀÂG,Hvf$Yp€§DG€l	HÊˆð¶d±†Œ2æý“#@5ßŸAR®¸Ç–DË(RŠ
-J¼ÿžDË*R&àÊ€=0?þ¤pü‰Þ®DËNRÉ‘ÆØIo[¢i(+C ˆ´Ç¾DËV22Üá¨´,#‡¡ðˆ%pµÒ2ŒŒb•¼Ë¶´#S
-…FìY&´l#³ê`"¯ƒ–qd5ŽT‚„@Dé~ZH–mdQ-Œ${²¬#Ç¹ì¡‡dÙBNBÊC\ò´€,[È9BŽXÒ!§%ÉýL™–0dV%P2&é˜‚¥ßþ«>þñÃ7ß~<|ñÕÚ¨	ÓeÞ¿üú!¾þòˆþãA_=è—þôAª>àÿ>|½ú†¦±-LqÌ{¶†Ls[2Å4Ä £ÀÍ^ YXB‰#¶>±7'–ý€#ŠŒ˜“ÀÇ9yœ›÷îŒXö8()¡2'=œ¶ÂMh¾R'éÎ?OOóŸÈ3ÿîãëÃ›!%©ñðãÅGxí#N7èÙXÖ³Nnäñ#§/&ó¯âñAÎÔ²š¨’´M-
-”Åþx:smÞl^Þ_¿üŽ:1›ý³¥xýíOŸŸ¯ÊqX>NG8íÂåÚº»‘Íƒ	¤¦Ø¯{æRó4Y/MÕ8ýœæâÕüíNš¹¡E§?iæq]N_=iÕi+Ä×*3Uõ5Ê:¸+„P…[fì©§ÖÖÁ-T!ÆXó 	üp“ut‹èÑYãˆ9`ô$°ŽV‘i”Þ1ÂÖÑ*R!SÖƒ¬S‚ƒ7¼yŠÆ%×GL€ç?²uŽJ*„Ú&à9¦CVÎƒ¹i8ÿ]ocç¾8=&Ë»~ûˆ&„ˆ”øù/»~PrÉ€CZ9)/ÖŒgï*×=YÒ4;˜ŽFñòµO6F•¥e½±G‰¦CíÍÂt‡ÛÎg¹Â§ñN¿?u8û÷SÌN¯½ö‰ÓÁ4?2díã?ÑÿüTÿó³Ù¡ìê”ýß¿ÿæ»9üøß½6ïƒ!c.MÆ›öfæ“Æ—s·áèU]Ep_Àò$àTr±+lMœ-Ìy7œ^,-ôC–zúÂØgGakãõ:/Ü	¥M+©õÊT,~^9]·Ft±Å’9×]YÃ<Ï¾s¼>,oÇóÌáí^óã´òÞÝ8ªÔB”›+ÊÜù?êÓâg/µTáÓ6<?yîÿú†ÅŒìD‚¹Mz]T1c;) Šh˜¹S‚O¼áÍÀKÊ 9Kéþùa1C1%MR÷¯‰ç°Šù®¤´	à—Ó¹§ÿkð|/üÐ¨Å¦Iˆ¡I^çêþò‰òKÆë|ë^XÑùµÿñ¤=\½òî+[^fDÌ9õ,Ñy…‰aë J¡FÙŠÈòhSKÂÙÑ|ë¦ñ-£
-¦:Dœ¹É¾üE8åÑ ãü,[xR¯ŒPk­éxà|zQ†Ãe‹¾aºñtOÇË•úül.ØyÌÙ9}í9§ÝçqÈÅY<R.œ¿ÇOOÛ®Å_$ŽC®Ÿøòj°×7xµêvNÿøÌU‰M)ÅXQz\¤³ß8?À_Þ^ñC/>Çb–iò¸ö<û®z–#m¹7O{¿y;š;—¥>‰÷x¼˜ñ<7€Y®o[3)^é/nß(nÝWÏcÜ”¬Î[<_Ã3ç1ëŠø‹¥:¾Ž{"EÓ¯*5æ~å›Ä˜¦¡¸¢˜VMsb±ŽfÁ˜o{ÝÎ·ÞÅç§?óÊ³>4ï5Ü¼®-—vqU™í<Ës¸w²7Ž0D*Ò3ÓÏÙr:EíÌ)S^»Ÿžý•Eèdy¿¡•5ÆñYïéÆ·„Ñâ3?½Ö­å-ït3_þ:odbv¶Fi¢YÊ—#„€(À4ù¹m×›U}%AÂ<D–SÒ‰Öfqžœ³BÍúÊÀ)6î(/áe¢Y ÃY³yˆž£ì
-˜
-T˜R¿?òÆ·ë_˜pÄø/¼ñíò†ZÃˆñª ’yš§¥à 	>õ†·Ë_2ÄŒ;M€]žB ‰*õ‹ðÒßŽˆTÈ1Ž¿e
-ì˜ˆ@’VƒÚW•LcX+ÔB¤Æ0@ÁM?.2äU^yã[–PB„XrÙG³e
-H¢Þd3‹
-
-–þ%øÌß,(  5æ²Ï
-ØQ£M8b	~ì	`Ö°Nàµ'€YNÀjÅF2Y_ê³µ?¼´|ày•6]ôÙµû&3[¬ùþŽ—Óæµˆ
-¦®8ŒO™ÞX 2V¹ÜH—5D+‰”Å=ârÇõ^6{™Zä”BŠ-¯¾¨Ue½ŠšAÃ)Švz	3y
-9F÷ÝL¨Nkj{Í_¬Ø"°¾\—¹Š’³š×÷ºÃó‚_¶Z™¹³èóØÖ<»Œ?,ªT®b+‹A?™˜/ÿz¹.æJšv“76û‹"ŒÓ\y*e: §˜TƒJm[óøÌô(b€”bîÞ¿ÝÓ¥H”+‘ÀKöÓ©H	b,z¿ê–À…¹Ó©˜ðgy’ b¼Ÿg[LŸ"gõ¬K“]ëu«ŠéT‚’…àf|‹Y¢X
-`!À{ox³D±kˆºßE¸SÍ­ÛÏ7K¸óUÊ¦kƒ¢e®ÒQÕt.xYÖ¸ÝšàÃÂÄ/œp=È˜"/Â§…Û„ÑÍ7nêN6\+øz­Ó+Cá›¦wS-âƒmD@Ä¬Ã#ˆbÐžk–~êoÂrA¬µ”þ×o°KÕ„á†	ÐD¼Ã
-˜ \SÆï\‚Ÿyã›tŠA&±ÁíÝµ²éYë;ëé±Å'ß,®z§œÜú£oó¬éiÛ¸šÑCb(Ä’úµè·ŠfôdÂ×0ÓëÓ×æ¦/ìñJêò¨Ë+CãÕ´ÚÌ…â sÞ*˜EZÕ·+ý[ù­7¼¾ÌPc²“7·ÐvˆbþÙEPf¾ø/ž{b/ïpg?!>­¢Õen›…a±VˆaªëºDÆÅù+/³H[?ÕÁ`‚ÔŠ’Z^gsÓ—Ä$¢Rã!Ö¹Ôû9!¬#™Ac>MëÙÍA¬S¹@‰¹”ÖÀ:¿P4èMÓøkày!¬5J©mZm×–/1³4+'Ôü¶ñ¢Ÿ{*l·àF§’¶=š¤÷öÞÞ6¼ÏþÍ´cºrÑ±&g
-¹ö'¯DSÉA1'­“Oñ¹ºï•?`°NmTz&z€AÈÀ÷Ùó(Åþ÷o¡1é™0E¨¹ÄxˆE'£#8âÓ3™‡PF`äI ‚¢ã¹õäÑ¤cÂ\ LÝ3à¯€y•
-5ˆ*açøÞ-M&&C`¡iüÞpwIÆ„µ(äUúgÀM»¢ÉÆ„¹‚¦CLb-›ø½ÞM`ZB}o.XQ9h´gTx æjãç¥^ŸuÎê!”ºMƒ&ß“†['G£×ÚyQ`4éž0F]æ~sëF¢Ñd|"bˆu¾Çir>‘»‘yc×ä|RVÄT™¹ÿØu]N“ò‰"A$*uŸƒ×¤}R^Dâ${¼&+å …w“Õ½ûÁk²2QÖ¼LíŸ/ÚUÄ0aåû¼&My¡ZG,€¿L‹X3ò€ð^“–H5€Cª{¼&íV^$=”ö:x¯6þ“^%Qõ^“©‡ƒÒfÕ³=Î“«‡Q‘ÈZãÚ-ƒÄF“ªGÃôÌ¥8s\cg2õh¹I)ÒwM“¨‡9‘²Ï¡g²õ°XFÜø]›o’õpœðbaÀ•Û·™:Zðîrq‘*aá¼?“-…sRê]ÙeL{XbŠeÀ4±›ö°FHÄEv°‡&3…)©Äì¡ÉM!!A@‘=.&… ƒÖ7ïbM&
-­7—˜§+ø½­¡M-ÁcL;XC“èA	ô”:#î &ÑƒH„œ•†õþÖÐ¤vHŠº˜¸ûÐ&lÏÌy`%ÉnVÀD—_R¬eÓ#nE½›ê#xvšÄÄ¸cÒ qÍxˆêÂß“+ßŒÏ*CtIù™¡¤î‘DyŒ™A1)±{üKmŽ±Dˆ$ûEpï©&XXù{K¬…‘uW8:ÐSEŒ&TXcôTKîZ„çö¶A;L(Pb¥{Q<Ø&šØa"QÌ Þè:ÇwOo;L¬˜ÅZû÷eC3Œ**É$@§Rº>¤‰&Éš¹«tò9½]L41%&ÞA+í j€ÈiŒµt/7&š˜*B©Ú[äþ–‰&¦"Ú]…¤{<H;šhbª	˜kî·LMí]ÌkþT8%yînL8±6ø¡¢|6÷?±L<1SÐâþ3a¬1¸Jº¿m0ñÅ¬µ^A‡íßWJ3” 1‡ûë¤M¤šw8¯²þL‚üyœ(öªtœiâ[¾¿JšñÐJP“Œ1•îqeÃ$1B¨)«“ ŠÜñ¸²a’ÚŒŒhàÎk`ƒ$1gqV4X%Ij‘.O®1i¢$¯¢ ý§Å™fòHæîL6‰ê]3s9Ä)TÊï¨—æÅ›õ‚“†Hàl:‰\¡j†úÕè~^„	‚D)E0-›Ã¼{+‹tM¡ŽÁoÖgÃ“ŽÃ.+a"1„‰/­{Üe0ñ‚
-)Ç]¶ƒ‰Ô(Š#Áõ`LÌ VÅ&½rwÏk©M¼òt¤pÄ*´ô4ïØ„b2®i6ánûÊa*ÝAÍ;6Í#Oëp]4oÙT€„ÔmÙÁ4“‰›B`Q7$jÈ!”{eqÉDp‘$(¨uŒˆP²æ“ïµd"¸´¿6kÊ¨_ /™O&‚‹¢ÖŽ“†Ûž¿Ï½R‘‰èR¦TBÖ¬j§R´´v4A]T*—@Ý"øÛÂ4•¡JP`áÝ÷…¬PÂTc²ÃÆ0ïÕA€µÐ¨[/±K&¶HÁPÊAjÑ&ðAFÓWKÏÖ0ÈéÊ ¯W6¦(ctËšè%íÚ8õJë>Ü}f‚—´ª0E!€ß<Ø/ñtqÖÞ÷÷ËÉÄ/±Þë˜’ç’ÝKž+¤ªñ=\B²ÊÇ
-\&$ñÝ]B²[ÊG†EkivX;¼‰PQpÌn*ŸåÔðx5ýd·”W¶­“ìáÙ=åµÙv)a‡£×î(_*Pœ
-\ïôÚ-å+CÎeÒû¯Í¡NÞÇþ>©‰6Òo’˜iŸÔÄiµ#ç d"øã›õžœ€3%º¿i°û½ë)§}yw‡ÐÄ‰É€	ð-ƒYìPÉiÃ`¢$
-ŒD{,	7$ˆ¢Ù¶nŸÜ£)¢•®Ý	Šm¤FÈ18GôSˆŠÖ.WGrû­`ê0„Ñ½˜`£«dN‡#2ÏæÄ¶T™à£sI«„€!Ü©[WFåm¯'æä'qœXpOn¿p.”XpŸi¯	…­ï/x·†¸é½Í|m³«lôôùjìf?å{?k¹:€I/³ ÔÚ|óÙË÷vo¥2ê6•ÌÖÏûº-Š«Oœ9Ö¯GtÉ¯ÈÄã‰²qejÚ”WwAÈÂÉZ[ëY©®›»‰Æ‹Zw¸ÀK*’‰ÆSC]' L—gò§øÔ*-21z‘$Ô>sÝÆÛM&Fïr^¤,y3¦ãRb-»3ž, /ÌÚ5?TëÖ2~ˆ¬he¬Mò{ùj7`‚ü5o?J÷Æa‚ü”_/q¥!"¸>·	óCÖ®Ø'Â\“>i¾‰š¸?”
-¹”6‰žÚº­¨M§PŽœØoŸ¬ñ×ÇÕâa Çý¬ù·åAú¸3ç}ÚüÜé¦Õá
-WäMÇ‰9?œýËOigMvðHJSÿ¶ðsÉn ž"`éÝÍqJy© è(å2/ƒ«,<Jß>™øK.yÜ<øG…	ÁÔx!ï(ƒy/%•†º­±&™àKEçD©ms63	»²˜1K¥§åœÛÜ ¾`I\‹XfÊYCbïŠÐCëL&ôQ˜¡y5º-•	}T„4IhtF½Ýá¤ÉD?jä0“Á·Tvô2œw-LÄ£$8¾vOŸ<`®-ÕUÛrv{w‘	…”ŠÀ‰QïÒXzâš?w§Å4œ
-ùJAd_ÃiÂ"cÊ¨Ú­%n¦Ã„@j\A)]˜M7ÿfb £¶²œÀ»ØMy¹ÃGÔ‘žd¸ïà™0È¬*9Hÿ
-l"!•X•dîáa"!KQÆ§A"¸Å!&²f56Š0Ì6˜¨HZ8\SìŸ×8˜HT`jÉ*€¨,KnÎDAâÔè6ŽÐß:˜HH¤Â!§}Ìƒ‰†DÖ"ÑA2øöÁDD¢6œ-J+Ñ-ƒ¿5m|O”Q“àË`³ÀpàF†Ù©\/”…Jÿ|x”Pd‚!1 X)°®÷`Â!1'È5ïcL<$–‚!ï²k@žÚqï`¦Mü#i=+E––!­QÌp©ý"üÂß¬c§0±–1NþØ8Ÿ8h
-šD0+ÙwœþH¬u3»‰`c}´7{è”áñ”øüœÈùoG™¦Àþ/Ý3Ãn¤˜#¤TJ›±jnqêÊÂ^‹r…Á$ÖDnƒ\Û-ÊßXÇ[ß>•<L¿_p› a¢¬0‡šË!‚THÓ,óZžÛª¡å'—õ)f‡ùOnSVóª—Þ8o%OãÒI}Yƒcd¿n¾{Û.|ã}­fâ:7CœÔ;î*;7`·»ñçášq›7qM?ÚïöÇ&èVQðÔF0@î¨×qá&æV;¦H	ñ±Û"¥Žã_¸˜w•T5œVvÀ¼¨ä¬Í-Óˆ5ð]2¶· Iñb‚BõB½=u[lƒnQi{“&°QKÚùŽ+¶û&Ö ˜’F0C¨}Ùc/Â6ð6À€ª½2øŠ`·/FÀ æà/ÝñÍû	@d? —ž(÷¯\l‚Œ!À3l£l9@ÈI=Òn5ô·bY£ÀdRPNwLû°²å2U™u¯Asã®ËæG®WFx½ž>*}ìÔ|k³žžM”-	=¶Š`õ]ð›@[eúäš¥9y¼0›P[JÚÚy:x:EpŽ	´U@·hß˜þãß58&ÎöñžG;¸lblµY.i÷ÃDÙ*µ'Ö,Ôï~xÕkl‚l§žM%Ô»ý«Àþ«·n¶9
-wsíÍ”F@ú—ùwŠÍÂ8¬PJÁþ%öRdlCx‰ÕÂã ÿÒ½²áU´h	ºÜ½JæEŸÙ†ð’ÀÔ–»ÿXýi+LíòÎí*Ž¤ >q”ÜÄ³–vUÒ<G¯–»Gª		fÉ@Ã
-D¡ÜQÉmÂm?¨³ .wKò°‰V*Ü\%ï¡áfr$È¹æþ³V?¿ò!G§ë›hcVb¦È¹_½¿t'Øn´U€rÉû8Œ&Þx*°f­+à7»·tp¬ôº¥°†•÷p™lÌqª¥Í½"¸–Æ„«»š³ò uû­®­1á¿zŒç€ZÆÛ;þ
-Ø…Ì	ò*¹ÿ
-˜eÌT¡–)\Õ»®Cc#Ïˆðž˜#ÂÝ†gùxñ« û2fi–J±ãð¯íx¿&X¯Uu™):f=ŒOäKâÐøë«‹0Ÿ¬Ž±€9Mp²«w˜!³–ÙždfeŒQ^Î¾0O€¹©6¡¡HDIM×ò2±¡#ä¢a Îb*÷Œ>›ðNƒp¥Ð6-©Ê¥r,’”ï]•=«õcû*ÅWkÿÞÑI¿úœí†’¬¼h€RøüÌl7”˜«Ê°ƒZ˜÷‰¨oØ	.å¤-¡¸ö‹àÞ©ll£öðCm)¾‡y0ï¹@–TGèÇ²Ã6´±0”âˆ9ðµ¼l,P«ZÈnû4AŒWÂ&ŠÛO¼¿ð¡õk§bc²~ýð¶Ê<–ƒ=«Å³Œ&¼óâæ¤‰¨¯’a»>ŸO¿_ys›0:5Ir”âNâò“p›dçŒõ6}˜+ÕZ<¹¡:æV–íêwíÄ‹ † &µa	=«îZUKR€µ}¿®Q5Q±
-OçJ¯Ÿ¸˜™eå8b"	&–R‚Bi„ï]ìÆv§u¦.	ÎÆäÄ2ÔÌÃ&<–j€”rˆC–Æßf¼F¨Ò*CƒC¾b¯n„‹OÈu)éªµüÉì1·„T7maT[Lõ-­×º™<Ÿ#³sãL`5¿¡šôVŸ,èºz’eaââ‚|¦í0Y·n<W™«W<{9»#¹A›íâÙÃ¢Mr¾þå¬¨òåë#ÔZ5^8/~ÿú€I/ßÄ|¹±.*4•Š¯HÓÜé0áÖ –¦)ð÷N0ŸoöÙÊï/£f+}y9»„õJçox²vNã£«{ûÌAžÏâÁ¯¬Ïúp[–ãxr_æÆ84Ï¼QÚkÌÈ9ßö¨qÓí\à%?Ðê`mLG»„{ú×/VÔm9‹îÞÂMëÂèšô™Ð›;Ùm!rSÑTê††ñKúÉ³½–Ý¹ŽCÍ-ã
-âEÍÃ`Áƒ¥ÿ3ß0ìMl7NJLMG‡ecå¾»RÁó»Í¦õlÙg$”/­?¾°ŒÄiyùêÌyœ€ü	0m©@Ä¸KsÏG›çð™—Í²vZN[1>h½òó3:&ÅC`Án	Õ@VfÜÀÜ¬±›­ÓÙ¤^iÃë×‡7WnÁl“¬{GåQœO}íI[+G™!gÞh}Þ~ru46Ü_LšŠ*@¨íCF¤Ptk²NËrB€Äù:°£z\²ùž^úu2û—9äŠ&ÜÈ°´Þs±4WqJK°ik¯^â”‡2üÌ_·Í"IÕ°ûæº=ŸRšˆ)ŠlsöÞpÎ½¼ÓçÞ¯>¶¦eçu.ßÞ¾-‡}eYOC_…l/S³ðj¯¸fg‹kNÝÍmvù‘UçûöY-ù.s¢˜¶sðt@þõf°ó ¼þ‘¹sv’gqÛ^ÕÓ_Kø¡Q¾_®ü>´©âI×oÆq÷sÝÜÏÚNIDžïOrýE	 ÛŒ9Rhˆ,S¬ƒ,JçU?s¯p·¯kéÖCÍ8ÎêeÑxÂiØ››7l Ÿ`þfÀ“ùºÙÄ³½ˆ¯5W&hþóº‘ãë|°™u—O£È¯«|fÅš2ÂH©mÚç%<Ê(6I’XPä8D×Å7i’8f(I¯Ý2üÆÀLç+w…†L‚›s0Y’8U¨HaÌB¸Eœ&K%ŸÈœÈà5vc“#I¨” à÷Y	;©¯­¢ì´vV_©¢R¦!2dO“‰+Õš÷™“I™‚#¦iOd`©÷ÔG“‰'0vxÛg!Ö:¬Å #¬Óo]ÌšÞ¢æÜîä$õ/šŒJ¢«¨\gû,œY
-,1q¾Û¼­7:{d6{î¬d/w6u÷ÊZoÜò–ÛÉ3õÓf¾ëÑM=!|iKs¦°‚þt{v´—Ñ»Eˆ[CŸOJÑ™ÔPˆ±YöuRˆkÌZ«ß^j2F¡RwIP¿¡A²îÍfRF!È¡T"ƒëÈšäP(˜HÊüxy5Ùô$Bi–á9Zbõ-[|f½àæi7Ñ0ƒpèÕZW¯Ñ¦¿ýhñd#UùÊ¾üÒ2'ÕÈ/É&Í•
-˜õÚeW˜•L5C”„cv¦¯‘æ­"TÀX3÷ËðW® æ¥bÂ$I¾Ÿá<+ºÝnk«œcn·e³×)OÞü†ºë&{U7zµÔÚìP@
-¦)ö¯ç_»ëi¶'à¤¸&ÚÇÔ‹IÍ¤L¡S°±¼[ª˜ÌLÚ£¡nàyÞÀv€rQdl>Ã .µžŽnŠÉuqï‚@­E°'Udw„²¢†úßŸoÝbü'ž>s“uybŠ˜V˜”šgfS_ÿÆÕW›d7@*ã¥9ÌíÑða³k³’¡2˜])El~¬˜!VÄt—Ùm¥¿¸ÍI½¸"=ÙžX¦£·ûÊÞw½ì0c„¢M—û×Ë«)“ÌKK˜yÄzÖ)šÎÈ<ußPÝÕ¾›i …×3äÓ¶:$±™ÇAŠÄù€… jöò™«õ·Þj™¤`¨o2Nã@©ÏW—O^lV0mfÁµò\§ÇfCåÄd),joÒóâï\Lp
-iz ô²r§£ ½…®ØTa cÀØ?+MÚ±z i´³[–!6UX,P;5be~˜—KøÝWÅfË$!§ÖÅ„«ÂN…Dø{w|Ór–™èæWž &¿)ÓtJµ0Oè¡Íâ­¾“Öä÷RæÐ*2B /¹,&¿1i‹I€A»É=¤ü® ¼-€âÚ2Éó%øï­$zW/­0ñ«Y_'`à‚¼MÀ$´f‚3q–þEvíŸÉðE‘1ˆ¹‘ç
-`à„P1s×øÏ¶¿&í—‚	'È@”rÜ”)B\“tçÄ4¾9CÊ“ËÔ»(ÿÃÀfP‰P'•þ÷µ'IËEI Jy€ï\	Lû›TŽi„¿kµ>W»±ÙúP… SrÉû¥Ý7jÒÞ^Ýè·­/yåŒ”zu!XÉœ@
-f‡ªTLn1…ÞŽ“/Ññ*BÄ¤Ó\B¨L©_×Ÿ1éÅ”:“ÚçfRŒñ#9pêÜØ³I1Æ‚RàÕú`ó-„Fxµn¸Í¤ÆbmNL…r¿ ®Wk2cqÖJ=Tj mQ|¿Ê(1™±8é‘šh§Û•MF¥±’°"ÄR«ÛÃ‰/6UÎjêŸ+ a³SU©H;­Œi&%©EÏC‚XâÝÒ6;UÒAáþñ]µÂM…9L7’NÞ´rÞ^ÍAÊ)—è8&ûÕ…i²ç,œgÛ~ÑVé%&%–<Uâ¤¢ž÷½Åq•°0²:ü½4”/‹Íb”¢6«"«û6‡‘6E‰–ÁuÒl#…ìN\òÝ¸á ›Ã¨&'=(€Tžp“ÁHÛ
- «ÑéÀuPL#­¹I•t+F½ òóýd+š8T¥'œlAç´œ‚&Y+ß»ö•íáÙA™hz®Ì€¡"ï3-&×‡ ºµä€*wäó\çÀ$ä` N¥|×@šÄLˆ+q¿ ­ÎÁµEb¾2‰YmÓ™RÊŽw`’G\yFxîüÏFï`›I1CŒJšy¹+še®« r«h›úppÒ²ÖU›-ßãü“™C5SÓMO³ã¤²¥7ËÐÂ,§ôÙÏ^gò×¿¨®³°R=vá5X?çÚàj[
-ý|ÔòòQu%é	~Eä:ÿ÷¥Å¢¯º}ÌZÿv¶W¸¾æ¨ýá’ùÞ.ªBL˜<g‚ÀS]Aï¦ oG˜ØxÎ	˜‚ú
-Ú^Èñáž”Uj˜3]RÖs¬ßRøÇ·	™–J±0®wo¦5«3È\úW3ýØJ)â…`».&fZH ‘Á½å˜€i¡¢DBCÂcŠ0-¬´ßJ`„#9à®¨	—Î@YßüþÎƒ	–™ÚK@I<Ê*`”þn°ÑÒ‘Ÿ0\ðs~ÛÙ©övq&.=“ëÒÓî¡~ÃbØêL›˜í‹ŸJâ\ÄºŸ¤%¡e*W9îÞ™;°de
-wˆÍµI*×(£–ž`\pÉ"÷á)üˆbÓµ=y	TZ&ºïoÂÒµ²+EmÂÑ;~‹'`¢Ì•–€W Bƒå14Ó‚±bêž›x”¤˜Å>Q	\lºfÔ¥³ê'%H¨Å>½kâ:g&L›ržjÕwÐJŽ­<í•³¦f»EpQÈb¢±§pÓ(\ÕcS­ 5jrx‡½ib±9H’µNa§½iâµÇoQÃ;nNÌT ÈT×¹(®Ãnc‘9æ¨™¡=v§]<“ —¢Ù±=vçZýÁßfp#F`Iqˆð¥Ñ„ðj-©ƒfÁ+g‹&ˆW{h¥„m³Ð¼3-ç¯Ã»íÙ^n×ªk¢‰Ö®S`¢ÿ—;ýfE›íÐ.î[4a±zi+ƒDp­A4Á«’jNmÇÃ¦Ÿ»ã›A”ŒZ>èxj¼:ÆàiQRÛYµMôfƒÝ{A}¼‚ÿfI	H¨]wßsÃYËMj×R€Bèá$0x-Ì‹ìÙ–™š: ,³[wÿ•´ƒI |^Þ¤Šþýü‰+T¼àÚO–êqÎû>.Ñ¯>~üæÛýÃÿ>üÓÛ/¾ÿøñû?ý³þöëÿÿþãþÛoûý÷ÿðƒþêÝôïß}ó/üî›üþ;Ó‘(%—ƒVÝ¢Ä’Ÿ«Tósú¿ |¥S
+xœÅ]Y—%·m~ï_qåÑâ–=báf;^$;»²i²ZyÐ(žÄ9ñ(Q&''ÿ>Õ}—ª‹*°›¼å—i©ûÞ"ŠAÀ÷áÕ—ÿùõ»ÃO~rw8¼úâó?ùå!Üýô§‡Ï~ùùÝÝá!Âá%r€’Ê!'„šŠÈá›ßÝ½ú&¾ùï»pøïoÞÝ}öú.^w÷êm8 ^¿=_¼þÝÝ¯¿ÿUá«ÀA~ ÿ|zÿÏ‡×z÷«×w}÷«/>¿{µqª aªcÄùÁƒLõçGúÏÇ§ÿú*ðôë¯Åéçý÷‡—ßø*Pzü(?òUñô”fX>2p¾üÆùy§ç?þiöüùo?~;<H(y3K›Í(ÄÍ™Åâú¼>ÈñöQª<û¿‡¿½÷$dkí+Ä’%¤	ôðýýáõ¿o/Æð*”ŠyÀð!°#@´ „"¥¼sÆOæørŠ#èMA¶D`‚Å¼uÆ/æø	jÊ±ÿ;güj/)Å!ã{ïÖq€’!ÆTi„
+z"XG F†€4Dw,K‰1C2D	&OËbb ÌƒDÈž¦9L¤¶nÅíãt¾ŸŸpx<éâýÊáqÍ•'Ì>ó¦í\AË°"á˜Ù¤àÍ¦e[‰rÊe—Ã-ÓJÌÀyÓ-ÛJœ!¥ÀØ¼ñ-ÛJÂ ¹Žßµ+dÙV’œÃƒÉ“À2­R#kUÈ²­¤¶•jî2*mç+™†µd9ÆrÈX@¤Jê0ÞF$Ó°– QpŒ®—E¦§Y*”R‘Gˆàš#2bPg—R²ž£A¦Er¥@]"O8’ùÝ¯á–fZIŠÀÂ‡h‡ç|i(9@ŠIOŠn<CÉ¦¡Œ$eÌ¸›”MK)eÈx†ŠmCÉ )WÜe‹²e+)E%î²EÙ²•”IÌ2f‡>ÆSè1*ÃÁR˜ÞdÉ‘ÆOw‡²i<+C ˆ´ÇµL'#ƒpÀ}6¨e'9d…Ç¬‚¯œ–dŒ«ä]v¨X†’)…¢›^<—Z,+É¬z8]So®‡bYIV+‰A ê»Ø¹K`IÕÃH²‹5ËHrŒ ‘Ë>zh™DNBÊclOË$rŽ#–tÈ¡ÔtË¸•˜61dVMPwÝï–ëð‹ïÞÿöí×ß¼?|öÅÚ¨„€õbê?ÿò.¾üü/îˆþ÷N_Üé·~w§‘}ÂÜ}¹úŠ¦Ñ-LqÐ:Go–M£[2Å4Æ%àcŠ¥Ù%ˆ––PAâà^ì£eˆ#àˆ"#fåÝ)S6Ýò½	ÙL6¥š€$ôæšN>Û)7ÆËœØüç1²øE|xY"¤$5>†ÏáµsZ²Èm]?ë¬\¤Æ’ù×ãÑfF3‚Q$i›Z>(+}ÇÆóº/®/ÿÉ<¿ù0û§#ãòóß¾_|~¾*ïgYÕcqñô¯B@w‚ÌãI×±_÷Ì¥~ÈÆ~dªÆñç›‹t|»Sîw]‹®Ãâ³¯Î®VÐÜ×(ëô¬Bn™±§ž[WX‡·P…cÍ$ðS¯Öá-‚€©Æþ98xÃ[«H‚4døïyÃ[‡ªH…L9J÷ðŸxygóøŒJ®1vÿ¡7¼uxJ* é>¹•Å•c`nNçt±±‡Æ‡ú·mö´}2„("üü—]?¹dÀˆ!­g#Æ³w•Ë¿~lÇ<ÚÂó×>ØUü<ãƒD/ôŸ—‹®6{œå
+Ç;þþtÂáFÍÌQÌŽ¯½ö‰ãy4?)díãŸžÊ£~8;‹}býÏ?ÿúÝ¿¾ÿ›w÷æ]P dÌ¥IÃÂ¦†½´Ê¨ìò­GÜ°\	8•œGì
+[gsÚÇKý¥ž¾0öÀÉ?ØÚx½>ÅwBã¦•I	JÁžÒ³©Xüœå-Œèb‹%sæåó~mžgß9–î-.§qg~n÷˜§•÷^èÆ£J-D¹º™Ì}þG}Z¼áì¥–*|Ü†§'ÏÝ^ß°˜AH"·éQ¯gšÌ N
+€"Èý|ßßŒ¸hNÎRzÆ~´#™!˜5uß%Rk´#›aï@J› naÒ…®—™
+Ï7ÃwmjœM“C“¼Î•ýCóª¼q?Z¤‹ëöÂŽÎïûºq¸xçïÜw¶üÌˆ˜sêY£f%áÍ#HjI4ª®ý•;²UØ>@œ¹Ñ>›üEåÁ$ã¢”}îKÝ¡ÖZÓã‘óáYç¼ÈK¦+_w^óÞ^>æI‹d^<ÿÆ.?¾ÇÜý{øôt`Ò¥¸ó«Äã‡+xÀã`÷OÀLÿó‰«ÛN bÊ=^ÒÉuœŸá÷‡—Ä…W\Ñ³Û±X…ù%è³¼zž}]=É‘¶<Œ«§½Ù¼ Í}ŽóZÅû`áç¹\ÈryášIñ±þâúâÖ•õ4ÆrÞpuÞâé&¦_»ó'+â/–êñuü3Ét­Š@My€öUýgîÇ®,¦“UÄœ˜†ì„c©ñõŒÛ+wºú.>éÈ_=ëmónÃÍ;Ûrq÷•‡ñ_ÌÝ·µu/f¹lÚœÀS ßé9›N§Hƒ9eÊk—Ô“Ë²ˆŸ,/9´r­³Æx|Ö›† ºñm#Y´øÌ.ukyÕ;ÞÂÌ—¿ÌÙŸ˜„­¡šlÖöå!h)|¿LÛþGMÛ¾˜e~%Aš@ý²ýbZ›Å˜µb–ÀPN±qGõ¡ÖŠY3•Õkê¤{|?wRì˜
+T˜Ò î=ì&!À§ÞøvùC­aÈ¸¨5ó0OEïXÆÿ7¼]ù’!fÜåõí²IŠëà‡Þøv@¤BŽqÄøîT; "¤Õ’öV?UÓÖ
+µ©PDÍÁ–òª/=,;(!*|¸ì¡…Õ2ƒ‚AñE´Ï˜iŒPP°Xð0+	(@šú¹ýØuŠT°¯¼ñÍ*Ö÷çã{(Ãj–p„Z±qü†<ÖÂ‰údíYÎï<J›¾ùìÆ}•™G,Öœ~Ç}«uë>K’dsÇ4gªâõ+TF-Ë[¦ºi;²¸Aœo·6/S‹œRH±éå·3µê¸]	Í˜áD;¾†Ž<F£ÿv&h'È55¾P‹ú/VmY_®Í\OÉYÑË[ÝáyÁ/[µÌ€ÜIôylkƒ]F…*‘•Å ÌFÌçÿûh]Ì•Lí4&olœÛaÇƒéWH ÄÚh"ºÁãÁt-bPZˆ<B=Lß"P®4B>Lç"%ˆ±Pê—ÀÅÓ»˜Àhy J¦›y¸L÷"gõ±K›}ëe1ŒBP²ÐEtÓzÌZÅR ã|f“$E*0·‰Ðš€¾¶u°YÓå3“[åìîd
+HuN§˜eÕÛµE>,,þÒç	—S€Œ)ò"öù˜€5òGWß¸ªDÙÌw­ 	æ×¤Ž©…klšßMåô©slp@Ä¬ã#ˆr9=ÛD¹»Ód¡@k-¥|e“½„	ÝD¼Ç˜à\Sè]÷¬¶©^˜*L8b›Û{leë?&n¬ï¬gÌŸ|¹¸Ótë¾N¾¦§nf3¬H…XR¿&yF4k^+ „¹^ŸÀ6ï}a—Wò™±¼I´ÞZMâ®
+Å6¥a)Læ	¨œ-ý{Úƒ=¢Iœ#!CuÈ–ÞÜKÛAŒùgq›¹¼xî¾¼áÜ†ø´’W_Ù6ëÆb¬¹P‡d\«öïŠÔsþóÉþˆÍ5DR+ªó_gsë¸<v6ÓÝ.1&(„t;‡ÄäBfÐPÓzö’	Ú”–JÌêÝ|LJKÑ˜8Mãw®€ë˜tB¨ÁLmð$Á—bfgVŽ©ùÕãEj÷X÷n¡‘ŽÅ%ïmúhÞØ;{Ûì>708÷Ó®LéÊ­Çšý”k}L'0§’ƒ"'Àü|N÷žn’8¡’8ÑÃøëoC&‰“R™’†£;_¿%jgR8aŠPs‰ñu.â&®©›ÍÕ¤pÂŒÀÈ“³ã½õ$%Ñ$lÂ\ LæÀwÞL¾&åÛ«A¥½"øk`žA•Mã÷®¿ÌS¨ÅJÿx‰Y4¹š0W !;*8Üv#˜dMX”©¥`=DŠP‘%‹¯±Ã\ì.Pél‚ÖÉa8C.µÔm~4	¡4øÂ89&¯¸sl²æaÆ¨ëÜmrýø´IEÄë\‡Ó¤ƒšxv#ó§®I¥Ô‰©2sÿ©ëz&E‚HTê.ç®É¥Ô‰ÄIö9wM®&ÊA‹ò&‹{ós×¤j¢¬™šÚ?®-0I™¨TÀ„•oèšœL4e‰j± ®š,LT3ò€p]“ªH€Cªûº&V¶$=v;t/6ÿS]¥Zõ]“¿‡ƒ’ fU´›Ÿ8&}£‚”µþµW€êŽoÖs©N×Ò™ô=
+()EÚá¢iø0' Rv9òL–Ë€Ë¾kîMŽˆ,ôß¶Ý8›I¬£ €˜p—`C2a©B¾½ßg’¨pNÊÈ+»L€i•»%ÅÂ;ØA›®¢FHÄEnoM²
+	š›JZts;h²UHHPÙsnïú›Ô‚Ú3n+hRShºÄ<]¸olmª	cº½4i”GOsœTÐ_ ³TR"ä¬d¬7·‚&ÏƒDRÆ4þÍ' nRÁvLÀ%ì'­L°hÍÏùTD@¥*¾A…½›ê#xvZÄ„»cÒhpÍZH˜@b¼%i9š0pLXR>ˆ¬UzþÍÌL¢	CÆÌ 8•Ø/@‹©6áÇX"D’‚#dð¯§&zXÉ|K¬…Ruw8ªÐURl¢‡5.Oµä¾…x~4Å„%†Pú—Æt¢‰(&FêÀ=ÇMH1±¢kÍ;)§G• •d’¡S9]wÒÄ“h#F¬ctóÉÝ_Ð“¶f&ÞC7í°j€ÈÚ˜±_5Ü{Ž	7¦ŠPª¶Ùã 3áÆTD{¯ôO‚yGnL5sÍeŸÌDkœ:ezv1&æX;QQÂ›ÛŸ`&æ˜)h‘ÿ¾Œ„	DÖx\H%í`#L 2kÑWHa€ -E&Yr%”¸“ršaÑD€Âñö3&š* ù}yWdÂd•¿3MÍ7×N2!•\	j’!¶ÓïÄjs5D5eum¦°±Ð-Û€ÚˆJí`F4Épóe°û>dàŒcŽ¿¨©¤µHŸ‹×”¢$RyŽ–Ø¡ï.ÊÞýp	™KT§›™Ë„wÕ”NÙôÅ¼³Þ~Ò ÜÞ¬v#z®P5y}¤M§²S7ÝãXÝ‡^
+ÄB‘GÌ‚¿=l<¡ÒO×j¿æ™VÑkD?†}–Á®ÁÚˆeð\21…*
+)Ç½6„YCª¤×âˆ•p½VˆUa…Iïã½³àk»ƒ|ÐÆÄG,ƒë7Ø=ä	!Ä8b
+Z¬³ÝFrÐ:Ò]”Ñn$OAsÍÓJÜ\íFòT€„ÔyÙÃ:›P±)@uGfD´IêÝ•ï%ÝE’ `ÑñjˆNª§oÌ(eD`Iq€ ^ÊŸì.òQËÊIƒqKÐqÁ²Ëç¨uw1õ+FC2Ù}äAåh„þ±i7’¯U‚¤6ˆÝH¾V(S#Övˆ	Aâ ÀŒaÄq”ÝH>ÅK™Ú¬I-åÙÑZi-€<ÙÅT ×Ó¼^ ™
+ TŒq»’L˜“¶|œ:®uŸ^¶†LŒ“ ¦ˆ#h9’M”O7ií0±ƒ§n¢œX¯uÈ…Éõí®ô\!UE’ïàÚ]éc.Š6ÞÅ?´ÛÒGÖZïwX»+}B¨(¸gf7¦ŸÎ›œœ<în´Ó+U×díwpìÆôÚ«»”°Çák·¥/(jAì‡¯Ý–¾2ä\&-¸ý"˜áÍ€êäü^ÜSœ¤qß$1Ó>î©‰NÒ:IÎc¿î‘m‚“„pÖaoo!ìžñzXÅi{ÞÜ14ñI"B2b\aÂ“”Õ’JN{ØŸ$Q `$ÚelÆn‚(S*®×9o 6¢•öß	ÊÊ‰rAç¸~
+µÑÚáâxn¿!L‹0º7¢t‘çépJ.ó<?jÎó˜˜¥SYìT1-¸¹ðÍ¿2BA¬G*æ'Ñ¢XpHR®¿p*®]PŸh/ù‰­ï/x·†¸ê.½M¦m²lôôùjl·f1E=Ê÷fÖru “‘fÁÁµùþæ³—ïíFM+ÜÖomö™­	ž·‰[Ôgiv¬/^Žè²e‘	ãÓZ€Ì•©iSv_ãM$_!„0yvªëoâø¢–%$Í»vðcW \1Õu‚ÐtI0ëÕ^ÏE&¸/’€„Úg­Ûš<‘	î;¤~k)§ÅCãÁëÍ}$‹:µKB©ÖeBYáÍš²òÅßÜW¸³gæoQSù#Æÿž;¾™»%„Ä•º‡áoSÐi_ìþr;_ì—
+¹(æ¡W—¯»¾µàÊ#…ö«'køåá´x˜… r?kþmyl>ìÄyŸ÷Ç?Îé Í§]uI\¡’¼jW1'³ßb9cá)Ý°ÉîIé4=Ö¹ÜÝ><EÀÒ¹šã“&LS±Ò%°ºE`×Ñ0‘šÚ4‡ˆà%¨É%š÷L0šäÆ7¯Ý@¢¤Òo•§~ÁànFž©ˆéœH¯â<‹Fšg2q‘¢dµœs““ÓÉkaÉLYC£šÒK#ƒ!×ØqI†Öåè¶M&.RÔ$¡Í×ÜáàŽoÆ%c€<d|×0™H‰iÐû»†Á?JÂAïïowúÉýïi˜ôŸŸNîškL,¤‚781ê8hÅzÇ¦ü™;%¦‘T°W
+=ÜÑHš˜È‚²©ö*‡ë5˜èG(›ë ûè&ŽLôcÔ—Ü¤	<ßÅ!êÉoûÎ›	ÌªCDp/´&úQÙTIFŒïž&ò±íŒÿCw|ËFÖ¬ÂÆñ‡ÿˆAË«aöÎ…¯‹fpCQ¨%« ¡@M±£ðÈßf|cê{›	GìÈÌ ešÍÜÅ*Ø¸­ù"ƒgØÄ;¢öŸ-›D¯ ?r°1;P†Ì€gØ„6¢¶¢Ü(À(ËÀ&ÈQI^(•þÉðÈ ØD8b*@±R`<oMˆ#æ¹*óê–Mˆ#–‚!ï²k¸žÚrßÞ@³	j¤À@¬±Ë2Ô5NV°D¯?÷Æ7
+™á!ã{×:6áŒ¤½Ñwß¬CgÜíýM°k™Ë>ãÛ`íÍ:x8~qNÃ|vyR|îvËÄ!¥RÚ,TsCSW–äu(WKbM»6ÈµÝ ü¥Õoü¡¿]àc}ÂôKð·IˆiúçPS1DúÍ’Ìo®K|–Ÿ\“˜æ?¸Î8ÍKTÞzã4t¼–,<mŒsæ~Y0c$¯®¾{Ý*|ã}­Fâ:\¶\3¬]µ]§æëv¯½Ó<\2!nó$®éG[[½ÀnÅ›ØYÅ²OÎR–ç×x°6q³ÚEJˆNJ›Ôƒù¥+€y9IUYðË.˜—“œA¢6¤ê^‚7ÌÆÌb $Åy±¶‡ /‚ØWcÅ6n•¤7Åtà•7ý†P)¶Û"Ö ˜=Ð†Osž,ðÂ„Î† P•¡[7×Å6NVaƒôOÂ¯ÜáÍ[	@d>€`O,û]l6Œ!À56>–„œJ þ^4²Ñ%“J€C¾an‡m|,Gû:`š»rwf¤Ÿíðzù{T¦Øi‰6ËßÙÈ’ÐC_ø†ßEü°‰‘U2O®Yê <p&›YJ¨d•&Áµ7&>V‘Ø¢maúÏ×Þ˜øØ‡{íá˜èXmÆ#…KÚÇÿ0Ñ±ÊÛ‰5õû^‰	›èØ©)S	õ'ÿ* ÿâ¥›ŽÂÓ<ccƒoCRø¿ô¯ò¹3lV¶a…R
+ö¯°{¤ÙÈ[b5ï8À»tuÜFÞ*À³]îNsÎ6î–¦–ÛýG*µ"ÊÎ¯Ü®áH )‹§ã6×CªDL™‡_eÄË’ªî1EYß½Ê&~—£vÔÙN•éæfy½«ü¶¹J¾½‚›Ø]­`Î¹æ
+ÞjÂÏoüýFÈÑi)Ç&6˜•W)rî×î?v'Øn¦U€rÉ{øŠ&4xªŽæ4B€†º‰V–ÜR˜doÉÆ©©ô‹àš¶«¹9Ëˆ™khL˜®ç€iŒËê†IlX"%ÈS˜äö‹`–$S…Z¦XUï"¸ZhCOàíž¸oÿÉcbÀe›Ås€_S_¾,Í)vþÞŽökJ@ÛL•ºÌ=æ<ŒOüèTkýõã³0¬Ž±À(Myñ3XÕ2×“ÌœŒ1ÊG³/ÌÓ_~bÆ„qR %5-\wÀËDrÒÄ²0…¸B¬õ–Ág©q®¤qÇ~õ5Õc‘¤|ã*íI±yž <¦ðÞžŸ³¡•}µ0ï+\ §@Ô¯Ë2Û#E æªì æu"jW›ÀCvFƒ™7ïI»>qíÁ½RÙ¸Dõ¬Q†ïbllb.%Õšà‘â°M,Êƒâ€Ypó´+ÀÄµª}ì¶N>xõ ¼"¸þÄ›3u‰QÝ°v*6¦ê×o«Èc9ØÓhU<»hB4Ïne½ö ^éhùøû•×8•°ÉÕ¢3“´• G)î.?·épN8mÓ…¹Ð¬Å“Jc®eÙ.qÐÎ¹`jRýÜ6hïÜ½l¦\¤ kgúîñ[ªÍÍPx:UzEø¾+€™tQJPŽ#¦À$˜ VJ	
+¥¨ŸïH`·¬›È¨5^ø|Î÷¥ÇŸÍœ.lâ\©H)kAPÿÊ¸ÑêJ5B•FñSxq\|"Ÿï‚—,‹O}:{Ì5kÔ•-[ØÓ+}Í½µn!OGÈìÈ8±LÍï¦&ÕN­ž3dY¸¸ŸØ6Lj¬+ŸÀUeòŠfÏ§6’®Ù.š=Ìß‡Ãø`S~t`„Z«ç…Àoî¨]"‘˜Ï7µ£E[LNº?ð³™?&ð%&@",MSàï+œ0=1>¾Ù'+¿?95ö²ÓËÙ¥«:õÀ£û³ r1>ºª±×Ïäô,ü±õ¹c¿mËrœÑMîË\‡æ™7JzÙ`ÐÛ5n:ü¼¤õY½¬Í‚Iµh—nOÿwœµÃtzwoÉ–u¡©s´t!áÓýáê2v]Ü?4uº¡/ü’"òd®åJu.ÃOsÃ¸ÂSxÖCó,X°Wé¿eöùù~iä\b»ŸtÊP¢`jY7>(^ýÈvz·Ù´žûŒ(òCóójýÓ•ûÒH.fà;Ì[*1îÑÜvwo“óUW£²V+lžÌdUˆO]	¬«@`Án	ô@VìeÜ€Ú¬q’ŒÓÉ¢^(Ãýýáå…W0Û±ëŽÇÂOyÇ¥ a“uâ¼rÌJ¿AÎ¼1Ðú¼}zq2º™U€P›}Œè«@KŠ¸™ßq~Äù:°…žzX²#ï,›nÌþÏrE®dXZï¹?[š8f#Ø´µ/qL@™~â¯ÛfæBÊ´¹nÏ§}fbŠ"Û¼ºWLs'ïø¹7«mDgÙéœó··¯DËa?¶£«Ç¡/bµç©Y8µgßûjZŸº«Ëìò#«¾÷õ³ZÒ\æD/ l§°é€ÄëÕ`§Axý#sçì(Ïâ²½:«Ç%¾”ðm£|?[ù}hSÅ£®_ãîgÚÚÏX5…—èùÉŠªÿü\ÿù±/‹IŠC …†È2…:0(C¢ÄpZõsð
+¿úº–n=Ôã¬Þ'‡½º9pÃðIà¯<š¯«M<Û‹¸!ñ>se‚æ/0/y|·6îòiÔ€ôu•Ï¬VSê)µMû¨‹"›M"$–9 !ƒmR!qÌP’Þ1ºeøSW 3Ÿ”=2„4b4%çÈ`§ñ+T¤0b!ÜâM“‰‹RMdÎ#fÁíÂ&&’¶8)Aû¸ï±b²!é<„e‡…“‰‹òA¥LC&Á«Õ“‰+Õšw™“O3DLÓ~ÈÀo¬v'4 i/¶}b­Z2Â6ý™+€YË2PÔlÛ¤®ŠE1™“´E%4ÛgáÌú_aˆ‰óÍæm½ÏÉ³‰÷›Óf‚ÁK›I- Y‹Œ[Þ2<1Iýà¢> |i±9É‡Y{ž*JàùÂžœìeänÞÖ°çS²sbA!"ÄfÙÔIQ­1k~s¨˜Q¨]Ôoh¬{³™4QHr(•FÈàº±bòA¡`")ý2x\Y‚&ežD(Í<GE¬¦b‹Ï¬× \=í*f}¼ÖrëJ´éoß[<ÙHQ~lßzi™Œj$‘“ÖŠJÌzþì²%Ìú¥š!JÂ¼Ó–0¯¡Æš¹_†?÷0Ù‹x"I¾Õ<)ºÝ,nk«œ‚m×…²—¹NÞüŠªë*ýzQ*z±|µ6¹˜„>Sì_Ï/Üõ4»p‚$L;Ùy“‹IDË”l,¯¬˜DLÚj¡này®ÀvdrQWl>Ã€*µž®nÆMß.E{rDv'+\xjÖ°v…ñŸxüÌUºå‰µ'bRVa.Pjnœ™M}ýW_m&Ý ©TŒC–æx0·‡Á‡Í®yÌŠ–ðˆÙõ˜QÄ¦ÃŠbEL7™ÝÖú‹ëdÔ‹Ñ“™í‰ez»éë•ÑñÖË$ïRv‘¢‘û×Ë+­“ºK©'0òˆõ:®S4‘yÎ¾¡¬«}7-ò?¯g6È‡mõGbóŒ‚I/—B}6cÇ_º«e^nµ‡MÆiü XðùêÒâÉÛ`Ú«‚kå2øNÍ†J‚Éz·”‰Êó#jå
+`"RH3¥oü%;l{ƒ[±©Át=bPcÒ;+MÚ±z M¡Î^<ü§ØÔ`±@U¸Ô˜•Y”Ã5„Ël¾0%‘JÈiŸ•1½”¸°Se'þÚß´¥@&¤Úù7® &h_¹¥Sªuê¥›ªBµouÖš”^JZEFàe–Åäô"&í¤1	 ‡=?—ü¥+@Ú€Ô ÄÏgzÝJœwñÖ"Ó¾N»$šäãmÚ%‘5+œ‰5ÈÓ»Ê®	4i½(’B5ÔÖ»Êë
+`Úà„PQÃlãw˜`“îKá‹„“h±Äí0I„¸:+çÍŠIÇE9CÊ“ßÔ»,ï
+`§D¨qÊ€Í÷®¦	NUbÈ#DøGWÓç •c"Âß¶š ‹-Ùl‚¨BŠ)9VÈ$ýÒ®5i¯n+ôg­/yá”+Tøâb°þ’9ÌG©˜ÄbŠ¼Õ²ù8à&â–…˜ÌbšQ•)õKàú4&­˜Rf²úRû\ÆLj1~  çŽ6©ÅXBÊ<Ûz71ÉÄ”L2ä0Â¹uãn&+kÃa*”ûp[“‹³Öë¡
+ ]Ì·­2I±XCX!ÑN×,›‡*`¬$Œ‰Ð1¼=døbQå8Ý2~?±	››ªHEÚieL[)IE(z$jK*=8n•y°¹©’Þ
+÷ßb§V¨©2‡érÒ)ƒ´’Þ^ÍnAÊ)—è¸&ùÕ™i²çL¼„Éþ¼•iRL2,J$,ù€!@Fõn6Î«t…‘Õóï ¥ŽÙ¦1JQ[ÕŒÀ÷Sl#í#Š,ƒë¬Ù4FŠÜÍ¨_ 72`ÓÕ’ã¤pbK¼•—b²iWd–Ø/€ë¥˜$FZ“*éVÄ mTŸï/»[Ñ$,Òƒ‚·sÿ´„&cc‚¨­d{DèˆÏÓeU‘»LŒéÃ† Zâ$‡ªÝòóKi\Áäå` N¥{øÿÀ¤˜`Š@\‰»Ehu.mƒ¤£¸Õ6)¥ìø&‰Ä…Ða†}áüÓšpzé¡~ñþý×ßüÛoþåðëWŸ}ûþý·¿ûgýí—ÿóæýÿýço¯þðÛoßÿæ;ýÕëéÿÿêëýí»¯ßÿöÛw¦-(%—ƒÞ<QbÉÏ¥Â˜ÓÁý?Û6àè
 endstream
 endobj
 
-304 0 obj
+311 0 obj
 <<
   /Type /Annot
   /Subtype /Link
-  /Rect [227.92964 597.455 239.54564 612.11804]
+  /Rect [227.92964 553.433 239.54564 568.09607]
   /Border [0 0 0]
-  /Dest 289 0 R
+  /Dest 296 0 R
   /F 4
   /StructParent 6
   /Contents ([4])
 >>
 endobj
 
-305 0 obj
+312 0 obj
 <<
   /Type /Annot
   /Subtype /Link
-  /Rect [136.71214 302.37463 148.32814 317.03766]
+  /Rect [136.71214 258.3526 148.32814 273.01562]
   /Border [0 0 0]
-  /Dest 290 0 R
+  /Dest 297 0 R
   /F 4
   /StructParent 7
   /Contents ([5])
 >>
 endobj
 
-306 0 obj
+313 0 obj
 <<
   /Type /Page
   /Resources <<
     /ProcSet [/PDF /Text /ImageC /ImageB]
     /ColorSpace <<
-      /c0 271 0 R
+      /c0 278 0 R
     >>
     /Font <<
-      /f0 259 0 R
-      /f1 241 0 R
-      /f2 253 0 R
-      /f3 247 0 R
+      /f0 248 0 R
+      /f1 266 0 R
+      /f2 254 0 R
+      /f3 260 0 R
     >>
   >>
   /MediaBox [0 0 595.2756 841.8898]
   /StructParents 8
   /Tabs /S
   /Parent 1 0 R
-  /Contents 307 0 R
-  /Annots [304 0 R 305 0 R]
+  /Contents 314 0 R
+  /Annots [311 0 R 312 0 R]
 >>
 endobj
 
-307 0 obj
+314 0 obj
 <<
-  /Length 6164
+  /Length 6803
   /Filter /FlateDecode
 >>
 stream
-xœ½=k³·mßï¯XU–œ›Dðéz’X²3“¶îc¬™>,·•_Çi,¥Êítúï;<¯Ýå‚‹½‡<çË9÷±K‚ €x>ÿæÏoÞŸ~3Ï¿~ù»/só«_/¾|yóß78˜ÁÏp@ô`Øa‚ó@ÎøáÝO7Ïß™áÝ_nÌð—wïo^¼º1Ã«7ÏïÌ€8¼ºßÎ_¯~ºùÙkcÌ?ß¯þxóÕ«›ºùêë—7ÏËÙQšDCÁ6ÏþÚR  	 kÀ¡ç!xŸ‚çó  ^ÀFÆzw> Œ _|¼ÿñîÍ»ûáÅ×•I]cF¬¿üæÆß¼üûÖÿ{c‡¯oò;?Ý8pƒþtóMmqV\\ ÜÏÓ¶»¿S0ë¤É½k©}ò×wÊì^šÝEH&v˜Ý«Ì*«'c2a Ë
-]U>S¦ÒôÀ[2í[;TIš=ZÖÚt•cf„kìqÖ~'EÎØZ›7ø™†^‰o“A0†vm›þ+mz‰k2PL¦W™JŒ•Œ‡àœ»wA‰¹:°	S;SO—Ä]‰<Ød¹ú~®M/1Wb&…Ýô	ŒsÜ~‰»%:,ÿµ1Aƒ U00jàÛ=÷€ ?|‡Ûï†W³¦ÈI—ƒÆ¸kà„$–H.BˆÜ‚ßjÓ‹,Ñ[pì³Èõ0‘¿˜Ä'‘'„Bh'JU‘Yb´`¢ÉúÞd>¹u®(ó'³ö“ù$rÝdÀGCöâ2Ÿ$®ËÆ sì Ñk2Ÿ$¦Ë&3}$wq™CÇetà“Ý!ÿÂ2‡%þÊ&ûÔã>¥óW–ø+£‡yáí2Ç`8œtsøFMê°Ät™¢óé*H‘¸.s ô)]\æ°ÄtÙ$¢ty‘ÃÃeg€}f³—9,ñCöÖ¼Žñ(¬BpE3NÚOÞ°Èq}ãƒi×(@C®Èq»Ý:óYÄ-ë¸ì4ncEœRÄËK +òßÀ;—®rë°"·M)3Û‹Û´¬Äk­1`Ñt°Vk‡ÝJÌÖ"‚EÆË›\¬Äl-!˜€š§ÿ[mz‰ÙZòàw˜^S¿¬Äi-%ˆ©í³€Ä-[@gÚvÿÜ·•ø£u‚Á«\¸Ä­‹`]Líh;â$~h}ë±‡ïJ•þNb‡6XH] x«M/±Cg,D‡ÖöÐÇ1qûï·e:‰SÑïÃŒÅ5ÀPŒã¿¾Í.÷·göœ¥a÷êçâs¹òükC<{äôÊ7‡¡¤Wu…Â‰>2ç }`¿S«$ô/ÕœdD®ÃôÿªM/ûÈpŒš§×|ßNö‘y@c®|ÙIF@È	›§ÿ7Í?*:ÈC¤`Û‘¿}zÙ…•€;AÀ*²ËžpÁ°=ÿþü­6¿ìÆ21šó¿~­ mÑAD·í*œZä¨Gz&Gmc	:üv¼“ùÛâñÍ^‹<}P|­.vSQØ¯L;“ËG~ž?~‘?~™?>9Àª#W~m~†—Ý‹Ogxxp\ù£óÁ>ÍgUÌe1Ûb{[ˆÇ¡&{rW_ÿn¦¿*ä¼°Ò§òtÇWŽ¶ÄªQìÝªÎ‚	8Dß¢´Yi¹¿ž#x“#SvÏ>ÍŠ‹ÍÒ”žêx“1|¡½L»z#˜•YÔ¹ý]õí*Å	óŸ)0r"5/þ}3¦À&¯Í€õË‚üÇ¹° å³w`±¿T¬®°°c¯®`dƒM{Ç­à>Á_®#LÞÒÏ²_=ËÆB@çmËY.nÒî—‹ù[ˆ$k³Ð.hD~<öx«“Ð‘iÓôëÏïöåÉê1›Jù~•N±•¸È{"€si$Ó±ö#?Èl÷ùèviwÛËÝªýëyþx‘?^žôÔÎýœQ<><XžíÿŸ¯dgEÑHõ½EsÉ¦çÒ}dlÚñkÇÛ'ÆQ“yÁê“Ì¸ç\°­ÒÈpâ×|`$_Ú
-¼uáSÿÏÌ…T<
-þºo®T.¤£,G>˜øª,î®òÿ*óX õlô“*hs9t'®
-QÔ*h‚‹'­ÄÿŽ"àHv£®2ß‰Ú3Íd‚vÖD³wvõRÜrØhˆ·ÈÒÃ*J;ØÅ‹™qí#G&~TW$Ù]1„¢ka[ÍÁ¬ò/—ÀÇQS‡€‡êY…á¹€dy‰Øb3 ‡]};ðxE<2þ“PšÓ?Ï¨û$&Š§NÔ~Ôç4 í{ U¬“…”%3P}ÉÏ'2C\	’é'Y ô©4%¿>âÔÎwâ$DœîwäqeóŠßCï7ñövx6Ùžýºr§¨|ªâiÕ•àsÄ9·èñÕ›\$‡4Ú%ÊeŸÔðBB®ß\–ãjzõýù]{qÛåÓI'XD[m	A³¤ ‰’oÞ²•E1’8›owÍÄ1ŠÕ9ÒISÔ¥}ÞsµÝÃ¿UR8ÔB/SÊ"K[èªü;MXˆQ@ÙHm²‘ºmò×&c€s•§ÆÉÿCË¡Ã}(Zòƒ7r€ï¹ÆùÐfÃ}rÀ§D¨{£a4ŠA?Ö@èZ‰ï?5$ˆá•Î€ñ/L{Q®ô¬ó>\šöÄÐJSôîòÄçk±wÉ¥k×ÝB2|2X…Ë}~ù†(¯ÓF¼/\0‹a
-	t¬ÈÏ—ž
-IŒ9åN¬ÅUË‡‹˜­9;ÞôF’(Ð†Óëtñ)¡@® Œ©*jN¿<:ýôy¹¯åH¥_böëžªÆÑŽ;¸ß¡Ç¢Í’Â´Ms¹Ð Gc:ìªG”ÄÌ-Bà^Û<½Æf“˜¶Å<ºöù5N›Ä  Nà}Ìó'“.Æi“`-xï¬»Ø¡ZØ\—ÏÔìm
-9'›ü»7ï~öýûÛJJûa´eu¼¾º-7MdQØ"RÚå9{°M^Iï~º²±ó{éâ^²y›OÒè¿8F©
-OÉòp4YšÒF+Þ`'¾ìÅ
-è9xV¢Sëª«Ð„œTÑ e»MŽ6— Ÿ6íâ'µ—Ž8=y#–†èÙ›ÚãÒ«†s1}#Xv´émâNNÞÎGœ©}Ë¹²;uïE¹‹3ñ¯+ŠäÂÒ£»ôâW'&!ØF>¥sB¸Sa¨û=JX¸îiœ:¾Ÿh‹*V¢ILxïLæ7
-E|ÖžN²yàÉJ«ÜÌ0&®†„7>T¢Dª|š†Ýø ÉÆx|v¦ZE16°mBÛz$ê½Z¬F…˜Ÿ ØPÒÃˆ¥¸R.„È]`Ð2:ÐˆÕ¸’‡Df#¯ÂðN@.ìÂÀÆtB‚Saíë&&´ˆá÷* ¢] ÍÑÈíHÐD4YCH`‰6¢@adklf~ñ/¬üoµ·Žâ½TsgÁ=Òûó–l·Î<Ñß‹'·Ú?¶pL938§NXl'ïUúSƒœMÛæßp_«mÑÁü$FVß‚~ÏÜž‡*ãP£r#¾#ËÖ2ÖD£±Û¨‹X¶®Áˆü™¨VºB[›ûRO@ßíì”ïÊ)f…:sŠÏR±#JünDÏêRKX‰Üv¥êŒkÜŸ‡U!-_„€)$;¸rhìåÊxÉeÜ0»V²úž! ˜Îçcškå2nd!æ<úæù·¨}r)7ö`]®"ÑƒæáC¹˜›%ð1ô `‹Ê%tóŒ¹\æŽ‰.Hˆ¢ÀyÖ]eäêm>—!þ:„(—o¹¼f;|+êåC.à=IÚÐ*, \Á-!Æ ü  òÃ ’ÃL\ ‹¹BP,àÆÆyŸÚ×¯“ èõFäw Á?¨ ˆq>²^Ívpä!ç…_êö+—X#vï­A„`ù|‰ülk1£qJ"0œ¶”3Jà]TŠæÊEÜØÑÎ×ÙºÁ?ªukÅ"k1ånà* bT‘Ë ÄØbå‘‹¶¹.…ÇLc@¹h›·C$¨¹p›O€®
-TV/—nÈáŽ/ÌêÅÚmcñ’Ôª—ÐÆê%(VuË8cR°ƒR¤óïfº>(V^#cÀEx7†.wBD…Ô$H„æß¢ŠÅÖˆ<Ûh›,X®‡ŠÈ‹%×&0„m%< ¢ì8kLp‚ý–2òbI·\ÊšØFwJ‹º‡<mJû/u~Qçµ’Ï-Pzº*ÅÒn¹v6YìqÜ7ä$¡XßmW=»ú5\,ò–¯ážÙøvT±,yË5´£	 C 2Þ+²dsÌU¶A¬ë–¯èOXH× ]þ‰¥Ý(&ˆ>ç\žÄÒn9á"zºŽ ë»å¨4Ëc;ú.ˆJ*fÖ˜2 É@r¬H¿–úH(ÖGc²£Ð{@ð'Ñ$@	R.B{é –IË‰ ÄÞt Õ,Jc›Ù2¹"RÇ€xmw6+D)^ˆÅÒò…1…`;°ƒŸT Äk{pBŠþ
-¼@,•Æ‘À!÷Ðõ-¹aÊÅ1^E4‹ÅÒÆ+kÕ‚›¸ñÊº^½ÊzÁ­»Ò´4ýy ÄÑuªfÛ£X‹'™7A¶ÁUO91ÊpK@Tâ$Ë*žE.ìÛµ2¾:ÝJù£ù“}“…„uïGüR°	ò×óãjÑa+äHï“o^ÄÁ´úÖ|ÀçÅÌEZö¾yèÂ
-Â„HËú³Òÿfå¬žNÃ4ÖÒÁWg;¾)’èÖÐÆõR9¹X´qn•e­Ÿ¾Ñþó`ªânÌF±	’ƒh0«£ÓÖóN¬‚Á¡Í¦‚V ¶\
-ÄÚ!è Eî‚n)«‡ä¢Å¾ªB(ÖòÈ…‹}ô}@Pð‰<rñâÈ‘Rû£6Õ@@±@†œ¤î7ÂÑ+SÅÊ=xŽLíû¢j©bEˆ?L²’x•*{D‹¶8÷ò«9oÝG#n 9ï%‚A—Õ×¸ÑÏ­Ü¶€’mÄMÍž¾€A¬êÎ¡*ÄÚdDG`P;HŠuÈzÈIX×ÚÑøïrû®N0èÖN±ÌÃ>öŠC¸D€§ÜP§:MŠ ï€%šygÖW»Á ï…ìðýð°&E>sh,c;ƒ6¿\ ò.óo!G¹,@v}:ì‚*ÉåÊ i#ÑÕâ$Ö`“[ºZçÚ!PÍŽIö P¶{öØÝ_IÍ`;ñEÙÀä	ñ’>1[zçð;vÔ
-€ª#&LgÿCò¶ßE'¤­}sPLtåÜ/†Ô)j³eSó˜è¶Ýt6WŸSo£Vpc—mÓò×n<+ªAŽÅyÆŠ'óÏî!ÐW 6ÒÊmHBî­Û›ÙÂ˜d	—µuÒ:d1ŒN­$¦µZ—óL\-W‹ë%1«5›Þ­7Ùys…k1‰Y­6x0¡ÇíSm^-&µÚè 0e^+ Zt?‰9­6!ÛzïÜl¨YPia¯‰üí´¸ˆJÒqÕ°Ì8­‡Hª•–Ù•hàNÿ“³+ågŽk.%ù;íÍ^­h¸>Ñ"—s^	{õÑ- <_¸VÁ\¥†ê}…Ùo#‡¦„`“MómÁs>Ü­óoapbFgVÖÉ†ìh…A»1‘˜Ñ™;ÄGãr_+ *‡:]®ŸÖ€÷* òu%¥¸Û‚¸Ö¤b-`‰’7®T jñJ¡ ,($ft2» ac¥ªDÿwêQ÷ùï<šqÇPÖZe´H®—WÒÞ8ê¡l\Lƒu1Çž¶ÓNVµÚ»3˜ )÷d°Làƒ¦¥­`­5‰™°.ßEöQ>×%b*ì¨\‘@©	uÄdØKÀ¸ |Pç—dIÈa—”çÇì¶¢‹Ò$Kry„´ó–µ"@eäb.l2@}æu~1nË‚‹»ù¯°’I"R¸bÀ‰aðÎ›› Z€ILXÅÌ9ë1Í¨*•˜°Šˆ¹ÂÝVl©!YŸtgÛ÷g«q(¼¹RÝ´x§ý[æqK‹(®Sû![k§U_	ñ}-Àñ·ƒ«6Œ*îÆ+­§Êq+íÌ%4mIÓ&äTcËÀl8¶Ó®z)”óŒm„rnùeHWyÛÒíyÈ'kuŽª„¦Ð{ï@Ôòü®‡Ûn ^Õ€Œã}KÔð²9\ÙÊ¯@BÅ.\”­ìÔuÄüp´9ºŒÑmB€ÐýtÎax¿Þ6vÑ$÷áí×HÌ<'ôLÛ–ÖÚ€Äìóyå¼Š`Ð7t`ó*a­[·Ú"Îzñ÷YÛ®Kõ^#1¡}D¸M8‡n^¢“—
-)¥‘C—=†ç5gö±lÙ-MOÊd? Êâ²=ö—uÖ?‘_è]j}>ú§(‹Z»‹®äX[]ÑëYx¢Ò‹[ÚÃM²|³ewJ¼žæ®=®Bp|¸N•2BýÇb3µCº°­7—¬ìÕŠÓ;£_pM{á‘îkºI–šžØÔŠ‹3•OL/ÔÇZ4Ó›kæežÌÒ§UŽXzêp;,›ÈF¬B>vË^ÃÖ*¡IàÌ´tÕ-ÞX)–º|vC¿êª«o¹H¿É6‹k’xŠq?]_§„Y§÷é¾GvKõV¡¯F1Ýú5Ccb±–‘Ÿ»ŸÍê×àÈùIÞÔz§Å†*°±»çµËâ®ôÆ^QmuVn±-ŒÙµü¢7‚°ÜJ—n¹Mé£ê@ÆyÒ–' Ê‚cUÛ„è«³°%¥žÛäBÝåê:§Ã¡ßšÎVý¹c²É7´Q*÷³I¡æërØÀÙÄT3öº,jðW›rxH,–„6Sì„áÞ–[ËOKŽ7‚¬wŸmê“)ÿØdæ8ü÷ãìd¼?ßÄ!×sÊ!Y˜7mÓf‡XÏétsE!—#UÏ¶pD€UG 'n0Ï/»¿ÂªÊÎåRkí#µ¿·[î&71pI	µâm#Þ]6á¹eé¶±f›ÙÙùr*í¤n[µ*&H.02ôÌÝv”÷¥þ|B2¯œ#ÄežWÇÓGæ!&rÚð8©2Þoh,‡Qÿî8´e c'âŽC#‚qDöá`/yQÔBäs…µý>X;ßâGÈ§3™Çê¤A[Ž3ØF44”wÞñûôwuÎè	
-áÀlš—ñÙípDúQöÏzäï¹sCwyy9-R_®R à©Iç-iÅ¦0AôŠ-cúúi.; `á}šÈíGb–‰>ä¢ål¹´1—}sïTvÓ®Òó_ä—£É^×ˆÅº~Œ!ÍÁƒ1öT6IJ}…¾6^_€]=Â=v¼«âÔhµ±»tJæÖÒ-¨qkÜ “ƒ\¸·%ÇCjz†ƒâ~Ôs¯ã:eT2Š37%ÀÙ¿ÉçLG©_=.=pºj©.KDíx@Ê±#lí&[÷Òz8÷8Î¸Ë|ä¥¿jb«9Â£b0¬c0š¹zØåÀŠ¨ä¹+‚jËa‹k|¨ËaSlÉ¸‹„Ë)&3zá6(¯Ðâz>ŒP5¬±°™ñj[+÷\aó„Êv
-)Û.»©© Š58GÖê	ÙÂ´¦ló¤^–V†ùÞ­6•+bíöFf#¸~®›Q²Œ†ªžóiŸðRÅ*š&O©3»JóÇæîç )÷,†Ûid¿È¿ÜxÄ2§”Ú8¿îv<[Ä’––j%tP_¯žíTbÐl{Z$QN§ÌõÁ‹‰9;^õùŽq;ÏDf9:XTÄÙUŽÃ‚M´08Y0÷“¾uiË»ív†ÝªÑž}Aßj[Ý/"KÇ\3.\ƒä$µãÉíÀ9úÅJÓtÔRè\DK›0ð€Dm$Ë’ì/®iGül–èbåÏÉ>¢/¬kÒ¡x2gÔÇ ”2„´òîÜºš=7æî&£cs]ÕìÀ
-Ê;Â‰ýÛÅ‚§‰’,yºÒ{Z¸ïÏ¾
-
-Ë¼¨RhO°êÙ£õ‹ûû7ïþðýï‡oŸ¿øpÿá§ïò_¿ùŸ·÷ÿ÷çï‡ç¿ýðáþûùO¯v¿ÿã›~|ÿæþÇïÅ’Lbqp­‹á\ÇÚ¯gN­ÿòcL¬
+xœ½][“·q~ß_1)J›Mt7®Ž¤X¢äª8‘Ë)ñMR’ÖÊ²-R¦7•Ê¿OaÎmÓ˜ÆžÁ9/g÷ìÎ  ÑôåëçßüòêíðÉ'7Ãðüëÿúå`n>ûløâË7¿ÁÁfx†C0½G;ÏàÐøáÍÏ7Ïß˜áÍ?nÌð7oo¾xyc†—ïožß™qxywz9ÿxùóÍ·gŒùÎÜÿ´ûŸ4þ¼¿ý~xùû›¯^ÞüÇÍW_¿¸y^Ò…]Ér#]X¡k$ë£Ûáå_V:'©ó¾Kçß}¬ôÎBïh\§±?Uz·RïhÚ¯pÄýíðÌ°Î:öLB¼gŽ°ÿ¹û~·û†ûÿ’©6`Šö?ã>C¾ÖÔ]…]¢Äºy‡ÁdÕ¦ØÞÏ(¾îß|=%ásðCûÇ~ßc6îv8öqWoæ@6×gÛ#§ÙHïŠ§VÆí41ànä@`Ø Û¾±Êvð"˜ò¼ØÛU
+„5I{^£q:ŸhS$ŠƒÖ÷˜Vf$
+ý[ã€bì°$Úz$©w´lÙüVé%}i1‘ÃíÓ?hÝKjÑ’…Ð¥{Ôº—£¥ÆpÙ74
+$åh™€"p†½?g?Ž4ü‹F€¤- ¬»üá %‰h-AèÓ¿a•	$‘hmì4êäŸuÜ>ë”'ûi¨)þç…Î+Oa¢»ïT¥]XšÇqõÜn#D´«jI9¦ÕÏA˜<DŽxÃá˜âgïÍ‡q&DõãÙl*NY;%)œô\•ÀC‹¢v-¿oœhIáˆ†bÓD¯rû´›ˆ¤oˆø,æ¶÷ß ïIÒ9”%žçD=HPEIz‡¬‹.á&vìþIþøTã’”¹ 8õØt†geI‘÷àÑ4îÿM§0’´…L®Ã•’¢d q ã‘Ö¿¤†(y°}úÿ@ë_R ”ØäÈ^gWJ¢‘Mo¹«íJ–D$c‚äñU·%K¢’)B´˜/g[E[–ä$³ÎÐUö%K2’­‡£—ß—,IFvù‚Ð¥m_²h±pØz×ký‹oÁ¦.ã¢õ/š'ƒ÷Ø8þæÝ(õ*Æ·£°õ{2ŸM£º­#œ xßC,«M¿h±˜,]ç°fE‰cˆ}HÐ$€m$ž ß¨Vûÿ\ë_4’¢ÖþÕÐxK´œý÷Wo>þáí­DW4€HÊ‰Véz6ÛžûÛ‡û?öãá7>ê $iîÈ‚5iÛ5÷èŒX_K·zÍf˜ínÜc…¼:^sK‡Å^Ž±¿œ/¬…Á½hë^¶ë¯Ýò+ž8NïTÜ …Kæõ´å“K¢2ÊÑiøHåI×!z0ì0	ˆâa÷Æ’²C
+Ù8lôó–•Z=øà{èFyŸV)0|¤næÀÏßßÿt÷êÍýðÅ×µ![Ha2é/¾¹1Ã7/þpcÀÚáoìðõM~éçn0Ãßn¾©zŸ$U†6 îzÚ¸¼šñÇIš½k³"ÙÎ]¤q—“tºÉÄ. Jè÷È˜L"¼œ¹ß‰îð@à-™>;Üi$H:£…`­MWÙâÎ¯“p­=>tÇM.
+ñ„ÀÖÚ¸}‰5[š-9Á‡º±ÿßkýËnŠ©GÿbÆ‹Vnã!8ç®"f¼häF6aâ«ìs/¹ÉƒM–;ð¡¶É½hÝf&…±†Ù_’D«6%zÌÀw½F‚hØf	c M$Èáù¨¯s½hëv6ã®3/¢¹ÛE‘{ðoZÿ¢ôû¬‡É ãÝÅ^”’!…âUD¥d´`¢Ïƒ—?\'áJé û‚(€“M¶Ý]ú DÓ¹1À{œ÷µƒ@Mç&+ ÌþœK+  šÎÑOvœÿ‹+  ÏMö©ÏK´A´Ÿ£‡.ÛÏ{( C êÞrÃF9”¤/3Bt>]gZD_#@ŸÒåÕO}Œ– ¥+hŸ(:öÖ»«hŸ(ú=õ¯¢|"¯Rp%Ý3r?ÕEÑëLŸÓ…¦}¢jÍÀnœÝÏ3´œçEaœRÄk(ƒ(JâÀ;—®s‰¢ÜMi»¶}EÑ—hX4¬ÛšÐIr¸5‚EÆ+Øf’o`bØÞÿµþå€k.qþ5‘›ÄpkJn»·…Û'9Ú:»ÝÌÆõ?ÿ:žÄlg Œ9)WIÁv¬‹©	Që_ŒÁö	vIÛg@=$1Î"XH(P3’$±ZÛƒ5ßÎœ¡G²´€e³šÒé“ƒiõ¬ª9­©“=wãÞßœ%up–v^ãŠS{ïš^>ÿxžÅ«zrÑÁæ ì›æj•¾W³‰jþ5"×ƒ€ìŽWi=l8FhÐ¼èhd'›4æ:Ë »Ø9ávþS%@t°¥3l5hHë1²,Çtw¡A‹ÛB#;Âìq,$ÏgxÿK¥ šìÑô à¿Õü>ÑÆ‹"ºÆÍ¨ç_/¥ì<ûèõZtQŽ@šDÕåoö¹_«kŠßä/êû•ngšcùÈ?å_å_÷Ð2¨tÑb™î,%(==Z¤DFþè|²ëYËÙ9ö¬œ¿;QìlËŒðåøÇž>(t¿0Ò§rw‡Wñd­Ñô(f»žN2Á¯[œÔè;ù “£ƒ‰¼ÉQ.ã³O¥}ý TmoÒF/7Ø×‰ó“zÙsçõwÕ·ë9€Ë~*Ñ€GVóâßWg¦Œäµþk0#Ò³GZìê×ò²‹õ-cË\ÈyÛ«#˜$–nY»9ÜÄžyJ\§¾—iu/{>qßHÚåêŽù[¨$k³ÖÍY
+“¶ý4Þûj'G{Mbýy?	³®l³	£”ïWùdÑQH‰Là\‰Mã´­]ËO6?Ý'Þ=©íåjÕþ5fp¿È_Ï+S[d"ßI)ËåÞžÉÿùHŠ0jª¯ì8šK1=×î'Á¦no^ÝÞ6Çd›M9»Åx´"ºç,\®Òôp”Ø|`¤cLýa-‹™À÷”o˜ú¦d.ÎA‹ù¹„]¶Wd(•úQÖ$þa
+¬2¸»Êÿ«âc1­gŸIŸTI›k¢»Õ,…ðSe ÂYpñ¤•$àÉ~¼Pe*âlÜó­ÚŠI ƒx“ýA›¶b‹>Ý£ä²÷³ÙšIîƒT&¾×Ç$Ù`1„¢Û$BÂŽÔÛ·_•b9ÅûU39f´JÄs•É-°ÅÍÌÊ·Ÿ®Š0G^; f<~T•l%. Ðö| ¯ý*š‰‹BÀõ13P}ÌÏ'ªƒP'G2%„>õ §”Û‡Yµóµ8j"qVwkò¸²|Å÷}Ó»e¼½žM8€g_wOŽG–Ô‰ÑINëæ/9D@rH'+E9ôã¡¼Ð–ë÷˜e»š¶^}~ó^ÜýD]u<”7‡£¢º,b”&H”|uIGëÙ?ëÄˆQ•œÀY×…˜©ªO>iÇwi½w2n´?þötühÕÌT‹áL)º¦Á®ÚÐ_© mb ÑW”-Ø›	x­ †æ|-OÛ	x£ †Q´äçs^š³ G^ªˆqC9fSj›^x$(¢Ä°˜ëÀR'CŒÛtŒ·xv”ÁaF6ïÃØQ†„ñ8Eï®Á2(LìK.µMîR’¥è‡SõV¸ðç×&¡‰ò"nÄëóÂ}³hFÎO¿“Ÿ/½’Ò8Qä”Û´¶=E°œÓùÉ0Ò¹¬ùƒÊ’®Ð†¦Þ€ž‘ÊhPs¾˜]ÍñË£ão~‰ô2o©ôhÌ¾îxêÔÚHúñƒ8³ä/uIÅ24ÀÑ˜Íkz§®©˜*Fœƒe7ö®K[1KŒyt[»×e­@À	¼ÏÐÄÎz`ãŒ» ¬¬ïuÚScíò™š™Nãfk4 ™œŠÅ>+éƒ[‡iº—ê‹ú	²é2+Ð¦ª¤w?ZYÖùvqqi^äÅ“tr{ôµ§dUx²sšÒ°+^u§¸¬åOˆõ‚ø.¢QxuÕÃè(€·iuó«Çn×ä¢s	’ñ©i!ŸÔ^:BäV+ÌßhVhÈ²ê´‹iãÁr¢l™÷m*OÄˆÊyóÌL=ž+kT÷}”k9;'–	S³iÍ.£ ª“¬#o×9;Ü©4Ô½&%-\÷TNçjƒ*Ý]¢MxïÒfQl£h«äuËþZ… sHâÅâ&*A¢ûU¾Í€Ô$SØOã³3ÝÛs&†Ó6¢¡†IÓrÇŒ*”Ä`ÚˆYº°e`°”‘‹y3j¡,yH”!ª7öÿ£Z&A†”a`c:_ÕJ"v™˜Ðnf€?«Ý‹Vwt€–­ßÎz¡¸‹0%jš Ep½¯‰•¢lÔì¦©½uPÏåñv$½?ïa)±µçiÉ©ù“­F	)âš±Ï)Ù.»=~RyCÎ5Fp6µôÞRb¬²<{{“CY}Gˆ>sizúˆ:£Î×2(EåÕH›2 0>{>OPû³[q0›;Z‘BÇ®4z^¥2uvDí"`ÀÆéYÝ@Q7¨Ü3<žq×g/]U
+DK!`
+É6ä‚`éü)hHÐG6.#P>«4øp>ª·UF#‘}‡þ[Žy2j{°Î¿ÕÃ'ÃÆYCô£–ç9úÌŽ9[½.ÊŠ¢ÙßyÖ]gDÃ¿ÏAsÁ_‰EëÈ€ˆ¶ƒ–•Ž2H\ô@&aØN€†Ö€2H\BŒ=ø«ZM”ˆ)@ëÚ@àœ¶6y@D„8Îå!½O]øPÃAÇ-Ch‘OÜÿ¦ QÈ‡k¶ƒíùI½üÊHnäÀŽžësÉ*-èà°)U¬¤S—!‚ÁÉ¤×Á’x×á’P†Šãˆ“ýœ›—øgu†Å(#k1å%ÞJ€j^‘qâ\& ö˜ÝÀ#ƒÂ¹.…ÛL_1á¼…úLAƒ•C†ó	Ðu™UâËÈp¹[‡##^\â‹Àp' ”-S ¡L.€:Š—­pÆ¤`Çº©É_øh(b»‘1à¢¼£ãù4¨ûDDv#“ vè¿åh(b¹x¶ÑŽàIÝù
+©ßBÄs›ÐÀ8Ñù[µ¼öÔ¥uàãdê7 ¢ˆ—Á³‰mt×`3ñðË!ï°löNë_ÄŠ#!ù\Œe;Ÿ«QD‹Ë8Ýd±ÇNWTD¸¸¥»ú]\ŒËwqÏœïÁ[)Ð	¥m6-3šÐCÚé‡ ŽBqm2WX¹:j†Ë=ÎBØphÑ{"HÅÑçT„+°‚x@5"¡§ë(>%.‡£Yv·Ó YŠIDƒcÌR1xHŒær J$‚¬1YÈáç=(øE¥@4P®ð
+ŠDˆµœBìM.ÐÜÁ$"¬±Íb™\Ý¨™æHDXË×UÏ6ÅËÖòe1…`;ƒ¿«È…Q¤W¢8Œ¹ÇQ_Q¦Œ'Œñ:ª™D|µÉeuÒeuh½©Ò:Ö•%ÖÝiZFÿ<âà>UóIDîIÆEæ&ÊÜõ”3¢§^D%,²-’eg‘yÕÐÙEw+hIó'ûæ	ãÞµø•Øà&Ê¿›W1b„¥#¼þyq¦`]óŸ=yÛ3úæá+&VÖŸ•þ7C¿z:ÕXË_ííð¦È¢¡Œ´¬csuæUyµ¾û£üçÁTÅ&lLŽ&¶ÉA4˜Ï¢ƒÙ„æN"Ær‡6›¶Ðp# c¤ÈÛIÐl$"ŒdÌcß¥ÿÔþÅÐÁGß¡ÿÇjÿb\ª¹<¥MìvÔ'ùãSu3ˆØržºo¤£Wš8‰€=xŽLÛE=›Š 9X˜(ä£á56¦Ý@&@´h·qænA^ê442Šœß’ý©.Y7Ïz}1ˆ	(Ù3#ZÎ—ˆæ,ú 
+-Ó¬è¨OUDë~NhíC€¾¢ußå`]Pmš$B9ìB¬8„+Lå@ž€ú r¡ˆä@>‡·aòº8Šx”O£}Ð—@¶îç¼î.4p¡(cŽ{eÜNÀGjÿ¢(ÌªºKÿ:Ö¬úÁ!^áø*çø§1Þ¡Cÿ-6$1ÉŸM.kÛNƒjJ´²M?ûtºœ•T_:U²ì#Ø¨L ¦z3ñnÐä ðKº4ÄœçÑ¡à³ÚL€sCbÎsv($oûÝaòÇgMµúHÌRe—ÀÄ:ÌˆV«ŽlÍ¾o¢k»Á4£Ì©s4ÐŒ1Õ)j;½¯Ãf<+ O ;'œÎ£5g|ôˆÕµr’+ñv˜Íl0L²„K\Ý‡Y4£×}"17Õºœ8â:œeµø\“S­·`½É®˜k\wÅU<˜ÐãV©ÚâÄU¦ìÛJ€¬Ob‚ªMäZ/•Í˜—æw‘É_OB4–:vbNÌ/”0‰ÖŽ?9aR~æ0æ"÷qo`¿ÓÞìUˆ†ë-Ò3çØ«ïˆV~áùÂ+ð0ôr•ª·fßÆ›2|IÌÍ×Ï–¶÷ß$àD‡»A B‡9PcÄ$Í\M>x;º„“ƒ\®èÖƒ€Ì¼bŽ&cJq\ìyþ¥z2ôµø#JÞ¸³ð±JA-þ(ô¡@5›ˆ9šÌîSÐ‘TU	âÿŽÅ ê>ÜâG3ñJØ UIû€„yy$ÛëF=TŽ‹©­Î  ßc“VÄÌVg$G~àÁ»óïuZ2‰y­._EÆ€«h1±õt¶
+‚¹dª‰‰­!ƒ¹¸hÉþ$æµ†?Icÿ)mÉ1R¹@ÌkÍp)»À¶¯€*ÂÅ´Öd€:ÐpaÓZ“w$\~$-’"D¤p%
+Ä Ãà7}ÖA7ÿŠ¹§˜"ç¦¼ Ó ‘ f”ºÖ‰h:¬Oº¹íj´ÕšØCh®@•ÏO‹Ÿ—%¹ÊÐ¬cù![+¨U4_‰Û;•úZãoW-UÜWŠO•íVÊœKhG&íH!'[fÃq;ûªWC9oØF!gŠ_†uå8¶–¢hOä&?\0ª2šÂï½£KËý»CÛÀ;iõ ä	Œµ«w9ÕbV–‡+‹ù“P±Ø“ê®‘˜í6ÇŽ1º¦	P¢´?˜KØý Þ®—Ž]Ê}xù5óÈ	Ç½Ú†¶µü‰™ä'öÊukCZ­¾®”_ó*¼V~m».âkKXü}V°ëRu×HLM?M¸qÐ¯÷üú](¤”Nº¬3<NœmØÇ²}·,6=¼~ tâ‚²Ýì/AÓŸÈ/ôÆMŸ·þQ…Ê0wQ™k£+ê=OTêqKkØ´ Ë7·¬N9¯Ç¾+ÈÅU
+×ù ²RF v,Æ0;vHMf£õóõ½
+©(ŸµÎß×ÏˆtX;šd¥é‰MüÔCQ[ù(óB½­E½ùÁ¼Ì}Y:¶ÊKw¶ÓÒÄ5"ø©`öÚl­ò™DÎl@KÝâÔå³%««þ¾å }“SlÜ $æí~´B¾Î	³bïÓu-vl*«P#£èný–¡JU×6éÒ¦¢Üõkpäü$j½fÆâ…bŠ*,ÐXÓsIŽZ\eñWê‡	m/¹¨6:+ÙÚìZ~Qß@n¥N·\œôQµ¡Šä<ž–[ FÊBdU…ÓW—aKN=·P…ºÊ+ÜuN†}å4]¬º/È#$
+›³½ýlÀÜX±¾à†É&&‘±‡€ÔcLcÛß5¸%÷mF`Ž}æ··#ÕRÏ’ã6Šõêñ³}2•M&ŽýßÏvÅÛóÍ24SÊÂ”xË"5[7Dp¦Ó6dç™6X7Ô€”´jÝØFÁQÌó¿Ë2nÇÈª²`¹TMû /^O Ä²p»	—¬Pƒa;Í<2DœŒûˆÂv‚_Ë‹ïrdä‚­
+ð†	†K4Í =sÿ–Y°&]€æ`€ÍJËÖYp–yv§6ÉAððM{—Üšf‹Ž¨Ó)ãþ%òny)4¬ÍžÍvlÌ|ÌžÎÜäKªFu†éßïÒÍdÑPÞLO?×Çáõ\‚°	›‡ñ›Ûá0éO‹KOo£sktyÃ8R\Xã&ŒœC±WÇ£žLK×	Þ£4ôŠñ:Ù¯ôñÇU¾ì1ÑD¿>k L|å3r½åÒ\V­Ù¿S1«M‹8Ï[â¿<ÙÕN®i}Æ|œËêÏØSÙp(PªÊxm ,Ãñ¶p—ïj)8ãY­¢.í’¹M³ejpU8â†¥•ëpÞŸáE¸?G¯ã:gT‚ý‹=7eÀÙ¿ÉûLŸRZß.ætÕž\‚32 eÄ0¶¶É"½4ñÍÝ‚3é2oyéTšTô¨3Èë3˜íLOp]6¬¸J™»¢¨Z6›]•C=6›bðÅ1\-gƒÌ,Ý…q¿¼BQéy3^W%hbaØ,‚ÊZÁsX†¶<Nåv)*È.k™é$úUÑšÃ„m ñ!Bk*6ÇËÒ0_»Õ’nE@ÜÎ¬ÏHXß×›§d²TÝçÓ²Üå«¨N<¤ÎŒØî‡rêçl ©ô,šOd¿Ê¿nÝÊiÖØù•´CtØ"à³´'+ñ}ú˜ÒêÞîÁ%æU­§ð„ræc0)æâxÕ3KGNÜg•Âòä©Ùv“÷ùýý«7þáOÃ·Ï¿xwÿîçïó_¿ùŸ×÷ÿ÷ËÃóß½{wÿÃûü§—ã÷?¾úñ§·¯îz÷VÄö°cˆƒ#0h]çi;³þ?rÏIð
 endstream
 endobj
 
-308 0 obj
+315 0 obj
 <<
   /Type /Annot
   /Subtype /Link
-  /Rect [70.86614 614.7932 82.48214 629.45624]
+  /Rect [70.86614 582.5842 82.48214 597.2472]
   /Border [0 0 0]
-  /Dest 291 0 R
+  /Dest 298 0 R
   /F 4
   /StructParent 9
   /Contents ([1])
 >>
 endobj
 
-309 0 obj
+316 0 obj
 <<
   /Type /Annot
   /Subtype /Link
-  /Rect [246.72314 585.4672 373.23413 600.13025]
+  /Rect [246.72314 553.25824 373.23413 567.92126]
   /Border [0 0 0]
   /A <<
     /Type /Action
@@ -4070,24 +4129,24 @@ endobj
 >>
 endobj
 
-310 0 obj
+317 0 obj
 <<
   /Type /Annot
   /Subtype /Link
-  /Rect [70.86614 564.7543 82.48214 579.41724]
+  /Rect [70.86614 532.5452 82.48214 547.20825]
   /Border [0 0 0]
-  /Dest 292 0 R
+  /Dest 299 0 R
   /F 4
   /StructParent 11
   /Contents ([2])
 >>
 endobj
 
-311 0 obj
+318 0 obj
 <<
   /Type /Annot
   /Subtype /Link
-  /Rect [89.63214 550.0912 217.34215 564.7543]
+  /Rect [89.63214 517.8822 217.34215 532.5452]
   /Border [0 0 0]
   /A <<
     /Type /Action
@@ -4100,24 +4159,24 @@ endobj
 >>
 endobj
 
-312 0 obj
+319 0 obj
 <<
   /Type /Annot
   /Subtype /Link
-  /Rect [70.86614 529.37823 82.48214 544.04126]
+  /Rect [70.86614 497.16922 82.48214 511.8322]
   /Border [0 0 0]
-  /Dest 293 0 R
+  /Dest 300 0 R
   /F 4
   /StructParent 13
   /Contents ([3])
 >>
 endobj
 
-313 0 obj
+320 0 obj
 <<
   /Type /Annot
   /Subtype /Link
-  /Rect [296.45413 500.05222 436.71515 514.7152]
+  /Rect [296.45413 467.84323 436.71515 482.50623]
   /Border [0 0 0]
   /A <<
     /Type /Action
@@ -4130,24 +4189,24 @@ endobj
 >>
 endobj
 
-314 0 obj
+321 0 obj
 <<
   /Type /Annot
   /Subtype /Link
-  /Rect [70.86614 479.33923 82.48214 494.00223]
+  /Rect [70.86614 447.13022 82.48214 461.79324]
   /Border [0 0 0]
-  /Dest 294 0 R
+  /Dest 301 0 R
   /F 4
   /StructParent 15
   /Contents ([4])
 >>
 endobj
 
-315 0 obj
+322 0 obj
 <<
   /Type /Annot
   /Subtype /Link
-  /Rect [186.20114 450.0132 322.63416 464.67624]
+  /Rect [186.20114 417.80423 322.63416 432.46722]
   /Border [0 0 0]
   /A <<
     /Type /Action
@@ -4160,24 +4219,24 @@ endobj
 >>
 endobj
 
-316 0 obj
+323 0 obj
 <<
   /Type /Annot
   /Subtype /Link
-  /Rect [70.86614 429.30023 82.48214 443.96323]
+  /Rect [70.86614 397.09122 82.48214 411.75424]
   /Border [0 0 0]
-  /Dest 295 0 R
+  /Dest 302 0 R
   /F 4
   /StructParent 17
   /Contents ([5])
 >>
 endobj
 
-317 0 obj
+324 0 obj
 <<
   /Type /Annot
   /Subtype /Link
-  /Rect [482.85144 399.97424 524.4094 414.63724]
+  /Rect [482.85144 367.76523 524.4094 382.42822]
   /Border [0 0 0]
   /A <<
     /Type /Action
@@ -4190,11 +4249,11 @@ endobj
 >>
 endobj
 
-318 0 obj
+325 0 obj
 <<
   /Type /Annot
   /Subtype /Link
-  /Rect [89.63214 385.31122 182.68114 399.97424]
+  /Rect [89.63214 353.10223 182.68114 367.76523]
   /Border [0 0 0]
   /A <<
     /Type /Action
@@ -4207,78 +4266,80 @@ endobj
 >>
 endobj
 
-319 0 obj
+326 0 obj
 <<
   /Type /Page
   /Resources <<
     /ProcSet [/PDF /Text /ImageC /ImageB]
     /ColorSpace <<
-      /c0 271 0 R
+      /c0 278 0 R
     >>
     /Font <<
-      /f0 241 0 R
-      /f1 247 0 R
-      /f2 265 0 R
+      /f0 248 0 R
+      /f1 254 0 R
+      /f2 272 0 R
     >>
   >>
   /MediaBox [0 0 595.2756 841.8898]
   /StructParents 20
   /Tabs /S
   /Parent 1 0 R
-  /Contents 320 0 R
-  /Annots [308 0 R 309 0 R 310 0 R 311 0 R 312 0 R 313 0 R 314 0 R 315 0 R 316 0 R 317 0 R 318 0 R]
+  /Contents 327 0 R
+  /Annots [315 0 R 316 0 R 317 0 R 318 0 R 319 0 R 320 0 R 321 0 R 322 0 R 323 0 R 324 0 R 325 0 R]
 >>
 endobj
 
-320 0 obj
+327 0 obj
 <<
-  /Length 2907
+  /Length 3098
   /Filter /FlateDecode
 >>
 stream
-xœÍÛrÜ¶õ}¿N[×Ö÷Ô¤Ø©ËJj½ÅyU+u¦–ÓÍv:ýû¹€ À]Ò¾ÖÎýNŸžmwïnnwäüòbõÏ#”P²aDS0J1A´f ‘+rûiuzKÉÅÛ%o/Þ¬¹\5‹?­(±$òÕÛÕ«ç—«Ó±}‘Y°L/¿1×Lq¾ô¾j‡WSàžÀ´¼¯¤àœÐÃvæŒÐêKlM(Í_~k¥+úío7÷äéÓ!§—/¿%tõÍ7äüÛøéÄZŒúSn_QòûíýêüzEÉõvuzG	cäú®¹¹]Zýôè¥ô¥¼»ëý›ÓwwÍõûŸ¸X“Ò½Áöo¼ïÞÃõÏäúÕêùõ,ƒ¢p
-´ 
-ª»ËÕ£à{-u°w×Äa÷`Mwˆò=Ivk²aœjÊH÷lÆŸò pP;ÂrÑÜI–êTÞCòŽÒö…w»}±L_Ácõ9†À"–OèîÎ"¸¹Š°@'W5<x®ugç‹Éž+Ž÷{)~!Ö>z¯ŠD?aÛ{/œrÉ‡[Ù)¥2 Ê]¤j±ByµŠÖT…@‰·„$1]2N½ŠÅŠP¥‚—,š?TÀ¹8­¯bõ6Pft— X•hUÖÌ¹Ð?k.§^¥ ¹À^CãsÀI`‚°“ºÀòvÅD‘¼n``çœ”¤RãÊ¨EUÔu™ªŒÅ>}YŸ¢¼5¨MQA4Fiæ]™7'yuŒåTYÇöQ8øX;˜ß-v´UQ±E¢Ï—”»Ä?î©¼+xG.ªaS1òSV “æx‰iA}Ü¥z¸'šÄ>ª‰¤“³ªagå°p6~ÓDÏG4¡…o>´´±{^ô¼CËÅhÞyRg®†e|Îwž+%œ•£?¥m”†üŸCVŒõæó>¡{ùù{Â­½¾Rìx‰ÞYÌ2Ï$÷¢-
-÷—‘‘EU¥U.´3
-po„ ÆhÅ“ Æ©õ$âóºÃ×qÛA¤‰=ú”ÇÝqM8î¥ãaµltçj6ŠàÊàÑbÐj[§©B’ÕŒÅq	HþâˆÓë}“ü3-ìžTOB£’8Ü^|õØë½ðŽv©9¯úçD7híÐïj'bÑbF™ø^ãlläÅFÔÌZ/®ã›u^qèú€3i[ÆÂÇû¾U.©8Š•ã±N%g $ç»h]O=ñUX/ñÙ×c£\÷lº¨’”ƒ¦òx•ìU&‰Ð’\È	h"­	C°FI•„h¸”†â»TåÓ|)qãàœ&2êä1NÇSÓ2Ügs|Øž‡(<d,¨ÅðûQjš0ÓüóõÍý/äÑ‡ûu.î”¶LO*¬EKIˆ1¸ó5a¬b’i’¾äG&¸ê5Ùè~yT}J–¦[dÎ»_“`³ØÊ½ÏFÇû5Û
-ÞXÆedŠlM$k­Õ‰ÚFú5¨&TkkŒõÆBT ŠŒuÖ¢ãÕ½3Õêl.cŒv"hÕÂf›î¯-¬gÍ¥}ô<³®«G÷ yÕþý×Íå¤¹\f¼¾V…3ÒS¯fgóB¡@#_„^=
-pÁ¬­_µ¬~Õ\\"ê¶ÏÞøÂ?»òš³ûÑc€°%ÊA'‰‚äßAC‰+`–	9­U…Fˆú#Œj™Ñåžæ’R®9 ŒÏâ¡y\“ë_KbÄK©…T8Ú™©…˜”Z (š¦¹<²šKPŒ1>o]ˆóà66ïI¸9p?>˜­a*k™éÆoPi§à]±ÈÇz±Öm´0Àµ*­ïxb¸j@ìÐÂ·Åý’}8-­vQKÑR7ÞÈ»ì8¬ÒU–äòZ.$Áqé‹2XðÄh&¯ÏFeÙYa‘rÓ|¹Êf@íº®€1ÛÅ3)9(¥P-íáÎüå÷p¯ýŸW¾e­ý¿Z¿ÿƒÿí$^râÝÚ3ÿàõT ‹€†ò¥ÝCT²Æ½M>ÁX@K©x·\+™.ÉYü›ìÝlÑ»q+yïÏsoÏ&¹7ž‹o{îÎ…5¨À(äTŽÖ¡’}z’›r	š2zt‹¡›MWàÔQæ?’ÿ )y’Å›*P_WWÐüÐGj]½ŽÊË0•JÈ“–Ü~I¡­É/í§,Qñ%)xu%)´eY²,Év&ôºƒ:NŽÏiY œª—á¬¨˜Ì4¶îxÏ¿ÉÊâ®Íö©±Æ5m1¢àe“w]é¨%ÒÝq%,ŒÇ†œ'HDkPgTÅ’ýfTÅ’‚j|ôÂÃ’$ÅýÃï'ÊV`ÈAKŠS„b‰ú—ä`$ÆxÊ'¡nFosÅÓØ2$!ôvüÜA°Y“Ôµ¶yÁéx¸ãÓ,®r$=(¼SH%j¼çÓkd”ƒB|ó]àígÃTÈJoVÇÚr˜aUÌ%×L0F6±Ø¤ª®
-ôaéëà2[_ê+lWqào§}ÌÞ¿š8/7á¹–,ZB¶¥›Ù= üæ¬‰3”bÑŒÐ=ùžùUûú›OwÞL®Ä¸# `}Ùj©T…sFsT‡Á(#ª¥8ž+ ®@³¹
-25Yáº”¬ƒ`™˜YŠ;™–«˜’œÉé ”F&-3½;õÞq¥Œ‘Ý·$k_Õ€|;´8˜)¦$¼LPM›ÜÞ£fÚ¡î¸Ì¶>ŠŽáéìjž*,lOû¨/W
-õáIà}’Žîƒ±ƒºt aàMŸ®<ž»3ÔŒ°Ž5¶kjf‹j¦ dx¼ž]Ì›Ú.ÅÒD[P†3yl»YÐj\i`R16‰KÄÛF‚R’ëñÄR–#4OéR =àGöè±B·Ÿ'ó äBÇnõ]öYî¸\ˆŸ,"¹Êz¹ú]2jéðB Yü :.© ¤™â4väAŠ»Ø;H0Tïh‹\aAXL)£ÐïÐ¹$ú8øe¤t?±c%°h©$iÌ¼ì¡þ÷â‹ËÌƒ¨Á¼L˜/ríQÖL•R¶æ‡vÙ7¾ÈJ­ö¨3ó<þÏ|¸ßj€b€4èK/ÖjG
-)êCŽ°(ãµf„È~ø…Š¦f1rj|/ŠS¼‚#=cPOy^Wã{QœâIfŠ—ƒl¦¯sõÊÜ‚¤hõ”³]ˆøõÆÈG¨ŽB’Ž×|ÝŒ¿¡MJJ@ºšÙøÑO†ñÓÚ¾™6ÏÈÁéW2ŒK€—+ñZœŠa2U0~úË9C¹ñVçÅoWGFKëiÉ\ªºfä©ª";ä¢)S3œaìÕÃÅÁ¾Þ¿Q¨Dct¬°Ég>Ý=0cÛ<{0ŒÅÓ¶—ÿÐ*^7k6÷ù(»‹H³€0í¾tOÞd®#‘Ü©Ý¶Ð,¥¸i¦—aÅ¡¹^u´XPJ
-3Idç¥z_…_Ýª€+íÀ‘Ò ’öžÖH8}ˆWPRØY$ü²Ùç¹­š£~W}áñïôÀÃÞmÇÒ Û`õ1ý´‘s£T–¬	vÓtŒOª'´27ÂÂ•N­6“ï€)9D	¨´p³™ß’¬çªºÇhš9\«}–™oç¶—dÊl¡ ù¦[21M¡I2§f‚!híÃ´|&(‘j*õAG@“êJ§GkÜ0ÍxÉÑÄnÕìqïlÿZ›‹¿
-Ÿ]ÅûI|¹:xl’ö£
-…<š7ŸZTh—/‡ (ÃfïQïQ¢,Úc¸ãl·»¹ýû‡¿‘ŸNÏ?ïvŸ?ýÜüúö_ïwÿùí9}ñùóîÃ¶ùéºýû‡›_>Þßì>~¾Ï¶k›þ·6D"P&¤ÑÇÂ}ý_–©2‹
+xœÍÛrÜ¶õ}¿N×ÖB8WªNÆ‘'v,+©õçAr­Ô™ZN•ítú÷î  ÜåªÓ—¥v	ç~§Ž¿¹[¼¹z¿f§çg‹.€	&Ø
+˜ÜŠY\£4ìý§Åñ{ÁÎÞ.{{öf¡Øù¢]üi!`Ã­´ì‹·‹ŸßžŸ-ŽÇ6Fhxöv–9)¾±FÅ•h±\"‹òÆJ+®•”Lì¶³tÜ2ê¶†éîhcW¾‡­rtfw ßþ~uËž>]0v|~öò9‹¯¿f§ÏÓS´Wí¸NyÿÇB°?Þß.N/‚]Þ-Žo`—7ýÃíåòÓâçGï„ïêöú`ûEl¾¼Ân¯Ð]…é®rs]·Ÿ©[’u×Ý7\þÂ._-¾½CÚ¿^_ÝþÊ}¸]#*¯ÍÚqe­)áEœY‡¸\²•DÖÑAª˜ï„ìPX² q¼‘J²øùG6þ±{7TùrÉ$ð¦iãÂ9Ub ¿Ä†k
+'á_ã¹Ü²u½ÁMÉ·@‡-äu&¥Nx²‚ƒ,óPÉÔXì#·²%[a ¯ÀôºeçŸRÞú›cÏjz¹ÐKVßôš€¹‰µ'Õ”ž7ýFj¤T”8XÛ¹ ù è¼'(tßÕ Ûë^Å=â¢32By«ªdÔôì®ëT«räÐÿ>€6(^žºhPÑp)`–dæ(t4º‰1<ØÑ\š²vCÙ³=œ¹Îr¦–G
+Ë•q:µ<_Ò lùìõ8
+F’Ýƒ*#)BM3_¶L`€$ Ù‡¾¹8g&°¥Ið
+$jh¸¢é8€˜tÚwM³Í­ïÒU©ÑMÙväC
+©ùð+;m¡ÌqfºÝ‚^%kªBÐ©w ÈðéMe‚½ô–êID”Z¬UŒ(M£8 Þ¯/RFP“ºÉp¬Š4@Q5gƒÿ¬ý8B¨µâV*ì…0¶.)¼Ú‘`ÃŽïŠ™(x*åÀÈÐy9Éå¦¦TÉŠe²Ú&M” îSÔ·
+¶,éè¡…rg,o–…2¹J¦*0ª°cûW8x_SHï–úÚº°CÒÈÊMæ$1Ši/â	!UøbügðF53€ßÀú¸ƒ*
+m'ÚÅ>´!S¬›÷rp8ÁiÒ›ØÎoÎF´Æ/H_ðkT¤–åq>¹K7Db›œó}`‹›(äåÐ(›Ôwþ_b1ä; ó3Âûô+¤a)»|–èk+_!åYà’¿Ï“-
+]ðš‰¡­g‚@ExÎpÜš Þ b)>š«qr=I8½ìöüö`gùbG>õñW\2_¯zX-"‘Qž/¶kg8è¦ˆ[Yšöã¤ýøK*ds7J O¯ûme¬j¶Äz–ÌïölÇïåwüˆH¶“Í;×Üš‰Ú¡ß×NÄ¢ÕLrò­2¦yÙÈƒ%*ŒäªÄZW'Wçoˆ|‘Hà+Ÿîû2Vº¬‚à)VË|…{Ž÷¨©wyWNÃSJíÝf5Ä¢NZàª18§<«È8-KŠ¼€vqÒ’òÆ•£éÌh¸TÄâœz‚\åóÄ)óãàg2êå1ÍÌsÓ2ÜgµôNC”ÇAcÕÑ­æü0Jí]3”µÆTŠÛ€"TX‹˜²(cp•K’74Ø€S¨ggúèqµK¶²ýò¤•-Í· Î»]²h³ÔÊ]“òvÍ]…`,ÓŠ²@X2-6&›ù¡»D¿e…*cU±½±Ð†;)QÏ`¬·¯n½±¨‚I%s À…j&‚6µWÖn~8ñÏb]ß/Ë"‡ðÔæù×íÇQûqNÜx=|4.ÒS×W29T†[”¡W‚ü„ÀlSÈÚ°úUûás	,PwsïMX`Ã½‹P¨9Í±‰Ö\)‹vÐ¦\)öï¨[/‡”ž6€NsPˆv—#œã¢gËH%¦ÒJŽRœÅÃ¾EÍ.+‰‘+&-©PÌM.ì´ä¢)Ú¦Ù <„²Vjn €Å÷7NÄûð§©ÏÎaÃujO]Ôl2ØÖsÝLB¼b”÷ud¶²Êq Ñ˜¼Ì¨ák©O‹w¾+î—í#Eiµ„|––{òVäuÇÒh•­ò„Êm¥jU^â!ä/ÉvRÑÏFÒuÃ"Ú¨4‡¹ˆ,^ ÛR:K€Úõ“
+sÝœ,g7\i‹‡vr§áãMpr¯Ã×‹Ð¿>	m\ÿá·£tÉQðlÏÂ×S}\„­àÂÚÃ:.4´nò	®áØçÊN’ÃC`¹Tzû¦ú7©ŠþMn•B9Ï¿=›äß$áöÌŠ–jÐpgP
+=Z‰ÊVô	
+5ò5gìèC7›¯À©+’Ü¤P€¤\æÉ¯ª@}U]!ÊCg!×3;£ò2N¦2òä¿_Vjk3ÌAŠÄ")¿d%¯ÎŸd¥6rª…d	Ùz˜ÐöŽ*9ŸóÂ@,8ucJŠ©œáÂÁÇ¿"…q½Iø…kœoßzj$eÀ1ÒfÏúêÑ†J?u_ÒbX78ËXÉÖ Ô2(ŒeûÍ(Œe;Eùä‡%QJÛˆ?L[­¡äVœ$‡¨iÉÑü˜Œcù,ÖMãè;ª€šÚ†,†¾?wmk²ÚÖ-9ï²aP
+W=’ž)ä5æ»Éu2ÕÖ?ÁÍb¾¼Ã¨˜‰YëX«@S¬*‚T~Jqç4èIHíTaéãò×Î¥¶¾8ÔWÙ.ÒÈ;Ýî$íý£ùórE5f±1\é¶|3Ÿ ;”à¼5ñ–Rbšz` ß³°j[ƒùÎ›ÉÕ¸wÁ…Ä>š=T®"¥âÎJ4»¸SÕrœ¢* Jna®‚LMW–Ò¥·BÏMWŽ&¥+JMàlPŽá4‚æØ€ëšªw+…rßBZ­}UòIêvò!QNÉ6x™¡š·ºƒO%š¢þ8bÛìý—,|§©q“:~T94(‘ÿÉúºÆê’Ð„YŒ7}ÔrîÎˆQ	ako×ôLõL.Tyt©¬gÏçMq—Âifnœ½oÓYéjÜXÚ L¢Ä!"n§¹1ZÚñäR—c´@éR¨=àyôX­;Ì•¨à±[}CÞ£Ž£‚ül£Šëiìv!bÔÒá….@¶øAr\VEÉ“Åiì AJ{Ù;X4Tïk+ª¸ ÉÁg ß±sÉôqðËHñ~b×JÙ¢¥BàÒÎ™þ+' }Ÿ¸Çâœ¸‘´™èSMRhÇKó]{í«Ph…†{Ò›y‘†ÿ§!Üî?5Ä°nÿ+C#â·“ÙÚ]Žh kýE¾†ÈT`f1rj„¯‹Ó¼JnŒ™á¿˜áëâ4ï|Pˆi^É5H@ªhI-È*§Ic™ìE¤·f>yeuz08]ó9Ã™¾U;š–”€ôu³ñ£Ÿcbb€6}†höŒœ¿¡ãH°x©½’®Å©f£ã§¿œ3œ›nuV|›udÄ´ž˜ÉeªkF^—ªjr±K.ÛZµˆÌèÞCÀ>Eÿ•‘\htÎ¦
+›Éw×|ÊDmólìÆ0Ï›_á­«tÝ8¬dö7òžv“’€í0&íß}ÏSÞl¶#“Ü©=·Ð,%¹y®G°bÇlOWGŒ•PÜhå&‰ì¼dï‹ø5\qe3ud,·ÎèæžÖH8}˜WZàRÍš»çüs…Òrk¬î_ ²²áª{ÏÜ=å½+âXšv¬Þ§§6rn’Ì²%Ãn¤îÏéIõ”VSƒ,Òh.EcÝ$ÁÛaRQs4Vù@â·,ï¹¨î1šh×ž„<3â¦¶—fj²TÐ¾â­AMSèƒ¤™SsÁ4ÓðF+<øhZ;!†Vh»Ó¼Ím¥Û£‹Õ©7ÖöÇíLìš=îí_kóññ½‹4g?J?.vž”zS®ž”JËö‹
+ñèŠrã`&õõ.%I¤Š[0¾Y¯¯ÞÿýÃßØÏÇ§Ÿ×ëÏŸ~i}û¯ëõ~ÿÀŽ_|þ¼þp×þt¹ùþãÕ¯o¯Ö?ß’=Û¶	nÓÈ(íÂ„ÿ®p%@ÿu¢zE
 endstream
 endobj
 
-321 0 obj
+328 0 obj
 <<
   /Title (Technical Note: Benchmark Platform Models)
   /Author (Ruixiang Du)
   /Creator (Typst 0.14.2)
-  /ModDate (D:20260710090045+08'00)
-  /CreationDate (D:20260710090045+08'00)
+  /ModDate (D:20260710091226+08'00)
+  /CreationDate (D:20260710091226+08'00)
 >>
 endobj
 
-322 0 obj
+329 0 obj
 <<
   /Length 1187
   /Type /Metadata
   /Subtype /XML
 >>
 stream
-<?xpacket begin="ï»¿" id="W5M0MpCehiHzreSzNTczkc9d"?><x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="xmp-writer"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/"  xmlns:xmp="http://ns.adobe.com/xap/1.0/"  xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"  xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"  xmlns:pdf="http://ns.adobe.com/pdf/1.3/" ><dc:title><rdf:Alt><rdf:li xml:lang="x-default">Technical Note: Benchmark Platform Models</rdf:li></rdf:Alt></dc:title><dc:creator><rdf:Seq><rdf:li>Ruixiang Du</rdf:li></rdf:Seq></dc:creator><xmp:CreatorTool>Typst 0.14.2</xmp:CreatorTool><dc:language><rdf:Bag><rdf:li>en</rdf:li></rdf:Bag></dc:language><xmp:ModifyDate>2026-07-10T09:00:45+08:00</xmp:ModifyDate><xmp:CreateDate>2026-07-10T09:00:45+08:00</xmp:CreateDate><xmpTPg:NPages>4</xmpTPg:NPages><dc:format>application/pdf</dc:format><xmpMM:InstanceID>gnRXeNQntaXosNCFMIc+kQ==</xmpMM:InstanceID><xmpMM:DocumentID>H9mFVSdnUBk6Ukf7g2+74g==</xmpMM:DocumentID><xmpMM:RenditionClass>proof</xmpMM:RenditionClass><pdf:PDFVersion>1.7</pdf:PDFVersion></rdf:Description></rdf:RDF></x:xmpmeta><?xpacket end="r"?>
+<?xpacket begin="ï»¿" id="W5M0MpCehiHzreSzNTczkc9d"?><x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="xmp-writer"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/"  xmlns:xmp="http://ns.adobe.com/xap/1.0/"  xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"  xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"  xmlns:pdf="http://ns.adobe.com/pdf/1.3/" ><dc:title><rdf:Alt><rdf:li xml:lang="x-default">Technical Note: Benchmark Platform Models</rdf:li></rdf:Alt></dc:title><dc:creator><rdf:Seq><rdf:li>Ruixiang Du</rdf:li></rdf:Seq></dc:creator><xmp:CreatorTool>Typst 0.14.2</xmp:CreatorTool><dc:language><rdf:Bag><rdf:li>en</rdf:li></rdf:Bag></dc:language><xmp:ModifyDate>2026-07-10T09:12:26+08:00</xmp:ModifyDate><xmp:CreateDate>2026-07-10T09:12:26+08:00</xmp:CreateDate><xmpTPg:NPages>4</xmpTPg:NPages><dc:format>application/pdf</dc:format><xmpMM:InstanceID>whEojs4FEWcuzaT0OGBvWA==</xmpMM:InstanceID><xmpMM:DocumentID>H9mFVSdnUBk6Ukf7g2+74g==</xmpMM:DocumentID><xmpMM:RenditionClass>proof</xmpMM:RenditionClass><pdf:PDFVersion>1.7</pdf:PDFVersion></rdf:Description></rdf:RDF></x:xmpmeta><?xpacket end="r"?>
 endstream
 endobj
 
-323 0 obj
+330 0 obj
 <<
   /Type /Catalog
   /Pages 1 0 R
-  /Metadata 322 0 R
+  /Metadata 329 0 R
   /PageLabels 16 0 R
   /Lang (en)
   /StructTreeRoot 17 0 R
@@ -4294,7 +4355,7 @@ endobj
 endobj
 
 xref
-0 324
+0 331
 0000000000 65535 f
 0000000016 00000 n
 0000000106 00000 n
@@ -4314,318 +4375,325 @@ xref
 0000001799 00000 n
 0000001872 00000 n
 0000002299 00000 n
-0000003598 00000 n
-0000007697 00000 n
-0000009849 00000 n
-0000010246 00000 n
-0000010704 00000 n
-0000010865 00000 n
-0000010950 00000 n
-0000011031 00000 n
-0000011148 00000 n
-0000011349 00000 n
-0000011504 00000 n
-0000011659 00000 n
-0000011750 00000 n
-0000011829 00000 n
-0000011976 00000 n
-0000012061 00000 n
-0000012142 00000 n
-0000012262 00000 n
-0000012399 00000 n
-0000012554 00000 n
-0000012642 00000 n
-0000012721 00000 n
-0000012868 00000 n
-0000012953 00000 n
-0000013034 00000 n
-0000013151 00000 n
-0000013288 00000 n
-0000013443 00000 n
-0000013534 00000 n
-0000013613 00000 n
-0000013760 00000 n
-0000013845 00000 n
-0000013926 00000 n
-0000014040 00000 n
-0000014177 00000 n
-0000014332 00000 n
-0000014420 00000 n
-0000014499 00000 n
-0000014646 00000 n
-0000014731 00000 n
-0000014812 00000 n
-0000014929 00000 n
-0000015066 00000 n
-0000015221 00000 n
-0000015312 00000 n
-0000015391 00000 n
-0000015538 00000 n
-0000015646 00000 n
-0000015854 00000 n
-0000015946 00000 n
-0000016126 00000 n
-0000016309 00000 n
-0000016489 00000 n
-0000016581 00000 n
-0000016762 00000 n
-0000016943 00000 n
-0000017122 00000 n
-0000017214 00000 n
-0000017395 00000 n
-0000017576 00000 n
-0000017755 00000 n
-0000017847 00000 n
-0000018028 00000 n
-0000018220 00000 n
-0000018313 00000 n
-0000018494 00000 n
-0000018586 00000 n
-0000018767 00000 n
-0000018952 00000 n
-0000019133 00000 n
-0000019225 00000 n
-0000019410 00000 n
-0000019595 00000 n
-0000019776 00000 n
-0000019868 00000 n
-0000020049 00000 n
-0000020234 00000 n
-0000020415 00000 n
-0000020508 00000 n
-0000020678 00000 n
-0000020771 00000 n
-0000020942 00000 n
-0000021036 00000 n
-0000021208 00000 n
-0000021303 00000 n
-0000021421 00000 n
-0000021546 00000 n
-0000021639 00000 n
-0000021789 00000 n
-0000021906 00000 n
-0000022111 00000 n
-0000022204 00000 n
-0000022300 00000 n
-0000022440 00000 n
-0000022564 00000 n
-0000022672 00000 n
-0000022767 00000 n
-0000022959 00000 n
-0000023075 00000 n
-0000023168 00000 n
-0000023423 00000 n
-0000023662 00000 n
-0000023873 00000 n
-0000023969 00000 n
-0000024065 00000 n
-0000024185 00000 n
-0000024280 00000 n
-0000024374 00000 n
-0000024478 00000 n
-0000024573 00000 n
-0000024677 00000 n
-0000024781 00000 n
-0000024930 00000 n
-0000025052 00000 n
-0000025167 00000 n
-0000025286 00000 n
-0000025378 00000 n
-0000025497 00000 n
-0000025792 00000 n
-0000025973 00000 n
-0000026068 00000 n
-0000026176 00000 n
-0000026292 00000 n
-0000026408 00000 n
-0000026516 00000 n
-0000026656 00000 n
-0000026760 00000 n
-0000026963 00000 n
-0000027266 00000 n
-0000027479 00000 n
-0000027575 00000 n
-0000027671 00000 n
-0000027767 00000 n
-0000027871 00000 n
-0000027975 00000 n
-0000028079 00000 n
-0000028178 00000 n
-0000028274 00000 n
-0000028418 00000 n
-0000028568 00000 n
-0000028709 00000 n
-0000028834 00000 n
-0000028991 00000 n
-0000029084 00000 n
-0000029179 00000 n
-0000029299 00000 n
-0000029419 00000 n
-0000029519 00000 n
-0000029830 00000 n
-0000030023 00000 n
-0000030118 00000 n
-0000030258 00000 n
-0000030378 00000 n
-0000030498 00000 n
-0000030626 00000 n
-0000030746 00000 n
-0000030854 00000 n
-0000030962 00000 n
-0000031301 00000 n
-0000031568 00000 n
-0000031657 00000 n
-0000031984 00000 n
-0000032185 00000 n
-0000032297 00000 n
-0000032395 00000 n
-0000032490 00000 n
-0000032597 00000 n
-0000032713 00000 n
-0000032807 00000 n
-0000032950 00000 n
-0000033099 00000 n
-0000033248 00000 n
-0000033404 00000 n
-0000033553 00000 n
-0000033645 00000 n
-0000033749 00000 n
-0000033843 00000 n
-0000033953 00000 n
-0000034045 00000 n
-0000034265 00000 n
-0000034378 00000 n
-0000034498 00000 n
-0000034634 00000 n
-0000034767 00000 n
-0000034896 00000 n
-0000034989 00000 n
-0000035105 00000 n
-0000035255 00000 n
-0000035494 00000 n
-0000035615 00000 n
-0000035710 00000 n
-0000035823 00000 n
-0000035942 00000 n
-0000036071 00000 n
-0000036173 00000 n
-0000036265 00000 n
-0000036465 00000 n
-0000036575 00000 n
-0000036688 00000 n
-0000036807 00000 n
-0000036946 00000 n
-0000037063 00000 n
-0000037218 00000 n
+0000003638 00000 n
+0000007553 00000 n
+0000010038 00000 n
+0000010470 00000 n
+0000010928 00000 n
+0000011089 00000 n
+0000011174 00000 n
+0000011255 00000 n
+0000011372 00000 n
+0000011573 00000 n
+0000011728 00000 n
+0000011883 00000 n
+0000011974 00000 n
+0000012053 00000 n
+0000012200 00000 n
+0000012285 00000 n
+0000012366 00000 n
+0000012486 00000 n
+0000012623 00000 n
+0000012778 00000 n
+0000012866 00000 n
+0000012945 00000 n
+0000013092 00000 n
+0000013177 00000 n
+0000013258 00000 n
+0000013375 00000 n
+0000013512 00000 n
+0000013667 00000 n
+0000013758 00000 n
+0000013837 00000 n
+0000013984 00000 n
+0000014069 00000 n
+0000014150 00000 n
+0000014264 00000 n
+0000014401 00000 n
+0000014556 00000 n
+0000014644 00000 n
+0000014723 00000 n
+0000014870 00000 n
+0000014955 00000 n
+0000015036 00000 n
+0000015153 00000 n
+0000015290 00000 n
+0000015445 00000 n
+0000015536 00000 n
+0000015615 00000 n
+0000015762 00000 n
+0000015870 00000 n
+0000016078 00000 n
+0000016170 00000 n
+0000016350 00000 n
+0000016533 00000 n
+0000016713 00000 n
+0000016805 00000 n
+0000016988 00000 n
+0000017171 00000 n
+0000017351 00000 n
+0000017443 00000 n
+0000017624 00000 n
+0000017805 00000 n
+0000017984 00000 n
+0000018076 00000 n
+0000018255 00000 n
+0000018443 00000 n
+0000018534 00000 n
+0000018713 00000 n
+0000018805 00000 n
+0000018986 00000 n
+0000019171 00000 n
+0000019352 00000 n
+0000019444 00000 n
+0000019629 00000 n
+0000019814 00000 n
+0000019995 00000 n
+0000020087 00000 n
+0000020268 00000 n
+0000020453 00000 n
+0000020634 00000 n
+0000020727 00000 n
+0000020897 00000 n
+0000020990 00000 n
+0000021161 00000 n
+0000021255 00000 n
+0000021427 00000 n
+0000021522 00000 n
+0000021640 00000 n
+0000021765 00000 n
+0000021858 00000 n
+0000022008 00000 n
+0000022125 00000 n
+0000022330 00000 n
+0000022423 00000 n
+0000022519 00000 n
+0000022659 00000 n
+0000022783 00000 n
+0000022891 00000 n
+0000022986 00000 n
+0000023178 00000 n
+0000023294 00000 n
+0000023387 00000 n
+0000023642 00000 n
+0000023881 00000 n
+0000024102 00000 n
+0000024198 00000 n
+0000024294 00000 n
+0000024414 00000 n
+0000024510 00000 n
+0000024605 00000 n
+0000024713 00000 n
+0000024809 00000 n
+0000024917 00000 n
+0000025025 00000 n
+0000025175 00000 n
+0000025299 00000 n
+0000025416 00000 n
+0000025541 00000 n
+0000025634 00000 n
+0000025762 00000 n
+0000026067 00000 n
+0000026236 00000 n
+0000026330 00000 n
+0000026434 00000 n
+0000026544 00000 n
+0000026654 00000 n
+0000026758 00000 n
+0000026881 00000 n
+0000026979 00000 n
+0000027182 00000 n
+0000027485 00000 n
+0000027698 00000 n
+0000027794 00000 n
+0000027890 00000 n
+0000027986 00000 n
+0000028090 00000 n
+0000028194 00000 n
+0000028298 00000 n
+0000028397 00000 n
+0000028493 00000 n
+0000028637 00000 n
+0000028787 00000 n
+0000028928 00000 n
+0000029053 00000 n
+0000029210 00000 n
+0000029303 00000 n
+0000029398 00000 n
+0000029518 00000 n
+0000029638 00000 n
+0000029738 00000 n
+0000030049 00000 n
+0000030242 00000 n
+0000030337 00000 n
+0000030477 00000 n
+0000030597 00000 n
+0000030717 00000 n
+0000030845 00000 n
+0000030965 00000 n
+0000031073 00000 n
+0000031181 00000 n
+0000031520 00000 n
+0000031787 00000 n
+0000031876 00000 n
+0000032203 00000 n
+0000032410 00000 n
+0000032522 00000 n
+0000032622 00000 n
+0000032718 00000 n
+0000032830 00000 n
+0000032954 00000 n
+0000033049 00000 n
+0000033192 00000 n
+0000033341 00000 n
+0000033490 00000 n
+0000033646 00000 n
+0000033795 00000 n
+0000033887 00000 n
+0000033991 00000 n
+0000034085 00000 n
+0000034195 00000 n
+0000034287 00000 n
+0000034517 00000 n
+0000034626 00000 n
+0000034739 00000 n
+0000034857 00000 n
+0000034986 00000 n
+0000035115 00000 n
+0000035208 00000 n
+0000035324 00000 n
+0000035474 00000 n
+0000035713 00000 n
+0000035838 00000 n
+0000035934 00000 n
+0000036054 00000 n
+0000036182 00000 n
+0000036313 00000 n
+0000036418 00000 n
+0000036511 00000 n
+0000036712 00000 n
+0000036822 00000 n
+0000036935 00000 n
+0000037054 00000 n
+0000037193 00000 n
 0000037310 00000 n
-0000037402 00000 n
-0000037494 00000 n
-0000037589 00000 n
-0000037681 00000 n
-0000037792 00000 n
-0000037904 00000 n
-0000037995 00000 n
-0000038099 00000 n
-0000038180 00000 n
-0000038270 00000 n
-0000038358 00000 n
-0000038440 00000 n
-0000038522 00000 n
-0000038667 00000 n
-0000038809 00000 n
-0000038868 00000 n
-0000038927 00000 n
-0000038986 00000 n
-0000039045 00000 n
-0000039222 00000 n
-0000040198 00000 n
-0000040289 00000 n
-0000040538 00000 n
-0000042394 00000 n
-0000050797 00000 n
-0000050971 00000 n
-0000051756 00000 n
-0000051847 00000 n
-0000052093 00000 n
-0000053597 00000 n
-0000059754 00000 n
-0000059919 00000 n
-0000060187 00000 n
-0000060278 00000 n
-0000060555 00000 n
-0000061775 00000 n
-0000069795 00000 n
-0000069974 00000 n
-0000071212 00000 n
-0000071302 00000 n
-0000071556 00000 n
-0000074020 00000 n
-0000087582 00000 n
-0000087758 00000 n
-0000088331 00000 n
-0000088422 00000 n
-0000088679 00000 n
-0000089871 00000 n
-0000094326 00000 n
-0000094364 00000 n
-0000094723 00000 n
-0000094777 00000 n
-0000094831 00000 n
-0000094885 00000 n
-0000094939 00000 n
-0000094993 00000 n
-0000095047 00000 n
-0000095101 00000 n
-0000095153 00000 n
-0000095207 00000 n
-0000095260 00000 n
-0000095314 00000 n
-0000095368 00000 n
-0000095421 00000 n
-0000095474 00000 n
-0000095527 00000 n
-0000095580 00000 n
-0000095634 00000 n
-0000095687 00000 n
-0000095742 00000 n
-0000095796 00000 n
-0000095850 00000 n
-0000095902 00000 n
-0000095957 00000 n
-0000096140 00000 n
-0000096499 00000 n
-0000100990 00000 n
-0000101172 00000 n
-0000101354 00000 n
-0000101535 00000 n
-0000101910 00000 n
-0000111613 00000 n
-0000111794 00000 n
-0000111977 00000 n
-0000112344 00000 n
-0000118588 00000 n
-0000118768 00000 n
-0000119067 00000 n
-0000119248 00000 n
-0000119547 00000 n
-0000119729 00000 n
-0000120030 00000 n
-0000120212 00000 n
-0000120513 00000 n
-0000120695 00000 n
-0000120996 00000 n
-0000121297 00000 n
-0000121719 00000 n
-0000124706 00000 n
-0000124910 00000 n
-0000126188 00000 n
+0000037548 00000 n
+0000037640 00000 n
+0000037750 00000 n
+0000037866 00000 n
+0000037958 00000 n
+0000038050 00000 n
+0000038142 00000 n
+0000038234 00000 n
+0000038326 00000 n
+0000038418 00000 n
+0000038510 00000 n
+0000038605 00000 n
+0000038697 00000 n
+0000038808 00000 n
+0000038920 00000 n
+0000039011 00000 n
+0000039115 00000 n
+0000039196 00000 n
+0000039286 00000 n
+0000039374 00000 n
+0000039456 00000 n
+0000039538 00000 n
+0000039683 00000 n
+0000039825 00000 n
+0000039884 00000 n
+0000039943 00000 n
+0000040002 00000 n
+0000040061 00000 n
+0000040238 00000 n
+0000041214 00000 n
+0000041305 00000 n
+0000041554 00000 n
+0000043410 00000 n
+0000051813 00000 n
+0000051987 00000 n
+0000052772 00000 n
+0000052863 00000 n
+0000053109 00000 n
+0000054613 00000 n
+0000060770 00000 n
+0000060935 00000 n
+0000061203 00000 n
+0000061295 00000 n
+0000061572 00000 n
+0000062834 00000 n
+0000071133 00000 n
+0000071312 00000 n
+0000072596 00000 n
+0000072687 00000 n
+0000072941 00000 n
+0000075459 00000 n
+0000089448 00000 n
+0000089624 00000 n
+0000090197 00000 n
+0000090288 00000 n
+0000090545 00000 n
+0000091737 00000 n
+0000096192 00000 n
+0000096230 00000 n
+0000096589 00000 n
+0000096643 00000 n
+0000096697 00000 n
+0000096751 00000 n
+0000096804 00000 n
+0000096858 00000 n
+0000096912 00000 n
+0000096966 00000 n
+0000097019 00000 n
+0000097073 00000 n
+0000097126 00000 n
+0000097180 00000 n
+0000097234 00000 n
+0000097288 00000 n
+0000097342 00000 n
+0000097396 00000 n
+0000097449 00000 n
+0000097503 00000 n
+0000097557 00000 n
+0000097612 00000 n
+0000097667 00000 n
+0000097721 00000 n
+0000097776 00000 n
+0000097830 00000 n
+0000098013 00000 n
+0000098372 00000 n
+0000103278 00000 n
+0000103459 00000 n
+0000103640 00000 n
+0000103821 00000 n
+0000104196 00000 n
+0000113453 00000 n
+0000113634 00000 n
+0000113816 00000 n
+0000114183 00000 n
+0000121066 00000 n
+0000121245 00000 n
+0000121545 00000 n
+0000121726 00000 n
+0000122025 00000 n
+0000122206 00000 n
+0000122508 00000 n
+0000122690 00000 n
+0000122992 00000 n
+0000123174 00000 n
+0000123475 00000 n
+0000123776 00000 n
+0000124198 00000 n
+0000127376 00000 n
+0000127580 00000 n
+0000128858 00000 n
 trailer
 <<
-  /Size 324
-  /Root 323 0 R
-  /Info 321 0 R
-  /ID [(H9mFVSdnUBk6Ukf7g2+74g==) (gnRXeNQntaXosNCFMIc+kQ==)]
+  /Size 331
+  /Root 330 0 R
+  /Info 328 0 R
+  /ID [(H9mFVSdnUBk6Ukf7g2+74g==) (whEojs4FEWcuzaT0OGBvWA==)]
 >>
 startxref
-126447
+129117
 %%EOF

--- a/docs/typst/models.pdf
+++ b/docs/typst/models.pdf
@@ -1,0 +1,4631 @@
+%PDF-1.7
+%€€€€
+
+1 0 obj
+<<
+  /Type /Pages
+  /Count 4
+  /Kids [297 0 R 302 0 R 306 0 R 319 0 R]
+>>
+endobj
+
+2 0 obj
+<<
+  /Type /Outlines
+  /First 3 0 R
+  /Last 15 0 R
+  /Count 7
+>>
+endobj
+
+3 0 obj
+<<
+  /Parent 2 0 R
+  /Next 4 0 R
+  /Title (1 Conventions)
+  /Dest 273 0 R
+>>
+endobj
+
+4 0 obj
+<<
+  /Parent 2 0 R
+  /Next 9 0 R
+  /Prev 3 0 R
+  /First 5 0 R
+  /Last 8 0 R
+  /Count -4
+  /Title (2 Wheeled platforms)
+  /Dest 278 0 R
+>>
+endobj
+
+5 0 obj
+<<
+  /Parent 4 0 R
+  /Next 6 0 R
+  /Title (2.1 Differential drive (kinematic unicycle))
+  /Dest 274 0 R
+>>
+endobj
+
+6 0 obj
+<<
+  /Parent 4 0 R
+  /Next 7 0 R
+  /Prev 5 0 R
+  /Title (2.2 Kinematic bicycle (Ackermann))
+  /Dest 275 0 R
+>>
+endobj
+
+7 0 obj
+<<
+  /Parent 4 0 R
+  /Next 8 0 R
+  /Prev 6 0 R
+  /Title (2.3 Bicycle with acceleration input)
+  /Dest 276 0 R
+>>
+endobj
+
+8 0 obj
+<<
+  /Parent 4 0 R
+  /Prev 7 0 R
+  /Title (2.4 Single-track model with linear tires ("dynamic bicycle"))
+  /Dest 277 0 R
+>>
+endobj
+
+9 0 obj
+<<
+  /Parent 2 0 R
+  /Next 11 0 R
+  /Prev 4 0 R
+  /First 10 0 R
+  /Last 10 0 R
+  /Count -1
+  /Title (3 Underactuated benchmark)
+  /Dest 280 0 R
+>>
+endobj
+
+10 0 obj
+<<
+  /Parent 9 0 R
+  /Title (3.1 Cart-pole (inverted pendulum on a cart))
+  /Dest 279 0 R
+>>
+endobj
+
+11 0 obj
+<<
+  /Parent 2 0 R
+  /Next 13 0 R
+  /Prev 9 0 R
+  /First 12 0 R
+  /Last 12 0 R
+  /Count -1
+  /Title (4 Aerial platform)
+  /Dest 282 0 R
+>>
+endobj
+
+12 0 obj
+<<
+  /Parent 11 0 R
+  /Title (4.1 Quadrotor (rigid body))
+  /Dest 281 0 R
+>>
+endobj
+
+13 0 obj
+<<
+  /Parent 2 0 R
+  /Next 14 0 R
+  /Prev 11 0 R
+  /Title (5 Legged platform)
+  /Dest 283 0 R
+>>
+endobj
+
+14 0 obj
+<<
+  /Parent 2 0 R
+  /Next 15 0 R
+  /Prev 13 0 R
+  /Title (6 Choosing a model)
+  /Dest 284 0 R
+>>
+endobj
+
+15 0 obj
+<<
+  /Parent 2 0 R
+  /Prev 14 0 R
+  /Title (Bibliography)
+  /Dest 285 0 R
+>>
+endobj
+
+16 0 obj
+<<
+  /Nums [0 237 0 R 1 238 0 R 2 239 0 R 3 240 0 R]
+>>
+endobj
+
+17 0 obj
+<<
+  /Type /StructTreeRoot
+  /RoleMap <<
+    /Datetime /Span
+    /Terms /Part
+    /Title /P
+    /Strong /Span
+    /Em /Span
+  >>
+  /K [22 0 R]
+  /ParentTree <<
+    /Nums [0 205 0 R 1 18 0 R 2 189 0 R 3 188 0 R 4 157 0 R 5 19 0 R 6 130 0 R 7 106 0 R 8 20 0 R 9 64 0 R 10 60 0 R 11 56 0 R 12 52 0 R 13 48 0 R 14 44 0 R 15 40 0 R 16 36 0 R 17 32 0 R 18 27 0 R 19 27 0 R 20 21 0 R]
+  >>
+  /ParentTreeNextKey 21
+>>
+endobj
+
+18 0 obj
+[236 0 R 235 0 R 232 0 R 229 0 R 227 0 R 228 0 R 227 0 R 227 0 R 227 0 R 227 0 R 227 0 R 227 0 R 227 0 R 226 0 R 226 0 R 220 0 R 225 0 R 220 0 R 224 0 R 224 0 R 220 0 R 220 0 R 223 0 R 220 0 R 222 0 R 220 0 R 220 0 R 221 0 R 220 0 R 220 0 R 220 0 R 219 0 R 219 0 R 218 0 R 218 0 R 215 0 R 217 0 R 217 0 R 217 0 R 217 0 R 217 0 R 217 0 R 217 0 R 217 0 R 217 0 R 215 0 R 216 0 R 216 0 R 216 0 R 216 0 R 216 0 R 216 0 R 216 0 R 215 0 R 214 0 R 214 0 R 214 0 R 214 0 R 214 0 R 214 0 R 214 0 R 214 0 R 214 0 R 214 0 R 214 0 R 214 0 R 214 0 R 214 0 R 214 0 R 214 0 R 214 0 R 214 0 R 214 0 R 212 0 R 212 0 R 213 0 R 212 0 R 211 0 R 211 0 R 207 0 R 210 0 R 210 0 R 210 0 R 210 0 R 210 0 R 210 0 R 210 0 R 210 0 R 210 0 R 207 0 R 209 0 R 209 0 R 209 0 R 209 0 R 209 0 R 209 0 R 209 0 R 207 0 R 208 0 R 207 0 R 206 0 R 206 0 R 206 0 R 206 0 R 206 0 R 206 0 R 206 0 R 206 0 R 206 0 R 206 0 R 206 0 R 206 0 R 206 0 R 206 0 R 206 0 R 206 0 R 206 0 R 206 0 R 206 0 R 206 0 R 206 0 R 206 0 R 206 0 R 206 0 R 202 0 R 205 0 R 202 0 R 204 0 R 204 0 R 204 0 R 204 0 R 204 0 R 204 0 R 202 0 R 202 0 R 203 0 R 202 0 R 201 0 R 201 0 R 198 0 R 200 0 R 200 0 R 200 0 R 200 0 R 200 0 R 200 0 R 200 0 R 200 0 R 200 0 R 200 0 R 200 0 R 198 0 R 199 0 R 199 0 R 199 0 R 199 0 R 199 0 R 199 0 R 199 0 R 198 0 R]
+endobj
+
+19 0 obj
+[197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 197 0 R 191 0 R 196 0 R 191 0 R 195 0 R 195 0 R 195 0 R 195 0 R 195 0 R 195 0 R 191 0 R 191 0 R 194 0 R 191 0 R 191 0 R 193 0 R 193 0 R 193 0 R 193 0 R 191 0 R 192 0 R 191 0 R 190 0 R 190 0 R 180 0 R 189 0 R 180 0 R 180 0 R 188 0 R 180 0 R 187 0 R 187 0 R 187 0 R 187 0 R 187 0 R 187 0 R 187 0 R 187 0 R 187 0 R 187 0 R 187 0 R 187 0 R 187 0 R 187 0 R 187 0 R 187 0 R 187 0 R 180 0 R 180 0 R 186 0 R 180 0 R 185 0 R 185 0 R 185 0 R 185 0 R 185 0 R 185 0 R 185 0 R 185 0 R 180 0 R 180 0 R 184 0 R 184 0 R 184 0 R 184 0 R 184 0 R 180 0 R 183 0 R 180 0 R 182 0 R 182 0 R 180 0 R 180 0 R 181 0 R 181 0 R 181 0 R 181 0 R 181 0 R 180 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 179 0 R 178 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 177 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 176 0 R 167 0 R 175 0 R 175 0 R 175 0 R 175 0 R 167 0 R 167 0 R 174 0 R 174 0 R 174 0 R 174 0 R 167 0 R 173 0 R 173 0 R 173 0 R 173 0 R 173 0 R 173 0 R 173 0 R 167 0 R 172 0 R 172 0 R 172 0 R 172 0 R 172 0 R 172 0 R 172 0 R 172 0 R 172 0 R 167 0 R 171 0 R 171 0 R 171 0 R 171 0 R 171 0 R 171 0 R 171 0 R 167 0 R 170 0 R 170 0 R 170 0 R 170 0 R 170 0 R 170 0 R 170 0 R 167 0 R 169 0 R 169 0 R 169 0 R 169 0 R 169 0 R 169 0 R 169 0 R 169 0 R 169 0 R 169 0 R 169 0 R 169 0 R 167 0 R 168 0 R 167 0 R 167 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 166 0 R 160 0 R 165 0 R 165 0 R 160 0 R 164 0 R 164 0 R 164 0 R 164 0 R 164 0 R 164 0 R 164 0 R 160 0 R 160 0 R 163 0 R 163 0 R 163 0 R 163 0 R 163 0 R 163 0 R 163 0 R 160 0 R 162 0 R 160 0 R 160 0 R 161 0 R 160 0 R 159 0 R 159 0 R 158 0 R 158 0 R 147 0 R 157 0 R 147 0 R 156 0 R 156 0 R 156 0 R 156 0 R 156 0 R 156 0 R 156 0 R 156 0 R 156 0 R 156 0 R 156 0 R 156 0 R 156 0 R 147 0 R 155 0 R 147 0 R 154 0 R 154 0 R 147 0 R 153 0 R 153 0 R 153 0 R 147 0 R 152 0 R 152 0 R 152 0 R 147 0 R 151 0 R 151 0 R 151 0 R 147 0 R 147 0 R 150 0 R 147 0 R 149 0 R 147 0 R 148 0 R 147 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 146 0 R 145 0 R 145 0 R 145 0 R 145 0 R 145 0 R 145 0 R 145 0 R 145 0 R 145 0 R 145 0 R 145 0 R 145 0 R 145 0 R 145 0 R 145 0 R 137 0 R 144 0 R 144 0 R 144 0 R 137 0 R 143 0 R 143 0 R 143 0 R 143 0 R 143 0 R 143 0 R 143 0 R 143 0 R 143 0 R 143 0 R 143 0 R 143 0 R 137 0 R 137 0 R 142 0 R 142 0 R 142 0 R 142 0 R 137 0 R 141 0 R 141 0 R 141 0 R 141 0 R 141 0 R 141 0 R 137 0 R 140 0 R 140 0 R 140 0 R 140 0 R 140 0 R 140 0 R 137 0 R 139 0 R 139 0 R 139 0 R 139 0 R 137 0 R 138 0 R 137 0 R 137 0 R]
+endobj
+
+20 0 obj
+[136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 136 0 R 133 0 R 135 0 R 135 0 R 135 0 R 135 0 R 135 0 R 135 0 R 135 0 R 135 0 R 135 0 R 133 0 R 133 0 R 133 0 R 133 0 R 134 0 R 133 0 R 132 0 R 132 0 R 131 0 R 131 0 R 120 0 R 130 0 R 120 0 R 129 0 R 129 0 R 129 0 R 129 0 R 120 0 R 128 0 R 128 0 R 128 0 R 128 0 R 120 0 R 127 0 R 120 0 R 126 0 R 126 0 R 126 0 R 126 0 R 120 0 R 125 0 R 120 0 R 120 0 R 124 0 R 120 0 R 120 0 R 123 0 R 123 0 R 123 0 R 123 0 R 123 0 R 123 0 R 123 0 R 120 0 R 122 0 R 120 0 R 120 0 R 121 0 R 120 0 R 119 0 R 119 0 R 119 0 R 119 0 R 119 0 R 119 0 R 119 0 R 119 0 R 119 0 R 119 0 R 119 0 R 119 0 R 119 0 R 119 0 R 119 0 R 119 0 R 119 0 R 119 0 R 119 0 R 119 0 R 119 0 R 119 0 R 119 0 R 119 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 118 0 R 117 0 R 108 0 R 108 0 R 116 0 R 116 0 R 116 0 R 116 0 R 116 0 R 116 0 R 108 0 R 115 0 R 115 0 R 115 0 R 115 0 R 115 0 R 115 0 R 115 0 R 115 0 R 115 0 R 115 0 R 115 0 R 115 0 R 115 0 R 115 0 R 115 0 R 115 0 R 115 0 R 115 0 R 115 0 R 115 0 R 115 0 R 115 0 R 115 0 R 115 0 R 115 0 R 108 0 R 114 0 R 108 0 R 113 0 R 113 0 R 113 0 R 113 0 R 108 0 R 108 0 R 112 0 R 112 0 R 112 0 R 112 0 R 112 0 R 112 0 R 112 0 R 112 0 R 108 0 R 111 0 R 111 0 R 111 0 R 111 0 R 111 0 R 111 0 R 111 0 R 111 0 R 111 0 R 111 0 R 111 0 R 111 0 R 108 0 R 110 0 R 108 0 R 108 0 R 109 0 R 108 0 R 107 0 R 107 0 R 104 0 R 104 0 R 104 0 R 104 0 R 106 0 R 104 0 R 105 0 R 104 0 R 103 0 R 103 0 R 102 0 R 100 0 R 98 0 R 95 0 R 94 0 R 94 0 R 93 0 R 91 0 R 90 0 R 90 0 R 89 0 R 89 0 R 87 0 R 86 0 R 86 0 R 85 0 R 83 0 R 82 0 R 81 0 R 81 0 R 80 0 R]
+endobj
+
+21 0 obj
+[78 0 R 77 0 R 77 0 R 76 0 R 76 0 R 74 0 R 73 0 R 73 0 R 72 0 R 72 0 R 70 0 R 69 0 R 69 0 R 68 0 R 65 0 R 64 0 R 59 0 R 59 0 R 62 0 R 62 0 R 59 0 R 61 0 R 59 0 R 56 0 R 51 0 R 54 0 R 51 0 R 53 0 R 51 0 R 48 0 R 43 0 R 43 0 R 46 0 R 46 0 R 43 0 R 45 0 R 43 0 R 40 0 R 35 0 R 35 0 R 38 0 R 35 0 R 35 0 R 37 0 R 35 0 R 32 0 R 26 0 R 26 0 R 30 0 R 30 0 R 26 0 R 29 0 R 28 0 R 26 0 R]
+endobj
+
+22 0 obj
+<<
+  /Type /StructElem
+  /S /Document
+  /P 17 0 R
+  /K [236 0 R 230 0 R 229 0 R 227 0 R 226 0 R 220 0 R 219 0 R 218 0 R 215 0 R 214 0 R 212 0 R 211 0 R 207 0 R 206 0 R 202 0 R 201 0 R 198 0 R 197 0 R 191 0 R 190 0 R 180 0 R 179 0 R 178 0 R 177 0 R 176 0 R 167 0 R 166 0 R 160 0 R 159 0 R 158 0 R 147 0 R 146 0 R 145 0 R 137 0 R 136 0 R 133 0 R 132 0 R 131 0 R 120 0 R 119 0 R 118 0 R 108 0 R 107 0 R 104 0 R 103 0 R 66 0 R 65 0 R 23 0 R]
+>>
+endobj
+
+23 0 obj
+<<
+  /Type /StructElem
+  /S /L
+  /P 22 0 R
+  /A [<<
+    /O /List
+    /ListNumbering /Decimal
+  >>]
+  /K [57 0 R 49 0 R 41 0 R 33 0 R 24 0 R]
+>>
+endobj
+
+24 0 obj
+<<
+  /Type /StructElem
+  /S /LI
+  /P 23 0 R
+  /K [31 0 R 25 0 R]
+>>
+endobj
+
+25 0 obj
+<<
+  /Type /StructElem
+  /S /LBody
+  /P 24 0 R
+  /K [26 0 R]
+>>
+endobj
+
+26 0 obj
+<<
+  /Type /StructElem
+  /S /BibEntry
+  /P 25 0 R
+  /K [46 47 30 0 R 50 27 0 R 53]
+  /Pg 319 0 R
+>>
+endobj
+
+27 0 obj
+<<
+  /Type /StructElem
+  /S /Link
+  /P 26 0 R
+  /K [29 0 R <<
+    /Type /OBJR
+    /Pg 319 0 R
+    /Obj 317 0 R
+  >> 28 0 R <<
+    /Type /OBJR
+    /Pg 319 0 R
+    /Obj 318 0 R
+  >>]
+>>
+endobj
+
+28 0 obj
+<<
+  /Type /StructElem
+  /S /Span
+  /P 27 0 R
+  /A [<<
+    /O /Layout
+    /TextDecorationType /Underline
+  >>]
+  /K [52]
+  /Pg 319 0 R
+>>
+endobj
+
+29 0 obj
+<<
+  /Type /StructElem
+  /S /Span
+  /P 27 0 R
+  /A [<<
+    /O /Layout
+    /TextDecorationType /Underline
+  >>]
+  /K [51]
+  /Pg 319 0 R
+>>
+endobj
+
+30 0 obj
+<<
+  /Type /StructElem
+  /S /Em
+  /P 26 0 R
+  /K [48 49]
+  /Pg 319 0 R
+>>
+endobj
+
+31 0 obj
+<<
+  /Type /StructElem
+  /S /Lbl
+  /P 24 0 R
+  /K [32 0 R]
+>>
+endobj
+
+32 0 obj
+<<
+  /Type /StructElem
+  /S /Link
+  /P 31 0 R
+  /K [45 <<
+    /Type /OBJR
+    /Pg 319 0 R
+    /Obj 316 0 R
+  >>]
+  /Pg 319 0 R
+>>
+endobj
+
+33 0 obj
+<<
+  /Type /StructElem
+  /S /LI
+  /P 23 0 R
+  /K [39 0 R 34 0 R]
+>>
+endobj
+
+34 0 obj
+<<
+  /Type /StructElem
+  /S /LBody
+  /P 33 0 R
+  /K [35 0 R]
+>>
+endobj
+
+35 0 obj
+<<
+  /Type /StructElem
+  /S /BibEntry
+  /P 34 0 R
+  /K [38 39 38 0 R 41 42 36 0 R 44]
+  /Pg 319 0 R
+>>
+endobj
+
+36 0 obj
+<<
+  /Type /StructElem
+  /S /Link
+  /P 35 0 R
+  /K [37 0 R <<
+    /Type /OBJR
+    /Pg 319 0 R
+    /Obj 315 0 R
+  >>]
+>>
+endobj
+
+37 0 obj
+<<
+  /Type /StructElem
+  /S /Span
+  /P 36 0 R
+  /A [<<
+    /O /Layout
+    /TextDecorationType /Underline
+  >>]
+  /K [43]
+  /Pg 319 0 R
+>>
+endobj
+
+38 0 obj
+<<
+  /Type /StructElem
+  /S /Em
+  /P 35 0 R
+  /K [40]
+  /Pg 319 0 R
+>>
+endobj
+
+39 0 obj
+<<
+  /Type /StructElem
+  /S /Lbl
+  /P 33 0 R
+  /K [40 0 R]
+>>
+endobj
+
+40 0 obj
+<<
+  /Type /StructElem
+  /S /Link
+  /P 39 0 R
+  /K [37 <<
+    /Type /OBJR
+    /Pg 319 0 R
+    /Obj 314 0 R
+  >>]
+  /Pg 319 0 R
+>>
+endobj
+
+41 0 obj
+<<
+  /Type /StructElem
+  /S /LI
+  /P 23 0 R
+  /K [47 0 R 42 0 R]
+>>
+endobj
+
+42 0 obj
+<<
+  /Type /StructElem
+  /S /LBody
+  /P 41 0 R
+  /K [43 0 R]
+>>
+endobj
+
+43 0 obj
+<<
+  /Type /StructElem
+  /S /BibEntry
+  /P 42 0 R
+  /K [30 31 46 0 R 34 44 0 R 36]
+  /Pg 319 0 R
+>>
+endobj
+
+44 0 obj
+<<
+  /Type /StructElem
+  /S /Link
+  /P 43 0 R
+  /K [45 0 R <<
+    /Type /OBJR
+    /Pg 319 0 R
+    /Obj 313 0 R
+  >>]
+>>
+endobj
+
+45 0 obj
+<<
+  /Type /StructElem
+  /S /Span
+  /P 44 0 R
+  /A [<<
+    /O /Layout
+    /TextDecorationType /Underline
+  >>]
+  /K [35]
+  /Pg 319 0 R
+>>
+endobj
+
+46 0 obj
+<<
+  /Type /StructElem
+  /S /Em
+  /P 43 0 R
+  /K [32 33]
+  /Pg 319 0 R
+>>
+endobj
+
+47 0 obj
+<<
+  /Type /StructElem
+  /S /Lbl
+  /P 41 0 R
+  /K [48 0 R]
+>>
+endobj
+
+48 0 obj
+<<
+  /Type /StructElem
+  /S /Link
+  /P 47 0 R
+  /K [29 <<
+    /Type /OBJR
+    /Pg 319 0 R
+    /Obj 312 0 R
+  >>]
+  /Pg 319 0 R
+>>
+endobj
+
+49 0 obj
+<<
+  /Type /StructElem
+  /S /LI
+  /P 23 0 R
+  /K [55 0 R 50 0 R]
+>>
+endobj
+
+50 0 obj
+<<
+  /Type /StructElem
+  /S /LBody
+  /P 49 0 R
+  /K [51 0 R]
+>>
+endobj
+
+51 0 obj
+<<
+  /Type /StructElem
+  /S /BibEntry
+  /P 50 0 R
+  /K [24 54 0 R 26 52 0 R 28]
+  /Pg 319 0 R
+>>
+endobj
+
+52 0 obj
+<<
+  /Type /StructElem
+  /S /Link
+  /P 51 0 R
+  /K [53 0 R <<
+    /Type /OBJR
+    /Pg 319 0 R
+    /Obj 311 0 R
+  >>]
+>>
+endobj
+
+53 0 obj
+<<
+  /Type /StructElem
+  /S /Span
+  /P 52 0 R
+  /A [<<
+    /O /Layout
+    /TextDecorationType /Underline
+  >>]
+  /K [27]
+  /Pg 319 0 R
+>>
+endobj
+
+54 0 obj
+<<
+  /Type /StructElem
+  /S /Em
+  /P 51 0 R
+  /K [25]
+  /Pg 319 0 R
+>>
+endobj
+
+55 0 obj
+<<
+  /Type /StructElem
+  /S /Lbl
+  /P 49 0 R
+  /K [56 0 R]
+>>
+endobj
+
+56 0 obj
+<<
+  /Type /StructElem
+  /S /Link
+  /P 55 0 R
+  /K [23 <<
+    /Type /OBJR
+    /Pg 319 0 R
+    /Obj 310 0 R
+  >>]
+  /Pg 319 0 R
+>>
+endobj
+
+57 0 obj
+<<
+  /Type /StructElem
+  /S /LI
+  /P 23 0 R
+  /K [63 0 R 58 0 R]
+>>
+endobj
+
+58 0 obj
+<<
+  /Type /StructElem
+  /S /LBody
+  /P 57 0 R
+  /K [59 0 R]
+>>
+endobj
+
+59 0 obj
+<<
+  /Type /StructElem
+  /S /BibEntry
+  /P 58 0 R
+  /K [16 17 62 0 R 20 60 0 R 22]
+  /Pg 319 0 R
+>>
+endobj
+
+60 0 obj
+<<
+  /Type /StructElem
+  /S /Link
+  /P 59 0 R
+  /K [61 0 R <<
+    /Type /OBJR
+    /Pg 319 0 R
+    /Obj 309 0 R
+  >>]
+>>
+endobj
+
+61 0 obj
+<<
+  /Type /StructElem
+  /S /Span
+  /P 60 0 R
+  /A [<<
+    /O /Layout
+    /TextDecorationType /Underline
+  >>]
+  /K [21]
+  /Pg 319 0 R
+>>
+endobj
+
+62 0 obj
+<<
+  /Type /StructElem
+  /S /Em
+  /P 59 0 R
+  /K [18 19]
+  /Pg 319 0 R
+>>
+endobj
+
+63 0 obj
+<<
+  /Type /StructElem
+  /S /Lbl
+  /P 57 0 R
+  /K [64 0 R]
+>>
+endobj
+
+64 0 obj
+<<
+  /Type /StructElem
+  /S /Link
+  /P 63 0 R
+  /K [15 <<
+    /Type /OBJR
+    /Pg 319 0 R
+    /Obj 308 0 R
+  >>]
+  /Pg 319 0 R
+>>
+endobj
+
+65 0 obj
+<<
+  /Type /StructElem
+  /S /H1
+  /P 22 0 R
+  /T (Bibliography)
+  /K [14]
+  /Pg 319 0 R
+>>
+endobj
+
+66 0 obj
+<<
+  /Type /StructElem
+  /S /Table
+  /P 22 0 R
+  /A [<<
+    /O /Layout
+    /BorderColor [0 0 0]
+    /BorderThickness 1
+  >>]
+  /K [96 0 R 92 0 R 88 0 R 84 0 R 79 0 R 75 0 R 71 0 R 67 0 R]
+>>
+endobj
+
+67 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 66 0 R
+  /K [70 0 R 69 0 R 68 0 R]
+>>
+endobj
+
+68 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 67 0 R
+  /A [<<
+    /O /Table
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [13]
+  /Pg 319 0 R
+>>
+endobj
+
+69 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 67 0 R
+  /A [<<
+    /O /Table
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [11 12]
+  /Pg 319 0 R
+>>
+endobj
+
+70 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 67 0 R
+  /A [<<
+    /O /Table
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [10]
+  /Pg 319 0 R
+>>
+endobj
+
+71 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 66 0 R
+  /K [74 0 R 73 0 R 72 0 R]
+>>
+endobj
+
+72 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 71 0 R
+  /A [<<
+    /O /Table
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [8 9]
+  /Pg 319 0 R
+>>
+endobj
+
+73 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 71 0 R
+  /A [<<
+    /O /Table
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [6 7]
+  /Pg 319 0 R
+>>
+endobj
+
+74 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 71 0 R
+  /A [<<
+    /O /Table
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [5]
+  /Pg 319 0 R
+>>
+endobj
+
+75 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 66 0 R
+  /K [78 0 R 77 0 R 76 0 R]
+>>
+endobj
+
+76 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 75 0 R
+  /A [<<
+    /O /Table
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [3 4]
+  /Pg 319 0 R
+>>
+endobj
+
+77 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 75 0 R
+  /A [<<
+    /O /Table
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [1 2]
+  /Pg 319 0 R
+>>
+endobj
+
+78 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 75 0 R
+  /A [<<
+    /O /Table
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [0]
+  /Pg 319 0 R
+>>
+endobj
+
+79 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 66 0 R
+  /K [83 0 R 81 0 R 80 0 R]
+>>
+endobj
+
+80 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 79 0 R
+  /A [<<
+    /O /Table
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [268]
+  /Pg 306 0 R
+>>
+endobj
+
+81 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 79 0 R
+  /A [<<
+    /O /Table
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [82 0 R 266 267]
+  /Pg 306 0 R
+>>
+endobj
+
+82 0 obj
+<<
+  /Type /StructElem
+  /S /Strong
+  /P 81 0 R
+  /K [265]
+  /Pg 306 0 R
+>>
+endobj
+
+83 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 79 0 R
+  /A [<<
+    /O /Table
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [264]
+  /Pg 306 0 R
+>>
+endobj
+
+84 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 66 0 R
+  /K [87 0 R 86 0 R 85 0 R]
+>>
+endobj
+
+85 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 84 0 R
+  /A [<<
+    /O /Table
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [263]
+  /Pg 306 0 R
+>>
+endobj
+
+86 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 84 0 R
+  /A [<<
+    /O /Table
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [261 262]
+  /Pg 306 0 R
+>>
+endobj
+
+87 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 84 0 R
+  /A [<<
+    /O /Table
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [260]
+  /Pg 306 0 R
+>>
+endobj
+
+88 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 66 0 R
+  /K [91 0 R 90 0 R 89 0 R]
+>>
+endobj
+
+89 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 88 0 R
+  /A [<<
+    /O /Table
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [258 259]
+  /Pg 306 0 R
+>>
+endobj
+
+90 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 88 0 R
+  /A [<<
+    /O /Table
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [256 257]
+  /Pg 306 0 R
+>>
+endobj
+
+91 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 88 0 R
+  /A [<<
+    /O /Table
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [255]
+  /Pg 306 0 R
+>>
+endobj
+
+92 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 66 0 R
+  /K [95 0 R 94 0 R 93 0 R]
+>>
+endobj
+
+93 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 92 0 R
+  /A [<<
+    /O /Table
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [254]
+  /Pg 306 0 R
+>>
+endobj
+
+94 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 92 0 R
+  /A [<<
+    /O /Table
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [252 253]
+  /Pg 306 0 R
+>>
+endobj
+
+95 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 92 0 R
+  /A [<<
+    /O /Table
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [251]
+  /Pg 306 0 R
+>>
+endobj
+
+96 0 obj
+<<
+  /Type /StructElem
+  /S /TR
+  /P 66 0 R
+  /K [101 0 R 99 0 R 97 0 R]
+>>
+endobj
+
+97 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 96 0 R
+  /A [<<
+    /O /Table
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [98 0 R]
+>>
+endobj
+
+98 0 obj
+<<
+  /Type /StructElem
+  /S /Strong
+  /P 97 0 R
+  /K [250]
+  /Pg 306 0 R
+>>
+endobj
+
+99 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 96 0 R
+  /A [<<
+    /O /Table
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [100 0 R]
+>>
+endobj
+
+100 0 obj
+<<
+  /Type /StructElem
+  /S /Strong
+  /P 99 0 R
+  /K [249]
+  /Pg 306 0 R
+>>
+endobj
+
+101 0 obj
+<<
+  /Type /StructElem
+  /S /TD
+  /P 96 0 R
+  /A [<<
+    /O /Table
+    /Headers []
+  >> <<
+    /O /Layout
+    /BorderStyle /Solid
+  >>]
+  /K [102 0 R]
+>>
+endobj
+
+102 0 obj
+<<
+  /Type /StructElem
+  /S /Strong
+  /P 101 0 R
+  /K [248]
+  /Pg 306 0 R
+>>
+endobj
+
+103 0 obj
+<<
+  /Type /StructElem
+  /S /H1
+  /P 22 0 R
+  /T (Choosing a model)
+  /K [246 247]
+  /Pg 306 0 R
+>>
+endobj
+
+104 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 22 0 R
+  /K [238 239 240 241 106 0 R 243 105 0 R 245]
+  /Pg 306 0 R
+>>
+endobj
+
+105 0 obj
+<<
+  /Type /StructElem
+  /S /Code
+  /P 104 0 R
+  /K [244]
+  /Pg 306 0 R
+>>
+endobj
+
+106 0 obj
+<<
+  /Type /StructElem
+  /S /Link
+  /P 104 0 R
+  /K [242 <<
+    /Type /OBJR
+    /Pg 306 0 R
+    /Obj 305 0 R
+  >>]
+  /Pg 306 0 R
+>>
+endobj
+
+107 0 obj
+<<
+  /Type /StructElem
+  /S /H1
+  /P 22 0 R
+  /T (Legged platform)
+  /K [236 237]
+  /Pg 306 0 R
+>>
+endobj
+
+108 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 22 0 R
+  /K [117 0 R 166 167 116 0 R 174 115 0 R 200 114 0 R 202 113 0 R 207 208 112 0 R 217 111 0 R 230 110 0 R 232 233 109 0 R 235]
+  /Pg 306 0 R
+>>
+endobj
+
+109 0 obj
+<<
+  /Type /StructElem
+  /S /Code
+  /P 108 0 R
+  /K [234]
+  /Pg 306 0 R
+>>
+endobj
+
+110 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 108 0 R
+  /K [231]
+  /Pg 306 0 R
+>>
+endobj
+
+111 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 108 0 R
+  /K [218 219 220 221 222 223 224 225 226 227 228 229]
+  /Pg 306 0 R
+>>
+endobj
+
+112 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 108 0 R
+  /K [209 210 211 212 213 214 215 216]
+  /Pg 306 0 R
+>>
+endobj
+
+113 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 108 0 R
+  /K [203 204 205 206]
+  /Pg 306 0 R
+>>
+endobj
+
+114 0 obj
+<<
+  /Type /StructElem
+  /S /Strong
+  /P 108 0 R
+  /K [201]
+  /Pg 306 0 R
+>>
+endobj
+
+115 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 108 0 R
+  /K [175 176 177 178 179 180 181 182 183 184 185 186 187 188 189 190 191 192 193 194 195 196 197 198 199]
+  /Pg 306 0 R
+>>
+endobj
+
+116 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 108 0 R
+  /K [168 169 170 171 172 173]
+  /Pg 306 0 R
+>>
+endobj
+
+117 0 obj
+<<
+  /Type /StructElem
+  /S /Code
+  /P 108 0 R
+  /K [165]
+  /Pg 306 0 R
+>>
+endobj
+
+118 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 22 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [137 138 139 140 141 142 143 144 145 146 147 148 149 150 151 152 153 154 155 156 157 158 159 160 161 162 163 164]
+  /Pg 306 0 R
+>>
+endobj
+
+119 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 22 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [113 114 115 116 117 118 119 120 121 122 123 124 125 126 127 128 129 130 131 132 133 134 135 136]
+  /Pg 306 0 R
+>>
+endobj
+
+120 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 22 0 R
+  /K [74 130 0 R 76 129 0 R 81 128 0 R 86 127 0 R 88 126 0 R 93 125 0 R 95 96 124 0 R 98 99 123 0 R 107 122 0 R 109 110 121 0 R 112]
+  /Pg 306 0 R
+>>
+endobj
+
+121 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 120 0 R
+  /K [111]
+  /Pg 306 0 R
+>>
+endobj
+
+122 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 120 0 R
+  /K [108]
+  /Pg 306 0 R
+>>
+endobj
+
+123 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 120 0 R
+  /K [100 101 102 103 104 105 106]
+  /Pg 306 0 R
+>>
+endobj
+
+124 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 120 0 R
+  /K [97]
+  /Pg 306 0 R
+>>
+endobj
+
+125 0 obj
+<<
+  /Type /StructElem
+  /S /Strong
+  /P 120 0 R
+  /K [94]
+  /Pg 306 0 R
+>>
+endobj
+
+126 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 120 0 R
+  /K [89 90 91 92]
+  /Pg 306 0 R
+>>
+endobj
+
+127 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 120 0 R
+  /K [87]
+  /Pg 306 0 R
+>>
+endobj
+
+128 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 120 0 R
+  /K [82 83 84 85]
+  /Pg 306 0 R
+>>
+endobj
+
+129 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 120 0 R
+  /K [77 78 79 80]
+  /Pg 306 0 R
+>>
+endobj
+
+130 0 obj
+<<
+  /Type /StructElem
+  /S /Link
+  /P 120 0 R
+  /K [75 <<
+    /Type /OBJR
+    /Pg 306 0 R
+    /Obj 304 0 R
+  >>]
+  /Pg 306 0 R
+>>
+endobj
+
+131 0 obj
+<<
+  /Type /StructElem
+  /S /H2
+  /P 22 0 R
+  /T (Quadrotor (rigid body))
+  /K [72 73]
+  /Pg 306 0 R
+>>
+endobj
+
+132 0 obj
+<<
+  /Type /StructElem
+  /S /H1
+  /P 22 0 R
+  /T (Aerial platform)
+  /K [70 71]
+  /Pg 306 0 R
+>>
+endobj
+
+133 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 22 0 R
+  /K [54 135 0 R 64 65 66 67 134 0 R 69]
+  /Pg 306 0 R
+>>
+endobj
+
+134 0 obj
+<<
+  /Type /StructElem
+  /S /Code
+  /P 133 0 R
+  /K [68]
+  /Pg 306 0 R
+>>
+endobj
+
+135 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 133 0 R
+  /K [55 56 57 58 59 60 61 62 63]
+  /Pg 306 0 R
+>>
+endobj
+
+136 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 22 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53]
+  /Pg 306 0 R
+>>
+endobj
+
+137 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 22 0 R
+  /K [464 144 0 R 468 143 0 R 481 482 142 0 R 487 141 0 R 494 140 0 R 501 139 0 R 506 138 0 R 508 509]
+  /Pg 302 0 R
+>>
+endobj
+
+138 0 obj
+<<
+  /Type /StructElem
+  /S /Strong
+  /P 137 0 R
+  /K [507]
+  /Pg 302 0 R
+>>
+endobj
+
+139 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 137 0 R
+  /K [502 503 504 505]
+  /Pg 302 0 R
+>>
+endobj
+
+140 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 137 0 R
+  /K [495 496 497 498 499 500]
+  /Pg 302 0 R
+>>
+endobj
+
+141 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 137 0 R
+  /K [488 489 490 491 492 493]
+  /Pg 302 0 R
+>>
+endobj
+
+142 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 137 0 R
+  /K [483 484 485 486]
+  /Pg 302 0 R
+>>
+endobj
+
+143 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 137 0 R
+  /K [469 470 471 472 473 474 475 476 477 478 479 480]
+  /Pg 302 0 R
+>>
+endobj
+
+144 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 137 0 R
+  /K [465 466 467]
+  /Pg 302 0 R
+>>
+endobj
+
+145 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 22 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [449 450 451 452 453 454 455 456 457 458 459 460 461 462 463]
+  /Pg 302 0 R
+>>
+endobj
+
+146 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 22 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [409 410 411 412 413 414 415 416 417 418 419 420 421 422 423 424 425 426 427 428 429 430 431 432 433 434 435 436 437 438 439 440 441 442 443 444 445 446 447 448]
+  /Pg 302 0 R
+>>
+endobj
+
+147 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 22 0 R
+  /K [368 157 0 R 370 156 0 R 384 155 0 R 386 154 0 R 389 153 0 R 393 152 0 R 397 151 0 R 401 402 150 0 R 404 149 0 R 406 148 0 R 408]
+  /Pg 302 0 R
+>>
+endobj
+
+148 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 147 0 R
+  /K [407]
+  /Pg 302 0 R
+>>
+endobj
+
+149 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 147 0 R
+  /K [405]
+  /Pg 302 0 R
+>>
+endobj
+
+150 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 147 0 R
+  /K [403]
+  /Pg 302 0 R
+>>
+endobj
+
+151 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 147 0 R
+  /K [398 399 400]
+  /Pg 302 0 R
+>>
+endobj
+
+152 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 147 0 R
+  /K [394 395 396]
+  /Pg 302 0 R
+>>
+endobj
+
+153 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 147 0 R
+  /K [390 391 392]
+  /Pg 302 0 R
+>>
+endobj
+
+154 0 obj
+<<
+  /Type /StructElem
+  /S /Strong
+  /P 147 0 R
+  /K [387 388]
+  /Pg 302 0 R
+>>
+endobj
+
+155 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 147 0 R
+  /K [385]
+  /Pg 302 0 R
+>>
+endobj
+
+156 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 147 0 R
+  /K [371 372 373 374 375 376 377 378 379 380 381 382 383]
+  /Pg 302 0 R
+>>
+endobj
+
+157 0 obj
+<<
+  /Type /StructElem
+  /S /Link
+  /P 147 0 R
+  /K [369 <<
+    /Type /OBJR
+    /Pg 302 0 R
+    /Obj 301 0 R
+  >>]
+  /Pg 302 0 R
+>>
+endobj
+
+158 0 obj
+<<
+  /Type /StructElem
+  /S /H2
+  /P 22 0 R
+  /T (Cart-pole (inverted pendulum on a cart))
+  /K [366 367]
+  /Pg 302 0 R
+>>
+endobj
+
+159 0 obj
+<<
+  /Type /StructElem
+  /S /H1
+  /P 22 0 R
+  /T (Underactuated benchmark)
+  /K [364 365]
+  /Pg 302 0 R
+>>
+endobj
+
+160 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 22 0 R
+  /K [338 165 0 R 341 164 0 R 349 350 163 0 R 358 162 0 R 360 361 161 0 R 363]
+  /Pg 302 0 R
+>>
+endobj
+
+161 0 obj
+<<
+  /Type /StructElem
+  /S /Code
+  /P 160 0 R
+  /K [362]
+  /Pg 302 0 R
+>>
+endobj
+
+162 0 obj
+<<
+  /Type /StructElem
+  /S /Strong
+  /P 160 0 R
+  /K [359]
+  /Pg 302 0 R
+>>
+endobj
+
+163 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 160 0 R
+  /K [351 352 353 354 355 356 357]
+  /Pg 302 0 R
+>>
+endobj
+
+164 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 160 0 R
+  /K [342 343 344 345 346 347 348]
+  /Pg 302 0 R
+>>
+endobj
+
+165 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 160 0 R
+  /K [339 340]
+  /Pg 302 0 R
+>>
+endobj
+
+166 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 22 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [296 297 298 299 300 301 302 303 304 305 306 307 308 309 310 311 312 313 314 315 316 317 318 319 320 321 322 323 324 325 326 327 328 329 330 331 332 333 334 335 336 337]
+  /Pg 302 0 R
+>>
+endobj
+
+167 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 22 0 R
+  /K [234 175 0 R 239 240 174 0 R 245 173 0 R 253 172 0 R 263 171 0 R 271 170 0 R 279 169 0 R 292 168 0 R 294 295]
+  /Pg 302 0 R
+>>
+endobj
+
+168 0 obj
+<<
+  /Type /StructElem
+  /S /Strong
+  /P 167 0 R
+  /K [293]
+  /Pg 302 0 R
+>>
+endobj
+
+169 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 167 0 R
+  /K [280 281 282 283 284 285 286 287 288 289 290 291]
+  /Pg 302 0 R
+>>
+endobj
+
+170 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 167 0 R
+  /K [272 273 274 275 276 277 278]
+  /Pg 302 0 R
+>>
+endobj
+
+171 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 167 0 R
+  /K [264 265 266 267 268 269 270]
+  /Pg 302 0 R
+>>
+endobj
+
+172 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 167 0 R
+  /K [254 255 256 257 258 259 260 261 262]
+  /Pg 302 0 R
+>>
+endobj
+
+173 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 167 0 R
+  /K [246 247 248 249 250 251 252]
+  /Pg 302 0 R
+>>
+endobj
+
+174 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 167 0 R
+  /K [241 242 243 244]
+  /Pg 302 0 R
+>>
+endobj
+
+175 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 167 0 R
+  /K [235 236 237 238]
+  /Pg 302 0 R
+>>
+endobj
+
+176 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 22 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [185 186 187 188 189 190 191 192 193 194 195 196 197 198 199 200 201 202 203 204 205 206 207 208 209 210 211 212 213 214 215 216 217 218 219 220 221 222 223 224 225 226 227 228 229 230 231 232 233]
+  /Pg 302 0 R
+>>
+endobj
+
+177 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 22 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [154 155 156 157 158 159 160 161 162 163 164 165 166 167 168 169 170 171 172 173 174 175 176 177 178 179 180 181 182 183 184]
+  /Pg 302 0 R
+>>
+endobj
+
+178 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 22 0 R
+  /K [153]
+  /Pg 302 0 R
+>>
+endobj
+
+179 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 22 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [107 108 109 110 111 112 113 114 115 116 117 118 119 120 121 122 123 124 125 126 127 128 129 130 131 132 133 134 135 136 137 138 139 140 141 142 143 144 145 146 147 148 149 150 151 152]
+  /Pg 302 0 R
+>>
+endobj
+
+180 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 22 0 R
+  /K [52 189 0 R 54 55 188 0 R 57 187 0 R 75 76 186 0 R 78 185 0 R 87 88 184 0 R 94 183 0 R 96 182 0 R 99 100 181 0 R 106]
+  /Pg 302 0 R
+>>
+endobj
+
+181 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 180 0 R
+  /K [101 102 103 104 105]
+  /Pg 302 0 R
+>>
+endobj
+
+182 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 180 0 R
+  /K [97 98]
+  /Pg 302 0 R
+>>
+endobj
+
+183 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 180 0 R
+  /K [95]
+  /Pg 302 0 R
+>>
+endobj
+
+184 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 180 0 R
+  /K [89 90 91 92 93]
+  /Pg 302 0 R
+>>
+endobj
+
+185 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 180 0 R
+  /K [79 80 81 82 83 84 85 86]
+  /Pg 302 0 R
+>>
+endobj
+
+186 0 obj
+<<
+  /Type /StructElem
+  /S /Strong
+  /P 180 0 R
+  /K [77]
+  /Pg 302 0 R
+>>
+endobj
+
+187 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 180 0 R
+  /K [58 59 60 61 62 63 64 65 66 67 68 69 70 71 72 73 74]
+  /Pg 302 0 R
+>>
+endobj
+
+188 0 obj
+<<
+  /Type /StructElem
+  /S /Link
+  /P 180 0 R
+  /K [56 <<
+    /Type /OBJR
+    /Pg 302 0 R
+    /Obj 300 0 R
+  >>]
+  /Pg 302 0 R
+>>
+endobj
+
+189 0 obj
+<<
+  /Type /StructElem
+  /S /Link
+  /P 180 0 R
+  /K [53 <<
+    /Type /OBJR
+    /Pg 302 0 R
+    /Obj 299 0 R
+  >>]
+  /Pg 302 0 R
+>>
+endobj
+
+190 0 obj
+<<
+  /Type /StructElem
+  /S /H2
+  /P 22 0 R
+  /T (Single-track model with linear tires ("dynamic bicycle"))
+  /K [50 51]
+  /Pg 302 0 R
+>>
+endobj
+
+191 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 22 0 R
+  /K [29 196 0 R 31 195 0 R 38 39 194 0 R 41 42 193 0 R 47 192 0 R 49]
+  /Pg 302 0 R
+>>
+endobj
+
+192 0 obj
+<<
+  /Type /StructElem
+  /S /Code
+  /P 191 0 R
+  /K [48]
+  /Pg 302 0 R
+>>
+endobj
+
+193 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 191 0 R
+  /K [43 44 45 46]
+  /Pg 302 0 R
+>>
+endobj
+
+194 0 obj
+<<
+  /Type /StructElem
+  /S /Strong
+  /P 191 0 R
+  /K [40]
+  /Pg 302 0 R
+>>
+endobj
+
+195 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 191 0 R
+  /K [32 33 34 35 36 37]
+  /Pg 302 0 R
+>>
+endobj
+
+196 0 obj
+<<
+  /Type /StructElem
+  /S /Code
+  /P 191 0 R
+  /K [30]
+  /Pg 302 0 R
+>>
+endobj
+
+197 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 22 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28]
+  /Pg 302 0 R
+>>
+endobj
+
+198 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 22 0 R
+  /K [139 200 0 R 151 199 0 R 159]
+  /Pg 297 0 R
+>>
+endobj
+
+199 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 198 0 R
+  /K [152 153 154 155 156 157 158]
+  /Pg 297 0 R
+>>
+endobj
+
+200 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 198 0 R
+  /K [140 141 142 143 144 145 146 147 148 149 150]
+  /Pg 297 0 R
+>>
+endobj
+
+201 0 obj
+<<
+  /Type /StructElem
+  /S /H2
+  /P 22 0 R
+  /T (Bicycle with acceleration input)
+  /K [137 138]
+  /Pg 297 0 R
+>>
+endobj
+
+202 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 22 0 R
+  /K [124 205 0 R 126 204 0 R 133 134 203 0 R 136]
+  /Pg 297 0 R
+>>
+endobj
+
+203 0 obj
+<<
+  /Type /StructElem
+  /S /Code
+  /P 202 0 R
+  /K [135]
+  /Pg 297 0 R
+>>
+endobj
+
+204 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 202 0 R
+  /K [127 128 129 130 131 132]
+  /Pg 297 0 R
+>>
+endobj
+
+205 0 obj
+<<
+  /Type /StructElem
+  /S /Link
+  /P 202 0 R
+  /K [125 <<
+    /Type /OBJR
+    /Pg 297 0 R
+    /Obj 296 0 R
+  >>]
+  /Pg 297 0 R
+>>
+endobj
+
+206 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 22 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [100 101 102 103 104 105 106 107 108 109 110 111 112 113 114 115 116 117 118 119 120 121 122 123]
+  /Pg 297 0 R
+>>
+endobj
+
+207 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 22 0 R
+  /K [79 210 0 R 89 209 0 R 97 208 0 R 99]
+  /Pg 297 0 R
+>>
+endobj
+
+208 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 207 0 R
+  /K [98]
+  /Pg 297 0 R
+>>
+endobj
+
+209 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 207 0 R
+  /K [90 91 92 93 94 95 96]
+  /Pg 297 0 R
+>>
+endobj
+
+210 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 207 0 R
+  /K [80 81 82 83 84 85 86 87 88]
+  /Pg 297 0 R
+>>
+endobj
+
+211 0 obj
+<<
+  /Type /StructElem
+  /S /H2
+  /P 22 0 R
+  /T (Kinematic bicycle (Ackermann))
+  /K [77 78]
+  /Pg 297 0 R
+>>
+endobj
+
+212 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 22 0 R
+  /K [73 74 213 0 R 76]
+  /Pg 297 0 R
+>>
+endobj
+
+213 0 obj
+<<
+  /Type /StructElem
+  /S /Code
+  /P 212 0 R
+  /K [75]
+  /Pg 297 0 R
+>>
+endobj
+
+214 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 22 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71 72]
+  /Pg 297 0 R
+>>
+endobj
+
+215 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 22 0 R
+  /K [35 217 0 R 45 216 0 R 53]
+  /Pg 297 0 R
+>>
+endobj
+
+216 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 215 0 R
+  /K [46 47 48 49 50 51 52]
+  /Pg 297 0 R
+>>
+endobj
+
+217 0 obj
+<<
+  /Type /StructElem
+  /S /Formula
+  /P 215 0 R
+  /K [36 37 38 39 40 41 42 43 44]
+  /Pg 297 0 R
+>>
+endobj
+
+218 0 obj
+<<
+  /Type /StructElem
+  /S /H2
+  /P 22 0 R
+  /T (Differential drive (kinematic unicycle))
+  /K [33 34]
+  /Pg 297 0 R
+>>
+endobj
+
+219 0 obj
+<<
+  /Type /StructElem
+  /S /H1
+  /P 22 0 R
+  /T (Wheeled platforms)
+  /K [31 32]
+  /Pg 297 0 R
+>>
+endobj
+
+220 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 22 0 R
+  /K [15 225 0 R 17 224 0 R 20 21 223 0 R 23 222 0 R 25 26 221 0 R 28 29 30]
+  /Pg 297 0 R
+>>
+endobj
+
+221 0 obj
+<<
+  /Type /StructElem
+  /S /Code
+  /P 220 0 R
+  /K [27]
+  /Pg 297 0 R
+>>
+endobj
+
+222 0 obj
+<<
+  /Type /StructElem
+  /S /Code
+  /P 220 0 R
+  /K [24]
+  /Pg 297 0 R
+>>
+endobj
+
+223 0 obj
+<<
+  /Type /StructElem
+  /S /Code
+  /P 220 0 R
+  /K [22]
+  /Pg 297 0 R
+>>
+endobj
+
+224 0 obj
+<<
+  /Type /StructElem
+  /S /Code
+  /P 220 0 R
+  /K [18 19]
+  /Pg 297 0 R
+>>
+endobj
+
+225 0 obj
+<<
+  /Type /StructElem
+  /S /Code
+  /P 220 0 R
+  /K [16]
+  /Pg 297 0 R
+>>
+endobj
+
+226 0 obj
+<<
+  /Type /StructElem
+  /S /H1
+  /P 22 0 R
+  /T (Conventions)
+  /K [13 14]
+  /Pg 297 0 R
+>>
+endobj
+
+227 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 22 0 R
+  /K [4 228 0 R 6 7 8 9 10 11 12]
+  /Pg 297 0 R
+>>
+endobj
+
+228 0 obj
+<<
+  /Type /StructElem
+  /S /Code
+  /P 227 0 R
+  /K [5]
+  /Pg 297 0 R
+>>
+endobj
+
+229 0 obj
+<<
+  /Type /StructElem
+  /S /H1
+  /P 22 0 R
+  /T (Abstract)
+  /K [3]
+  /Pg 297 0 R
+>>
+endobj
+
+230 0 obj
+<<
+  /Type /StructElem
+  /S /Div
+  /P 22 0 R
+  /K [231 0 R]
+>>
+endobj
+
+231 0 obj
+<<
+  /Type /StructElem
+  /S /Div
+  /P 230 0 R
+  /K [233 0 R 232 0 R]
+>>
+endobj
+
+232 0 obj
+<<
+  /Type /StructElem
+  /S /P
+  /P 231 0 R
+  /K [2]
+  /Pg 297 0 R
+>>
+endobj
+
+233 0 obj
+<<
+  /Type /StructElem
+  /S /Div
+  /P 231 0 R
+  /K [234 0 R]
+>>
+endobj
+
+234 0 obj
+<<
+  /Type /StructElem
+  /S /Div
+  /P 233 0 R
+  /K [235 0 R]
+>>
+endobj
+
+235 0 obj
+<<
+  /Type /StructElem
+  /S /Strong
+  /P 234 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [1]
+  /Pg 297 0 R
+>>
+endobj
+
+236 0 obj
+<<
+  /Type /StructElem
+  /S /Span
+  /P 22 0 R
+  /A [<<
+    /O /Layout
+    /Placement /Block
+  >>]
+  /K [0]
+  /Pg 297 0 R
+>>
+endobj
+
+237 0 obj
+<<
+  /Type /PageLabel
+  /S /D
+  /St 1
+>>
+endobj
+
+238 0 obj
+<<
+  /Type /PageLabel
+  /S /D
+  /St 2
+>>
+endobj
+
+239 0 obj
+<<
+  /Type /PageLabel
+  /S /D
+  /St 3
+>>
+endobj
+
+240 0 obj
+<<
+  /Type /PageLabel
+  /S /D
+  /St 4
+>>
+endobj
+
+241 0 obj
+<<
+  /Type /Font
+  /Subtype /Type0
+  /BaseFont /ZRHHZU+NewCM10-Regular-Identity-H
+  /Encoding /Identity-H
+  /DescendantFonts [242 0 R]
+  /ToUnicode 245 0 R
+>>
+endobj
+
+242 0 obj
+<<
+  /Type /Font
+  /Subtype /CIDFontType0
+  /BaseFont /ZRHHZU+NewCM10-Regular
+  /CIDSystemInfo <<
+    /Registry (Adobe)
+    /Ordering (Identity)
+    /Supplement 0
+  >>
+  /FontDescriptor 244 0 R
+  /DW 0
+  /W [0 0 500 1 1 722 2 3 444 4 5 556 6 6 278 7 7 500 8 8 278 9 9 333 10 10 750 11 11 500 12 12 389 13 13 278 14 14 708 15 15 833 16 16 392 17 17 528 18 18 681 19 19 306 20 20 917 21 21 556 22 22 394 23 23 556 24 24 528 25 25 500 26 26 278 27 27 778 28 28 556 29 29 389 30 30 528 31 31 278 32 32 500 33 34 528 35 35 333 36 36 389 37 37 722 38 38 556 39 39 1000 40 40 681 41 41 556 42 42 736 43 43 778 44 44 500 45 45 722 46 46 750 47 47 764 48 48 750 49 49 361 50 50 556 51 51 278 52 52 500 53 53 653 54 54 278 55 55 500 56 56 278 57 57 306 58 58 1028 59 59 583 60 60 444 61 61 833 62 62 778 63 63 500 64 64 278 65 65 500 66 66 625 67 67 778 68 68 686 69 69 500 70 70 778 71 71 785 72 72 514 73 73 472 74 74 750 75 75 472 76 80 500 81 81 833 82 82 778]
+>>
+endobj
+
+243 0 obj
+<<
+  /Length 13
+  /Filter /FlateDecode
+>>
+stream
+xœûÿ  Aª
+×
+endstream
+endobj
+
+244 0 obj
+<<
+  /Type /FontDescriptor
+  /FontName /ZRHHZU+NewCM10-Regular
+  /Flags 131076
+  /FontBBox [-40 -250 1009 750]
+  /ItalicAngle 0
+  /Ascent 806
+  /Descent -194
+  /CapHeight 683
+  /StemV 95.4
+  /CIDSet 243 0 R
+  /FontFile3 246 0 R
+>>
+endobj
+
+245 0 obj
+<<
+  /Length 1774
+  /Type /CMap
+  /WMode 0
+>>
+stream
+%!PS-Adobe-3.0 Resource-CMap
+%%DocumentNeededResources: procset CIDInit
+%%IncludeResource: procset CIDInit
+%%BeginResource: CMap Custom
+%%Title: (Custom Adobe Identity 0)
+%%Version: 1
+%%EndComments
+/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+/CIDSystemInfo 3 dict dup begin
+    /Registry (Adobe) def
+    /Ordering (Identity) def
+    /Supplement 0 def
+end def
+/CMapName /Custom def
+/CMapVersion 1 def
+/CMapType 0 def
+/WMode 0 def
+1 begincodespacerange
+<0000> <FFFF>
+endcodespacerange
+82 beginbfchar
+<0001> <0054>
+<0002> <0065>
+<0003> <0063>
+<0004> <0068>
+<0005> <006E>
+<0006> <0069>
+<0007> <0061>
+<0008> <006C>
+<0009> <0020>
+<000A> <004E>
+<000B> <006F>
+<000C> <0074>
+<000D> <003A>
+<000E> <0042>
+<000F> <006D>
+<0010> <0072>
+<0011> <006B>
+<0012> <0050>
+<0013> <0066>
+<0014> <004D>
+<0015> <0064>
+<0016> <0073>
+<0017> <0075>
+<0018> <0078>
+<0019> <0067>
+<001A> <002E>
+<001B> <0040>
+<001C> <0070>
+<001D> <0028>
+<001E> <0076>
+<001F> <002C>
+<0020> <002F>
+<0021> <0079>
+<0022> <0071>
+<0023> <002D>
+<0024> <0029>
+<0025> <0077>
+<0026> <0062>
+<0027> <2014>
+<0028> <0045>
+<0029> <00660069>
+<002A> <0052>
+<002B> <004B>
+<002C> <0034>
+<002D> <0043>
+<002E> <0055>
+<002F> <0044>
+<0030> <0041>
+<0031> <0049>
+<0032> <0053>
+<0033> <003B>
+<0034> <0032>
+<0035> <0046>
+<0036> <005B>
+<0037> <0031>
+<0038> <005D>
+<0039> <006A>
+<003A> <0057>
+<003B> <00660066>
+<003C> <007A>
+<003D> <0025>
+<003E> <0026>
+<003F> <0033>
+<0040> <2019>
+<0041> <0030>
+<0042> <004C>
+<0043> <0051>
+<0044> <00660074>
+<0045> <0035>
+<0046> <002B>
+<0047> <0047>
+<0048> <004A>
+<0049> <201C>
+<004A> <0056>
+<004B> <201D>
+<004C> <0039>
+<004D> <2013>
+<004E> <0037>
+<004F> <0038>
+<0050> <0036>
+<0051> <006600660069>
+<0052> <004F>
+endbfchar
+endcmap
+CMapName currentdict /CMap defineresource pop
+end
+end
+%%EndResource
+%%EOF
+endstream
+endobj
+
+246 0 obj
+<<
+  /Length 8297
+  /Filter /FlateDecode
+  /Subtype /CIDFontType0C
+>>
+stream
+xœZT×úg]fçÚVeE£ÑØk,‰±Æ*ö‚ " ½,E–²°ì·»ô.eaÁ.jìcŒ‰±Dc^b411ßàå=ÿgA“¼÷òòŞùŸÃÙ=ÌÌïŞï~å÷ûİ•ÙØÚÚÈd²‹İÃf-3zÄ2wµkõÚéu©/t¤~2¡‹
+ ã³Û—¦ıİ£/óE_ÛJ¦ŸÌ¾‡õ3¸W?›çÏ»°ş³®Û@ë—S·A6r™L¡glößä>³»_ˆWHÄYo9Œ=fòˆ±£Çw˜áâïçì°<ØßÇß×+Ä+x¤ÃrO¯`‡0ÿ o¯`‡ ww×`÷Íj¿ÍîA!îsW8-w˜ãïâ°ĞËÍİ/ØİaÄ‡`wwÏ€)£F…¨=FúyŒÚâï<Ê§ã¡àQÖq#æ8.^>báüYï/vzdHxˆÃÿ ‡Íî!®^>Á#ml:ÙÈl–J:ûÖ~¼Ú,ÍÚ~Ùif…ĞÅv¹·Îiİº@·®b³Áh0éFc·n—ºZLiÆ4“É”Ú­»ÜFfcccãdu¡½À`uY?›)Vô±³q²`“mó\¶Qv­ÓÒN»å³äÛå1òç¶.¶õ¶ß2ŞŠ>
+=;‚5“.¤¬óèÎw»ÌîÚ½[×nou·ï^ÜıïÊ eòq]ìÙ­§W¯×{•öª·j÷1g²Ç>‹Wò:ş×Ş~½›^‰~åê«¯õAŸQ}õix-âõ)¯gôõí·¸ßwÂ(a—J¡:ëàİÿşÉúÈz£Ï){¬xhPÿAÕoN<hp(•æ•=ŠÇÊö–J»Û*¶EòÒ|<Ş6ŸU^QZŠ+EY­3îa†Enß·u†´šGuB8U[€ÉÃ	ùÕ8
+¡²’K’@!¤­Œõ‚¨‚›¢Áô„ƒğtDtc@Şn•TÆB1ä¦dwBà0ÈßšG'%uÕXĞ·gše-×,—ÆaW>+Ş˜(ÄA²69Şsàˆ…5à¶+¤Î÷04C-Á*…Ù%V<¤½(5ö¢¯ı2YT@y‘j>öái¬"ßºeÙäI}}³ªÃPõƒ:‹lw®zğÂN,è¬v’’µ~#?ˆÙdå¸}8'Şl<®Ê„úM:­/D“ÀÂ°Šòâ»>™Vÿí5ŠÚĞÔşÑ$øZvË”#A”ú˜q‹èÓh‡.¡û%îŠTÕ[dWAèwtbáˆ>µQ;¶/…‰°Ñ1ÒƒèñG÷Ô€óiFÂZUÛÖYóğAÆ„¶:™y8 Â…ìÏ—O^¼½b™@£şğÓn™5æ—f+ÿÂìLXïâ¿ˆÀ/w‰öÿÍ*-ùV¹Êÿd·m7ìÓˆ²§v·ÒÌYz‹ìü¤ÔzHr†;E¬&>ÊÔ®UQóoƒ;™˜¨IŞ­'Ü«Ë¥ù!å¾^aşA¥»„İÅ•RcŞ&bÁıÃf»ª/ÑíÒ-…İãO9±Kƒ´š­IR\ÏB#Ô{Ôm®_S°Èä9ëçûo+¯(,.WANbõÃÎš#ÙU@œÚ<Vµ…]­{_·ĞwºWĞ*ØH8Í”‡A„f8¸·èáf¦¸ít=¤ä\ŞW*úNÏ†Ïòr^»©æ¨ 6¶àä4Ò¾âVYûË›¹:Ìè-²í~éV‡şé6ÊMŒ’^RşØ>T†}+¤ÉòV—VDÚYG;›À‡yëTĞ6>•
+˜¸½!}Ï§R‘Åú|}©Î ‡pÒVÄÀúÖ·v6agë6„C;UÒ65Ñ OÑixÛC&3Æ O’éE*é»=”‹4º=ÇvµÈ%oÜÊ£ıà§´;í5”Êh/Êÿ<;c÷@N˜”Áƒ¬PoT;oô[.°±$à`Ğ~8µP'Êöï<x¨d/ı°O]îRîKÁ(i®Æ‚ï„a¼ˆÃì~¾dÁ×,Ü3¼=ùSAËÙ¾î[æÁ7;ñ‘¾a­ñA
+ıd_‡·’ˆšåÄÛ´RA{|S+\®¸|Qeu÷Sô*»óTË%%_\æçìçW\YYVV)Ğk¶ÿvMyDl6c½h‡ª<ıpæcî@«
+ğpwòU*ÏyXté"|NîºI{m|Ê_5ª¶2Ö#Yóì#õU`Ÿû÷ş¦¢=ñ¿`íD*è Ô+ªé‡ì©xXóöJUmág¯š<P ½ë“Ó«UXKØG#ç©”¸ğŸSİ/Ù÷å´øËr°Í=êîŒlç?æèWÿcùóıßêÍz9Û§ÍOïp’Ô‹¯ò©tf‚Ç¼(ØÉİª?›ŠÂÄì…C°WGÄPvFrv­
+G²ÜG÷¾ÒÁF½NÄ¿d»Y(´äT©”´{»A´fÒÓæ«ÍõÍ\‹dM¦- ÷ã„r8—ÑÓÀ)—Ïfe\hj4–ˆÈúé¢Á<`‘1Ê@|Ø"}–¢!,*&>ĞşT	RÃÕüy"ÊLØé7À“‹2_öot‚¾-)Üú€‰©„J}e2QVˆ{Êñ‚hWóî˜ Óî×V[IËÿ0äkÚO Oÿ=n5¦Ïaì«P£#b0û^»;âp*‹İĞæ«Çª½×µ¡ãn+°´# î)pô_«RÒï;Ü2şV†Y†¶ÍîÊ±µµ_·¥zåûo¯ì/Pö]ŸëôË¿òıUTˆ´3öëÃ‡÷&È‡ü„˜¤ˆh"!a;+ó‹Ë%–¼¨E˜_±_ÉŸÉ{¿œ¯TÆÖ³¿ÊD:U Oˆ Ô¿í,õ•N1qf„ ¡S[½î?T¤Z‹Ú¿wbR£Sã² L)Ùõ­İ m—™—.«3}õPC(GjÌñ¤ˆ¾è£»[°¨™s—Êz‹ìûñéGT ıÌpØ^êÃúÕº”¯ B»x‹ò”ûa*TáÀnK™ÏrÓ‘·…HÖl#\½ï:gµ8ƒGyğÀİ)h€:ãÙÊ%âêPÛEg’½’!‚(i†Æl,’úÙUÆM‡Cs“°íy8î»+&gkÕæ×§ìy¹pjÊî v‚Ô1FC\6 \H-RıÈî€tÉ£KŠKÒ¹Wl‚í@•à>œÀ³À§º*°BûYá®˜“nFÂ,Xíé6&‚Ç©ğÛº\}J,hHˆPÑWÙm-¤‚ÁPTd4‚±°h¿ë}	d~ü™ªÃ}‡EÜ÷òA;èp"Ãí£ƒwŞvüº¹3'&:&pİ o3\CÇík «¢CÙ©0‡'aEåy2†mÏ\ñ¬¢]dàtRno‘å–¬€cH%¡¯áf×=GÊÊÅÚ†üCÖŒLöÕ‚/¬4F[3–s(IÎˆ†HˆŒNÔ’ES§şÈÄeÒ ??³Ø@¸\©	…õ† #ña?ƒş#yDyf½#$¯_¶né’äP >l¹Q4”ùÎuÜtµ)!òÁ\Y}î3òÅ`&C“	Zˆ‹Û 'œ®#¿wB½~W2QÒM¥¸ìôÒ‚R„Ò˜R;w®ÂU{¹†c5R„4„ßSµYƒZ×M„£×jW“FÂœ9ğl4»[B£·GlOğÉuÃ·y»€™õh9*±ËÏM×¨‰jZ]±²b),† pƒwJ¨U¥;ŠëıtE@¾½téKÔEÖ•Öî®M-Â½¢H“^“”¨²-7¦@È*J/UÑÙÔ†‡ ½÷ö ø˜7ğJa§¡*ßB¸‹šŒœÒŠ½p`0„ìÔÖ•_1{Í[oÎi:.ÀÁ=uûMäŒâÚÂ„ÆÚÑUÿ{SU"¯1cg3Ş
+k±~Û´ Í%„KË/‰—2,\³K«;~Ãc4†}èº€¥ãè:ºú®ÁÅô‹ùåiØ­
+HVD
+qŠHH†DİÛn#ƒG ¡ĞŞ8ç¢¾ƒpöÃi´ÕJ3_Åİö„¦|jÙR½!DØ¦ˆ½A›¾áÂª¼Í@Ií¨İw#Ÿ¨NÀáÊ]Y«…ïòuŞ“_UÔyÏ9Ù@$E…n\¸Zd–ã”£üÌ+ª*8YëD8Mn8è¬9>’®q¸Yê#FYì^Â‚®§Tˆ><rCQ[a*¸nShf^‚ôËéÚª6Ïßj°­	™ß›
+¾™LjdãŠ/€`×Ÿ@^5©7íşşÄ‚¸4D•€Š	³œ}eÓ‘Ê& WÎ£ŒJIsiDè³ía²G§åx‹&ğ`ã¶´ÚyãRÀ€3÷àLì½rsÀ&HO2i!ÆÌ]B9²švŠ¡r˜S³i÷)s–ö¸óA¤AŠ	Ò‰’vÏ
+•F‰²")J.¥Jy‘IöÓ‡ o…Ÿuúì‡¸ä¤$D3¨-V1Ú\H åõP(€He:& Ü¾Öœ¼ )Ú\‚)2iQÆÄ\È…”Ì”,‚¯à5&³tÇ¾fƒ.Óé¡¸â©ç›å¸ÑÀ_npóŒÜP+äC^Zv–ñ]ÿÅ×kµz=$‘„Ô¤Ôœë×‘”/œqRzE.9¶úñÙq™!
+’bu±„şí3™ÄhH Mf\6äAJ–)‹àßÍdRs!Àºbêj.¼fi£hWt‹;ğ'ËõÛ bõÉ‰1äMª§r43IYÉ)BÊë è_—}Š Ï“àĞ6YĞF½ÜÎ Ü—‰á…bJ†
+HyxAH˜:Ú×¹Ñã¨pN•"8[šÆ”_h2tL¬#è†¶SÑ‚Kr©Œ®ä_0	é”šuÍDWlºğJ¥½i¯‡o"Q}
+ûÌ•„ÎıCğ1>xƒïupt”wÀz 3ßC»~ÚòùÆñ+UJz	OË²±P•èÈŸ¦…KÙßƒ#OË±M<\Ó`÷åÈ8b	Å‚’’@:H.ŠøaÈ):¨;Ği[èlÚ“Ú‘èHhS’Ò îr¹&ì”ƒr¸E”W²B%™˜/Ê
+[gÈ[Ú½®NöÓ«Œ´z½Vo ?ĞBrb4M3‡`“”£7B*ÙYÅˆoè_ğëğy$gE§j³}ÓÃÉš8‹™Dk¤¼|šÊtíï=
+9ºo‚vôW&5ÊoJcZjùk¢uLŠ¦ãš©=P;ãWLáQ1·ÆĞ;Î5â3n±âÑù-hlá½¨o=¢
+a*¸¬Œ €ŸşZ~kakÏ3ù!k>ÿ=İ<lIvôsõqßº·Å<Ê‚ë¢JÀ…7±P†ì‚ú“f”Á¨,s/ßdZ›ˆÆôR¦Û>‹,ıG¤¢„ïˆ8ÑÊïáZ³˜,òVÌæƒAtdÈL:íó‚ßgf{¿­²`ab‚Æg¨0^Ğ^#`çòª"ğGuÛY Ÿ2`:`\ÉoäçsÅA¹{µVJ€ƒš¡™kÃ½Ò,vAFñèÎŞóÂ.¨-Ù”¬õ‡H²µ<º¨´´`×™å3FÒ®«©L ŠÆªrÊ'#_âX–{v0=z“Š–şù3’œ}şübµÍóçØõøóçççÙ<ŞöËôçÏÏw³¢¼«6ƒˆÇÍx¬¢Ã{%WÔğ5ŸÙÑ‚ NŸ ík!¾)ê[}ƒ‰¸¸¶zyÑÃ²kçàù*nÑÁıøHó{	LkM—Ûée¨ı–OC–-€F¨ñÚã>0> ·wÂ55x|¨İäÚ›*ª–Æñs‚§Ğ!•cJ!ÇlÊ2VB1ûh›D©”È¿ÔîÉ[Cz‹ì
+MñİOh$~‹óp“‘q¼é«v ¥ó† ğ€eàe">ì^}ZÄAdl¬•ò4Óc€—™ˆ]á©›îàÓÁÓD|ÊØÿ‰¡ ÎB‚p>-aÒâ2£!†øn†0Á‡­1}
+{€(AÄ×DI&Ãã—­âÁd^,­c‹!-RˆÄÇz¶Í|°`¼ÜÏB­Jà1h„F8Ş®¾ (wÙÙ"Ou€:©3£¼¢[Gˆ²“O¤€]òÖÅgAzûöiõ±ñô‡ÉTd1]½›ğ®Ú}N…2¸7º˜¾iŒ]0•¨0¶i'A’u2kf0[jW„:Ò	tu¡nø6ƒ‹qâ¨B¢Rş¨¥óâ¡Äš|ï‰ø›$ÓEG»ş&ÉĞÇ,0ôáëi.¤^ì_»º;Kû#¡2ì+ ÷¿İ
+S1dÂ^‚WØj8ğDPb‡ˆ$CáÎ‘ÇıXŞº
+ïñ¸Œ¾cè´?W$:)ğ]p.QîTîè±6,`ÙÒ7¼Ù‘ûÒ¶=Ï+ÎÃ%uÓì}K2'ÀTb•p(m“µºö#XGˆJ×TêÓÊ0‰¹Éé‘	:mb¡nmß1«İ¶¯ĞğùÉ„¬5×YÊU`2dŒä ¾‚ ÇéÆdÔBñu‚ Á‡­íˆj™<UÚâ5FI~o¼Ó[dßÕ½`—¦ìëB¹Õï‚;l†wÛXÎ^7½X³Nó®hÕë°êáº5V•#Õ"¾/â4ñœˆS*d'/~|^”KI¸˜‡ÇóoN,&Ô^dåo>§áÓç®¾f:)ÍÙ möF†:%ôú„â¹Œñ­ÜÔ0¬Ğiô‡IÇg^ÈNjŠùtÛÎ„]	[J³¶ÂV2{Í¬‰‚LK]ydé	İE}­>+t/™Ùúf–cz6€)¥ú¸èuÑã`g¸ñ`§ß±Ğ_êY¦¶®|eòç+^b¤T“„tC¶1#üaê‚	ñÖ¾Û“²?»DPÂ—¿Ä9¿ü(Úıå‡_àî™´gòAŠDß„±ÛâçƒOŸ08…³'à1AÅ˜TI™£Æ:Óšœ†òˆrO¡ıíúÒNÔ†o`ß˜L¸à5ï._Dèrº•Ñh ‚‰Ä*”) â!ŠvØ÷Û½ë÷‚,ø†…«“~•ÖñÖşrğOû‹¢Ætê¡¾i/¬[YnÙpÈ­Q¡şû}ÖËŞ51vë0a¦)¸·:ºW7‹SÚ]iÚûlø^vÙ+Çjâ÷}6üá^ÚïÛY%ˆRx1L†ŸË¥‰½EovŒ.»N%fËÀ",Z0¼­ä±ÎÀ±rÒ–ÏzèbÆŞÖ™İ…½`¥PÖ€ûİJ×½rGMü³í´ŸÛÃêÆ*é÷ÔÕ\ğµÜ.~»=húu~3÷nYÃƒ¤¡Ã­áËL+Fp`ã&,¬107?¥8v’òˆbÿˆ°ÀU'ıO	WÏ_üFÅÙ·°ı\ê¡•~ƒÄZÑ®ğY0·ú™¶ÕYßd½/Bõ±¾x+„ƒVŸ¬%thÛ&:^Šfô)ÉiJv†rAd=tsÁUZp“NA	äxóûTÕ6ƒN4ŒŞ¤OÓŸ?~ü*¤$æl!¸¾­•1Å™bs!Œé)¹'K©8¥-íŸ¯r“ĞIºÅÚ—UD9¿N¤šíĞÔÍĞlß—û¥•´öàk=w;	K`£{b’_Sj á”¬¢6ªÿ†¶ü7Œi$ì½Ã‡ü»
+&Xe0©ä#uaV=QkÚ§‹†8ˆ!”¥^È°Ü·o6~t¤"%u‹do–UHåÒ täƒq´KèFJ¬² (uc2³Û!in<Dô
+hè0i?Õa' ¨ ZÕÖ‰³¦O"‰J‡"[J\èdFj3šÌwÍv'ÏŸ³ülÁ)çq™…;v¼uşKŞ‰	Ú„5sçÌ„÷a‘eù±ğ¡ùŞ@¦ÍH;ÓîŸM¹zåÔ=´UA
+=öÑ–£‰µğ4‰i)Ä o[ñ÷1L\4$XéRV\d1%#›H¦V-“–i4Aii»É#»äîìy£Ğæ)á©ÍªY«Âæçâ|ç£Ü’ãM3’cÛà?Ü¸éÓ¿©D^-b£xYT›±Àl×Ø²çBªå^°p·zKy‡êLìyZÂƒT›˜ ×-ê<×eet>•a¿È8ûÉĞLF¶Ì^4cy\ÓfÕŒ%£‡2Î`Œ¿¹ğÜ†3ûêª/9‰<_À…SÆ;$H¡{wÁVgX«š¼÷<¾÷“ƒ×I}sIÍ=ië„Kxî–æOpCwDrkoUÍYèBY[¿`Ù¢˜!á|µ»öÄ1óú|ß}‹ŠükWÕm!JuÅe$8°»üxŞb‡#Àx`Ïr­ÒœÆÃÍ…×Ş(¹¹óô§ppÏn;9ìÍiÓ¶šÃ+ÅbsåÑõ°]4çÖáşŞğ¡zŒ
+b’—nô]ç¥ÒÇëƒ“ ^Ÿ ‡X¢I‡Â~ÅÍº¹oÑ¾sü6ª\`úÏ35‰¢öÚ€b¿`ï¨£¿2•ß|ó“UŞiı Lv»Õ×d¸J 33/Ûk‚k¤{€WxpL"ÄCbzB*¤@Zjv69|Ür>&İ¼ÕÁ¾‚Rmn}Õ,«oÁŒ¹ä‚Wx¸‘xÃóóßO.pG˜¸i¤÷œÄ©ğLOÓ0mß”+aG€œ€/JöWu)õ\'“rx˜s5¶_æë›a‰%â{ÍYx gà"4gœ(Â®W3-@ª¡9¢hH–Lƒ…D"†…Ic_t¬µpI×Û)fPíEg™¬àFwà]ìnÈûN¨ºÑ°	6ÃÔˆŒ»ò¯0ªP¡D®|rÉRo>o–*-v'ãp3îiæ4šVïX>²5Bèãõ±Ú®¾.°‚v_$\³v9~í‡t¡ÃğmúKGĞñtuÆat~ ˆP“V™™?<oÔ·@~*Â>MªşøSchÿşSÕ'½.Õàã›  7Ü¼¢˜Ú^ÜF0¾zğûN H›y¯pï$5Õñó+KªëU'Àìš½”(ë4–¨ßê©õ`ÿ‹“¶£üÈJÑú!Qügõÿ9L`¹(M¨âe)¦•lû©œõPNxy’'pMëiê·Ó¼ V?9xµ’3uvúaX®1ã+-ïÿà_j6…Ù}zïíGÈßãì{J+p]'?¦6Â:p‰ôğ$¸ŠåHI±¶:¡
+öøô›Ü4]j‚Šël ƒD]XÜÚ°y@¸N6n°!}}I¼)É*´s{†ÄB|¤Ša# >ÏzèdJIË.¨;ñË†Œˆ‚-ÆÍ°<Á1Ø5xó–À@fÂ²ãÛÎnút“Ş¤ÏR½ÃRV¶Í²5Ê3aƒŠ+yuÂ¥¡h+ ùé{ä¬dmQ(6ïÅæ0™Äì•·º£‰/‡(Vaµ"ŠÂÂ <J Õ´š
+‡°°"ÈSa5­VDAxq1å	XUl^«”ØW-b”(jç=oß“·c¢•y(uŒ¼&âSÅŞ7i¶¨°Ô–rqşĞµ5íhMõYáWøfL1ü×üÇ»jÅ‰!@èbú6K]©+§ãp™ê
+Ü(ß}&W½×-H&dä«p&[Ÿ’ú‘ ¤¯«Í€¶+ĞVm–BE»´]€¶?ŞáÖHîÔˆ×1®0ÜMÄ§–ı¢=UmëÙQkœV
+Ü -ÌÓ„x,gWy­±¿Š›­öŠÚ¨â`ÆeÇ{ÂOpåÓì«†0Ân"-aòà‚ ¤ïKÂS\&ûÌŒÓÍVXìÄ—oÛé!„AT¬V«ONÖ $çA
+T¥vá|N»öIÒS5“¦Ñ.eÎûj
+w–¸²÷ÿo òG}hëÛ¢¬¨u¼Õ¯^ù$»éP…şÓ—BÄë´Vxµ -”:IFFk}1ÊS`iÇKsÚñgğ‘U%t'¸½í“ªË…`LMÍ#,İfòêvV~b Ö•ß~*Ã…ëŞ$İáÏpùM-†¼¬´4ë’¬Ë0FAx'ÌZ¸(&æwĞòv±®ûÿ7P©®¨}p«ô‚àË‹]ãı’ûØó>÷ø¸´oòh¦ì'c…å°6ÂÅy“sˆ+LÚëë·ĞÎACcéiâÍÒè76,¶Á
+cÀn²?£r‡œ¯ôÛ<ïÄ¦Û*äQ‰}Ñ[5ê?Ékè8{E	ÀçBD…#p•Ôí<º'·Bµ×çï”…°(_è`RRi[’B©•î|Y&ÃÙäRDë«<MRP%$ç&‘ ØJ7Y€1d^ÈÍIO»¹@Ğ¨-ËŒ¡¯o¥*DbÁùàA8%4±ğ¡éÃŒ)¥ywöŸ'ø:.c2­‘Qb­Z­=,²Æ£%GQwT.mÀwy¨Õpo/‰ÌZ°÷³º#Ç ™<{jôà)3F
+atn\ŸSdÙ¶Ôo‚!ıš÷2ßµü*Ì¶Vıe›×9zÚó³aWÒnØAÎ}ÔxùÊÅU³„’6Ÿ1}Õä	³Î·pºêâíC{Le*ÂùÂbëT¤¥-ßìµn
+Î¸ïŸk“6 ÜØï©\˜[V‡­#e,¦aÏÚ&¡µf/²İœ}Ê¶›veÖŸİxxµ§¯SÒb$³¿U¡ü»¿á«ª1ÖÁšm¾C`!øÕæG‚P×ªß‡8â"R¸VÃZòòÇÈ=¨6Ë6£‡õOn¯lİ*9òÿ$Ñ-ïè–[QñÕ	…q°Ì-b{Hkñ #hçÕTö_q¿Ç_*Š©'ÒkÒe~sr\0„:'²0‘ĞŞt+2ìã»õg„2¨IÜéO¬¸µ¼u’ÅZ˜7>±úü¿5{WIGãü ‡á8tæñ´ö›8j}íkÌÃ|ó“–»øÆlš)(ÿ yı
+endstream
+endobj
+
+247 0 obj
+<<
+  /Type /Font
+  /Subtype /Type0
+  /BaseFont /DVLYLA+NewCM10-Bold-Identity-H
+  /Encoding /Identity-H
+  /DescendantFonts [248 0 R]
+  /ToUnicode 251 0 R
+>>
+endobj
+
+248 0 obj
+<<
+  /Type /Font
+  /Subtype /CIDFontType0
+  /BaseFont /DVLYLA+NewCM10-Bold
+  /CIDSystemInfo <<
+    /Registry (Adobe)
+    /Ordering (Identity)
+    /Supplement 0
+  >>
+  /FontDescriptor 250 0 R
+  /DW 0
+  /W [0 0 280 1 1 863 2 2 639 3 3 319 4 4 607 5 5 559 6 6 639 7 7 575 8 8 383 9 9 882 10 10 869 11 11 660 12 12 516 13 13 638 14 14 699 15 15 702 16 16 669 17 17 575 18 18 831 19 19 575 20 20 607 21 21 527 22 22 447 23 23 454 24 24 575 25 25 1189 26 26 639 27 27 319 28 29 639 30 30 351 31 31 474 32 32 958 33 33 319 34 34 671 35 35 447 36 36 607 37 37 510.99997 38 38 607 39 39 447 40 40 901 41 41 639 42 42 575 43 43 818 44 44 831 45 45 864 46 46 319 47 47 575 48 48 639 49 49 383 50 51 571 52 52 885 53 53 864 54 54 575 55 55 692 56 56 575 57 57 1092 58 58 800]
+>>
+endobj
+
+249 0 obj
+<<
+  /Length 13
+  /Filter /FlateDecode
+>>
+stream
+xœûÿ  #ÅÚ
+endstream
+endobj
+
+250 0 obj
+<<
+  /Type /FontDescriptor
+  /FontName /DVLYLA+NewCM10-Bold
+  /Flags 131076
+  /FontBBox [13 -249 1164 750]
+  /ItalicAngle 0
+  /Ascent 806
+  /Descent -194
+  /CapHeight 686
+  /StemV 168.6
+  /CIDSet 249 0 R
+  /FontFile3 252 0 R
+>>
+endobj
+
+251 0 obj
+<<
+  /Length 1422
+  /Type /CMap
+  /WMode 0
+>>
+stream
+%!PS-Adobe-3.0 Resource-CMap
+%%DocumentNeededResources: procset CIDInit
+%%IncludeResource: procset CIDInit
+%%BeginResource: CMap Custom
+%%Title: (Custom Adobe Identity 0)
+%%Version: 1
+%%EndComments
+/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+/CIDSystemInfo 3 dict dup begin
+    /Registry (Adobe) def
+    /Ordering (Identity) def
+    /Supplement 0 def
+end def
+/CMapName /Custom def
+/CMapVersion 1 def
+/CMapType 0 def
+/WMode 0 def
+1 begincodespacerange
+<0000> <FFFF>
+endcodespacerange
+58 beginbfchar
+<0001> <0052>
+<0002> <0075>
+<0003> <0069>
+<0004> <0078>
+<0005> <0061>
+<0006> <006E>
+<0007> <0067>
+<0008> <0020>
+<0009> <0044>
+<000A> <0041>
+<000B> <0062>
+<000C> <0073>
+<000D> <0074>
+<000E> <0072>
+<000F> <0061>
+<0010> <0063>
+<0011> <0031>
+<0012> <0043>
+<0013> <006F>
+<0014> <0076>
+<0015> <0065>
+<0016> <0074>
+<0017> <0073>
+<0018> <0032>
+<0019> <0057>
+<001A> <0068>
+<001B> <006C>
+<001C> <0064>
+<001D> <0070>
+<001E> <0066>
+<001F> <0072>
+<0020> <006D>
+<0021> <002E>
+<0022> <00660066>
+<0023> <0028>
+<0024> <006B>
+<0025> <0063>
+<0026> <0079>
+<0027> <0029>
+<0028> <004B>
+<0029> <0062>
+<002A> <0033>
+<002B> <0042>
+<002C> <0077>
+<002D> <004F>
+<002E> <003A>
+<002F> <0034>
+<0030> <0053>
+<0031> <002D>
+<0032> <201C>
+<0033> <201D>
+<0034> <0055>
+<0035> <0051>
+<0036> <0035>
+<0037> <004C>
+<0038> <0036>
+<0039> <004D>
+<003A> <0054>
+endbfchar
+endcmap
+CMapName currentdict /CMap defineresource pop
+end
+end
+%%EndResource
+%%EOF
+endstream
+endobj
+
+252 0 obj
+<<
+  /Length 6051
+  /Filter /FlateDecode
+  /Subtype /CIDFontType0C
+>>
+stream
+xœ•xixTUºu¡êl T ‡
+­â©€Ìˆ8´¢‚Œ2É<T€@‰2O$E&ªjU*óDæ $!!©ä€Ì ˆ¢Ø´Â'j£¨ ¨‘ı¸Óİ÷©€\[ûûïş9õÔÙ{Ÿ½÷;­µ^µªwo•Z­î¿Ğ?jÆ‚g¼½¦‡lõs¾˜¥<¡«¤<©–úªÀƒ§«0ä—óİ#†hWé½Mó¤J¥èæ|†|R¥ú×¿\‡9ÿ]‡;–¹P¹¨ÕZ]í«~!ıçúù‡†ÇŒ1Æs¢÷3/yMôèíùjpxHp`˜ç²°­!ÛÃÃÆ{.óŒ
+	òóõßêïæïçìçêàï9{ùÒe³B‚Ã=çnòó÷ôòòôó÷÷ß>iÂ„ğˆ-ãCB·LØ6aëƒIaœë¼f-Z¸ÌkşÜ3.9><:ÜssH¨§Ÿ¸oàÖ°ñ*U/•Zõ’ò—AÊ?õ¦|eq.­«ÈË×J}{/qí“éÚ®ıä¾õv»Í–aËÎvu%m?9«µ0+ß“‘îÚßæªsQ©U*•êe§Ù ›ÓlOªTª)N«x¸«^vnÒ[uX=P½N}­WP¯\Î¸œï=¬·]3IsC»TxRÈcîl5»İgZŸâ¾ú¾ûègváºÛµ­¿Wÿv‡.Æ­ŸÛÓnWx89pØÀ¢?»çŠ:±~ĞøA§õôúó»<òƒ#ßûÓéÇ6=¶÷ñÿË#ù7:²˜#Ú©¶‘jewECèyİ–Åã]?~§¯Ü‰]R$¬»¬	iÆàˆmX„¤ÒZ-ùÉZ3w^^V»¡˜ØÁãïá}ÖÉ{}ÁKİŒ¤ÒŠ	İ7¹Ê(4Ú@+ZñÍLæ*ª¥>BÚQX€hLÇ\¬¹ÈÄãív·€ı½ğëb—•1ú¥x‘¿$qFµÔWKÏ§O^hĞU¤6n“©SÎ‰r'-iiiE£Â=daA
+šPT±¿£æB6ü|©ğÒªÓ§˜«OIâĞíßï<¯Gü(íÃ_ĞqMtü|ÿGòvÿŒ¼¹Tb5{È”Q‚x…Ow.>ß³øÂ,£@:»F,üPéÔ·4lØ°aCC@›ÔÖĞĞfĞ™ Ó]Y­|æ!¿&ğWh-õ!MaQVöç`'˜‡ÛaÔ¡ÀR²;–İ»ÙŸ½Æà dŞßÌ{ÙaüäÍçóÁ|”&6zÖ‚Áø­ı®²&&:3Ë  =;‡İ!5õâ~€‘\íİâC-ª¥qîû©ÏHÏ‘VŒTŞÚ«¯J@‚´Ğ†BT1
+n¾ö³„ëv?»¾!zm]E«„ƒÑ%æôYu¶°|§Q~ÍÌ³“ÀGàió!>…ÜRÙÊÄÈ­ğù/é¨¶¼ {Ü‡½(?=!!tÕ¦†v	¤¢‰EoÙ™®¢Ç°!=ãÚ»DZ±Şé»YT Ü[Ş<Jz+–ìXÅ@*øŸöÈMbË[»ÛÉİy@şRß8öî¡ŠÈ©¯z0¨ÑqŸFwçr#½Ø¹±Ñ½îÆrŒ¶“Kú™7Ä»Êie¨¾*¶ÁGŠ‡Ñ¼>€‰ß™b
+|+^e“1Ë7Ö…3ñgSH@ê›ˆdâ½“ˆÏXãJ0OÄ|¶êô42ÒÌkç/K8˜üîœCK,ÂÓØ¤Ù˜øsÅúlSJ‘—±'+§#ì¸¥4§¯á2äĞúøâƒÅéù6fI³$!•…–Äì“ö•”í5ğ qúu˜ó¬$~gz—Á¥¯¾ÂœuñæIÒt÷×oñ[Î=¸ëš·ßE‘D}´µ¤Áƒ'ê¨²rSV;“WL£\ºÎÑ×zÚÎÇ’¯‘º§IÕ“Ê-­¦±äFoø(›\¸"hİÚÙÏÆ-ã#•›4Rû>>>6³aUÎlŒg:Ê€L#eu×òXçvi4¦}‰ˆEv'§Ä0nëşQ“oN
+iÔR»¦gpØÌdQhÈ(x‹úSŞæ#ÇFM“ı;´Á¯Ğ`fü*¥èy4HKµ]+´ù0-iv'İQ"õKnâ½º©-E)JÓoä}vãÒ´“ó˜¨ĞÀšÂ‹¨B{`ëÂjŸ²ğãïù•jë^«Õ‚­¬ÛM7c¹­¥9•zZL#…\ä"×êtnrÍj¬Áÿå3`†Åf[ªM@¢5lÒ+Ñ›&¥°·Kw´¢òqÙâ­Æ-+&t#RÊÚ÷ÓŸ’õÓiÇÄÎÓÕúÖØ)‡ë™M{"èıÔf—¾À§¸¾èøª²<ï=Á9ë
+"jq MMMÀÄ[Ñ™RÎ{|Fj)ö Çn+e4HÈM/‹“âŸ`Êö­}\ƒ9“ñ*¦\X+ÇÖšH[•ÄÄÎı¦Û±ş>³áƒÙ¹[Z×o<¼,zwr”AW‡2¥Y}ø(½FŒfu9LÕÕæ’*ç0iÁòµ‡`İfèÖ
+á³”€x[˜i“ö{ûQãÎYÏX˜c—Xk"˜Ñb¯4(zaOzúa)KKdæqvñ4¿û 4ºë)‡·9ÈØH>N7R/
+¡Aï:<¤wØ€eh‹Ñ„ÌÌ/,¬Ö
+Fs¾ŠĞ†}~1ˆE8{SÏ<h¤QWËÎU¤åÇH‘°ÄYvíˆ‰B"‹wuD}ÓúBóßö·uà(lqÌßÏW/³¯A<â­;ÁxÔˆ1á×XXH&=Í*l¶©I{ 5ØŸt<6ãMø±±[¹NÒ}ÇÏu³Çô¶Ô¡ÎZga!& ½Ä€‚¢ÊŠcŒÂÑ6V—‡8°„MÚöô6[;Zà°¶X˜#Xğ…İwˆñEŠ·&¹$µ4Ì¢CrLJã‹»Ÿ×˜"“Ñ\¦¿M›nóMİñ‡²Âá~šôŠpníQñÖiÊ×óq4kh
+øæÖ’¤ŒR8`²ìLzùÕeğ"¸[3h®•8öT>weÿ»`bçxkv‰©obd-XYzáƒx‹Æ	(“³y›ïßŠY`|Éûñ‘d%U¾¥¦Dêç¢$yÈÜS¹"T"o‡d‚I)S–G$X”±\[ŒÓ¶óe¬»ˆŒB»ı>áî£İÌth’•_d÷‹ä¥$Ÿ2Êâ­®lŠÒ—§Øb¥$Á›ÂçıÄdüyïÊwŒg?Æ×8c'Õ»ï¿÷ş—ù'œç'¾›ZÉE{´ÍR¶Ï–¾Ïyƒ ¡¹1R,–ä6w±fÁ[sJgƒñtîÅÇp_îK^|¥hiÈƒ.Õ¡ˆê:DÙ4ÈEi¦`==>¡“ÿ™¿è=‚?Æ|5Š^¦W¾ì$7‰Ê×?®â"Aª/%Áñ’Ce‡[+9ÉL\e@E –a-Ó™J"•²Z¹ªÕËB¨%Ø
+æíDõ²s²œ-i»gÜÎEÚwÊ‰ëÌ\k‡ñ"hF·«¦ ´…(A=¯‚Ñ$R4YEÙÁtŞ©š_O“İ§NşnÍ1ñ’D}ô¥ÑH“baIK‹\»$hj¥Çè´¶2û¨M½²ú­Í+J}î¹á| ü§±ô¼&¶İ/1ˆÊ8z\Ï“µéÍ¶ÖŠú}GAõA:l`:>5ÕAÿ’îwIk”©¯,^QÜi€ş¤q•0;(,ä\¬’¨†FÊ‚øIKZ±Å:jÍèÑf¶å3¾_ğü2â#é“#g¯tüÅÔFå‰:÷¦^;JY²ïGâMåYòÔ£-ª!à€_MPÖäÂÍÙóò!ãÂ-”9+âÇh
+Î\f‹·¥U€íEf•áÓßü¢wdmÂ6ğñ ŒMåÛËcM©Ww2ñJcêÇ	XŒi¡Øq%±-­(;ÁÂnàj!I¥R6ÒQ±‡í+Ñt@9X-9£Ÿ*Q²ûYN³Hr†­RD¡z£Ö•ôúÎSê4g¢óQZ¹ùDÛ‘zgˆj¿¸(ã;FÂSåCy¯Ï,>¿·ÎQù–„¾Åñ5{›òq³1³ügÏ|qî«IH„Q,FyUĞ)Fv=!«‡ô¶u‰zYØn°¬ƒ?`‹…jE‰ñiİKùLeİ÷€¬ñ7{aüğ
+ìÌxChÊ‡ğ{ÿ×aJù‡Z“—±«ÕÈÈË*f4]YAÓ»Wüîmœr[“UbK¯µ—§W =ÌMqi¤7²nm&­xıwÌmÕşÌJ·´â>ósë~ëÿ·è!0Îï3R‰‡©ÃCÕõ„ ~ø‡o¹Ù5TÀ£#5Ñ Ê$­¬üğ?:àFlûÍZ¾RXİ¼2ëM'Éö,Êÿôí8mxG÷ÖV³5©{'Äl\6\P\ÆQœÚ×\Ó*çÕâ,A•ÁLWÁWÈ4´QQËA÷û¤¥L$^WîP˜ó¾Í‡KÓ°bkxÃ1Ío¬àoè¶ıÎ
+5mí»ZÀhìÏ_“ÁÀyğ¡3WÎ“vÂˆu§L…°¡ŒQ€€2›­¨ˆ‰×-'²*Á.YÈİ:^no§»2moTSRİ$7e®Ò¥oİrdò®òåiä4ãÇüîC7ábşzî’ óşõú$·ZÊD&²-ñ¦ähD³ÑûÖU´H:>ÜŞş€«ß'Wİ¡>¤ë•…JoıÉå5+¥™Ø´:|>iœ<}Òàé¿Ùq†p¹št?!:6xc]TTSWá0èèÖïåÀVÒ’/iÅ†_^~XwWµ—¼±rõŸ¨[ìşxKÖ9·UiÄK¿•mÿQ|yìÂ¡Ê¨)Âìÿ9Øƒä­¾NŞ.´ëÚ¿©9§˜“t'{ÄœÓä÷{R@õ¹¹t%(]ú¶Íí“¥ ¼‘fÜæÛ°`\ÇŸòç}£9ÁÍNn·¿K›~w–SªıÎ7}dîÖ)ğEF©”ƒk–õ÷¾á—[ôfËöxlFlvdi"Ê·ş |ñ~Ó7R-*Sów;Ë7©î¸(î<QŸiÎ„¼Ş;¾4hÇÿIü_V§g¨¹ìÙc³!ù»ìÉˆ…ïæ˜XÆ½ù„p>CÁÖó^ò‹ïsá›9e`9yöü_å,­t&İ}R‰W•/<äXaÌ	ÅŒO¦-äÑ©)ÊÏÍ¾&ÛÍ¡ØÆ'VÁnÎIfü>ŠF¼õ‡ÄvµSÿ‡55U9YåE¬“»kr‹£`fI1HŒÂÁô/m™`8d=da:ÏT‡âæP;KÀtè¢„R}‘³e«%-aÇüµÑ«À¸4ªãÈƒô†”˜Í1q–H$±_ïÎ²Şà³_ågü±Ûãh<½pX¶¤3qc£rNVW’àòæÃ,ÛÁ<d$Ò¹À­\¤ªß!ü¢î¡ák5kƒf¿†°Ø’í¹UEh`õa{C‚£ıVÉß–®âÜ…ıg)>šì"{úó©”zÇ…¾!»4ğMêeü|.	Ş—¢‘Œ]f˜KI¹óA‡øLğgÀW¯âÏğ^Ü…ÅÇ[­Hƒ)Ïœƒ´.-!ošPEóqŸé¨ñ‘TæÒuËCVÀœ‘XÌxıRÈ¨©,mÅA°Y»É¼iğÇŒ(TˆrT§ïN´åšY·–_ ]!Õ°ƒØ€1ğ·³_Å¦ĞdÿmhÃhzĞûÙ,üô9mä{5™©°ØSc’£ fZì_ãøĞ)Õ]ô°¶;S-ÿ7UÖë6!MÇêà°(êøm™õ3tß‘…â²’Òâ²œäcËo‚Ñ˜»«+ŒX¶Ã/x£)3áwj×FÂş†£5§A:€÷ÇL¦3µÑñÊhv?J^¼?H¢'yò¿Tªh§ƒoğµL¼óaÅ•³¸Á®N½À‡ò~“_yCíö¦#Õu‡%œ[¿ÛÖp =§ŸÃş:ŞD‚•~*u£ÅbM³î²Zv!•Åä¡Tj×ŠwI1«Œñ”aVf¬=XŸ[]v$¨v½oÀöUÏÜYDz‰f_ùéƒŒéH#•ôtéÓ)Æ%ŞëJ¥…z|ÿü%Ş/×©ŠUeï½«ìÛç>åÏKİ³‰?-Múâ«|:]×OY»`¬Ä½©„æi;K_ñ1ˆ÷öóOõ‰àƒøp‰Ï§#´B[‡6°z_,…ÉIêĞİ®<·l³†=íÌƒÜcV“fsªÕÌ†ñ\®¥ú3Î\Ğš5¾ğM³1ãy¡b5Ì v÷Ìz…/Fù=“ÜÌ\m‡ñ<È«»¯&;öW:’]ÂîSÁ}^ğïïh8İ×dfäœÓ‘ÕÔÚ¥u¨BãUòrézœş®ÇÌİ}g­›>3b9cúŸ¼y!ù#ÜÀEûßÚ?hyçRõy°‹ø0Ä1·éõŒ)˜ÍÈ+^O[ùÆCy7ğÑ|3ßDü)Š¢X’hùJ0‚şô'”^
+ŞÒûà™Ô²²:Ê®Ğ@®%­Ø©4{ÈcI}GÄ[c•—´û-™!ÎN«51ñŸ»çÂ¨;©…«yo£¶ÉşÚÀøÒÙ5oñ-´^Ï½«ÑU˜dåŸmîïŒ••^w&o)Ñz=ÈeÒuï2ÆGÔj6å.=„wĞvàÂO`âÍOÑXÅ‡d„Áò+Ç¦×ìdX­¦]lİzÍór×‚ÃŒ§1óê}*"­9”Bê°¯¢KÌ•‘L¼º'¾ÚÙúZ»cÖS˜
+>®<™ÆXK‘ñ+á÷€pç"=='›uthŞ_s+ÕI|^º@šNg÷Š¦ßQÒ9úˆ¦ëïğsc‘î7­ˆR¿GÓ>¥iNCOÒ;¶7­’"•ŸE½/Ÿ®,É°gØ‘ÍòLyÉ;¹úî9ëğÒsµmezüo¦ëŒJy«?{¸[¶ò¾şÃÍgŞğÙ°aÓ~ÿãR%ÊsŠ÷¤òŞ3—EÄî6ï6#…íÊß•SDê¿‘§s·ÿÍt•›då§5X1œtéºÑÃùıÍKà_¬ÄF;3V¥(±–ZjÌ6+"Xwæê5\ÍgXhğIyTÎ5¿+¼ãş©¸š6Ñ’¿Qr“”*m¶ö½ötèÉ¾‚¼:¾nT¬÷‹4ŠÜ©FmkÿÑÕ‘¬ÏAiŒK‚5%Õ5áØ¿óLü'½x±FƒÔì©²†ğ‘/U¢ŞæÈ9À5å¯Üû¹ú~`à^Ô©ÇRğ1OÏ¨ßrrVÁ'k‘j3¥§q·óf‡kpà»Ã±ßßØs§p-êèMsìÏc1ã?ª5mKÛ¶,¥®`MY½á ™Êç÷ÔìÛ_Ó€º(÷³ôø‹'éM&ş])"=	¯Üâ£¥`¬0ƒıI8–o9F#¿%Mu¶%?Ñ`†¦İK"V¤nÀT¬(Û‘›d·ÚÌ`;aŠ3ğ#B*¥B¤gdç4wœÊk»‰g_QÜÕ†ù™¾g™øKczÍ^´°“ö„Å¯LZøÂµh€DÏığ5éº¿:·½ÇÙô¶ìÒ5˜öëÚäY±|"Ÿ6\¹IOÈÚõf®Æ¬ÇÈßB¨rYp^ğn#­q‚’Di 'ï)Uä«'Ï‘Wx)Ká;••	 mE[ö½ò©ÆwPŠCæªp&*[Òb¶c¬
+inŞ»¯é‚ï»N¡øÒó<SÂ+¹/·Ì’§~vŒßFÄ{|Hº~$^)­Äöæäâ¸:\A)£§äÓÒw˜6Ê S‚’ˆÑ'•Ğ@—_=d®Rn’Jæ;„˜`
+e<¥{OQöiLÕ¦Nê¼ÕÛZDX­!æ0³!`¡ÎÒvÍhÅ	´˜™*Ä Ö“l·ÚPÉÙ&Pu÷šÜ¨‚´|”#gOF.£:…Û §‰œåFû-´ ·<ZGóìíÊ5Yİ*S
+£dÙ¥Ë¢ÌÒGRê?G$O•¡É%MŞuvµû÷2jOÙÉçqä‚SNªâ¥\ûD §÷r×2İkˆxÖ
+endstream
+endobj
+
+253 0 obj
+<<
+  /Type /Font
+  /Subtype /Type0
+  /BaseFont /DACQSC+DejaVuSansMono
+  /Encoding /Identity-H
+  /DescendantFonts [254 0 R]
+  /ToUnicode 257 0 R
+>>
+endobj
+
+254 0 obj
+<<
+  /Type /Font
+  /Subtype /CIDFontType2
+  /BaseFont /DACQSC+DejaVuSansMono
+  /CIDSystemInfo <<
+    /Registry (Adobe)
+    /Ordering (Identity)
+    /Supplement 0
+  >>
+  /FontDescriptor 256 0 R
+  /DW 0
+  /CIDToGIDMap /Identity
+  /W [0 38 602.0508]
+>>
+endobj
+
+255 0 obj
+<<
+  /Length 13
+  /Filter /FlateDecode
+>>
+stream
+xœûÿÿÿÿ õû
+endstream
+endobj
+
+256 0 obj
+<<
+  /Type /FontDescriptor
+  /FontName /DACQSC+DejaVuSansMono
+  /Flags 131077
+  /FontBBox [0 -235.83984 602.0508 765.1367]
+  /ItalicAngle 0
+  /Ascent 759.7656
+  /Descent -240.23438
+  /CapHeight 759.7656
+  /StemV 95.4
+  /CIDSet 255 0 R
+  /FontFile2 258 0 R
+>>
+endobj
+
+257 0 obj
+<<
+  /Length 1138
+  /Type /CMap
+  /WMode 0
+>>
+stream
+%!PS-Adobe-3.0 Resource-CMap
+%%DocumentNeededResources: procset CIDInit
+%%IncludeResource: procset CIDInit
+%%BeginResource: CMap Custom
+%%Title: (Custom Adobe Identity 0)
+%%Version: 1
+%%EndComments
+/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+/CIDSystemInfo 3 dict dup begin
+    /Registry (Adobe) def
+    /Ordering (Identity) def
+    /Supplement 0 def
+end def
+/CMapName /Custom def
+/CMapVersion 1 def
+/CMapType 0 def
+/WMode 0 def
+1 begincodespacerange
+<0000> <FFFF>
+endcodespacerange
+38 beginbfchar
+<0001> <0073>
+<0002> <0072>
+<0003> <0063>
+<0004> <002F>
+<0005> <006F>
+<0006> <006E>
+<0007> <0074>
+<0008> <006C>
+<0009> <006D>
+<000A> <0064>
+<000B> <0065>
+<000C> <0053>
+<000D> <0070>
+<000E> <0078>
+<000F> <005F>
+<0010> <0028>
+<0011> <002B>
+<0012> <0031>
+<0013> <0029>
+<0014> <0020>
+<0015> <003D>
+<0016> <0022>
+<0017> <002C>
+<0018> <0075>
+<0019> <0044>
+<001A> <0061>
+<001B> <0069>
+<001C> <0076>
+<001D> <006B>
+<001E> <0034>
+<001F> <002E>
+<0020> <0068>
+<0021> <0066>
+<0022> <0042>
+<0023> <0079>
+<0024> <004B>
+<0025> <0062>
+<0026> <0071>
+endbfchar
+endcmap
+CMapName currentdict /CMap defineresource pop
+end
+end
+%%EndResource
+%%EOF
+endstream
+endobj
+
+258 0 obj
+<<
+  /Length 7940
+  /Filter /FlateDecode
+>>
+stream
+xœİztTÕ½÷oŸÿÙçÌL’ÉÌdò„„Ibò !` e	Ş„DÅy„Hˆˆ)KQ¡Ñ¢ Èµ)¥¨ÔëåZŠAhDÀ"ŸE‰µj‹\±Ôk#ZI6ßÚûÌäÔv}ı¾u×ú2kæì³ÏŞÿÇïÿÜÀ „`Yew/÷]Øf†8hY•µ«oÓŸ´v O/\²²òÀ¥ß~Ğ£€×WU1¿<vH×3@t€áUUóm4ˆşÀuUÕËïñ[ÄxÌXRS6Ş“€˜ry_=ÿZ~JOböğ-_]qv …1g€È×ÖÔ-×ïÑ¿dÈõµµË*jG¾rÄ2Î f?´à¤úîe¡• Zğ€¶Z÷§ÇpšZ×ÂN²ìyœÄtâ$Öâæ WØ¬E+€='Ñ„jgıõtoáŞC=ı™åÑó8ÉŞB";‹lèáB­Ø€cÔŠj¥6€Uc7{@ZXVkhÑf¢	§ôÓ Ná<€-ØœR’­eáØMèÀ£ÚÜŠıx/é‰pZ<X.aµ¶W»Q«Ä&¼„&ìÀ¶m¨ÓÁ8ÇÛ´ÁØıØ	`vò6ş¨Äƒ·ñ6ş9vˆ7Z¯™ÌŞR¸ía‡ÙPmŞb4`İNwÑ{l¬¯ hÒ@óp'Şàm†Mf2šŒJ¶RŸ§>R?m…>íÅÃk. ¯Ñ %â%ìTûµ™|Ÿ¦ŸF%vb§úm²~NÑ7X‹‡4Á&êãišĞ OÁ£Ø 5 j(w¢|³õÁ^ìE:ßL[µ–£İˆZ%Û„&íN¡†
+0•ˆç±í7¼€¹
+u¼ğâ9Óà:iC|®}ZJQù>ÿÍ%¾WKÓ‡\uës™¾}˜±/l¥¯åÊ•%z?^º÷ßG)¶}zJò¹¿÷ğ\úÉ3J|-,º° @¶p^AúÉÅ%û´yWPš˜˜>¤°@=“\÷ñ”}<¥hŞ>_Y•o£kcòÈ®Š‘éĞP%¶êU|7&†ÎdÌ{€ÙøZMGæñ3íCá:Ó~¦=+ÂèNIt'Véè¬£~‰­¦óë/–ƒ €¡íÊ‡º¡7 õ~X¨æ‰`³k¦#:a@B~|BŒ#$a€‰Mìˆîİy$¦Ñ­7¦´º·Œw„ègbz?ÃYdŞ¤Â®ãííçİ¼¼¼¼¡pïhw‰//º¾¼è‰Îs{ò²&—˜.çgîè<Sı–&±È–œdDz£°é5’“RÓrXNöğÜa™ZË6<';ŠNMo.^Õpûs“6ln³øÀÏº÷ş/m…?ıÉ»¯İºGÏÛŸ‘qsñäIÉÎ¸«öJNnÍÍ-+]3TsØ²úgÿ‘(uewúZ½nL÷GfÁMÛœ­ö£¦Ã0`ó¸ÎoÏŠÌóíg^wç¹ó²ü).¸˜ËíƒùÜYÈb9®,·~6ÎåwÏÀ6Ã5Ãí™Ë,%ÜÉîœÈ›XNvT´¾vÔ½EO8x0ã…µw§•×¿óz×[ú¼÷V¬NºÎÂşØ•õ½±ÈôÇ…n
+;âÂ¦Ø#Qäj´·Òö¸O(Œñq®ãÙíA4;$šY)N–ìƒÛ…Äì¨èns²‡ĞS&ıÛLÑ)Şc)L¿yÇ´¢-sÿıùCOÏ{tlŞàÁìæe^vÃõC^;òƒß¾qnÔMRÊ+ùúŞBŒ?DÃz%@K ]yĞP¸:g±–L+[;/¾ÀÛşV®|¨OÔ‚h$û#ŒFC[=ÛcìğòDŞãêhïŠ}1‹%Ì–š–íq»´ä$ÍíòhU>Ø¸ùÁ7_øêÒ'.]¢³ï¾İöŞ{mo¿»S¼)şKœo±t&#CaèıôD`ˆ?Æî$3İ­¡GL30)Ìn„Œ÷º:Ú³%ïÌÑç;ÚİÑyyYÌì–Ú×Fz¿ƒwŞuß¦––¡OÖıò)í@×$íÀ¶?÷Ë®ôyOÎ+;§l´ĞmüqD`¨?ÆÉmát nvÔvÀa±k:—Çéu}¼sôñléô™í£·g»ÓÄÈD·7j‹LNJÍu'æ&ºµJ¶KÜqGıçŞØ+ÚØ`ş¸8ÚÔÕüı[öœÔæ5±›ÀĞèc Âê°ƒB_¢œFÈ»Óu¦½óu‹Wg»bÔ‡‡¶ú¶Òß]øÅ¯ÅïÙY¶õû?Øyæ(ıíA0TzŞ€$üÜŸã	·ë&âûfdh£Zûu™p‡Û¦ÓÜSÃ§õ™W˜ìê˜¼/tÖä}îY·•DÜ•#7”vî”|=R€Ñ£ÏwŒ–ÚºóòÜÑyYş	YzÏ2²Ì,[–=Ë‘2&jLô˜˜1±câÆôÓLü˜„5´F_Ã×kÌ5¶5ö55!MQMÑM1M±MqMıšú7Å7%$³¹L)–õ2ÜÕÔv'-šô@Í“¹ãgŒz2oRQŞO$–™RA'g»Vh÷}V×ğQ×jí¾ÏkåUŸ7oô˜ñ€††+êÃú#ËÇáktzmÛ­ì1ŠÖahÜ‰ñÊ³eZhWl6Çœëd–çdG± k''tkKKÆöò“>y­b‡_¿nİ¦MëÖ­§ÓÚ¸¿µo.ÃF±Hæf#æˆ·ß}ÿLÛ{ïå)Ñ‰ş(ô§"Š˜c“}³u€aìÅØÆˆÖ°íñ¤õwÙ£õ÷¸²—éÖŠ³ó®‹®‹®‹™»Xdb 'D³EN¶ÇTÉÂÔK:?|á™’#Õ‹İ&.‹w™ïó·¿jÑZ¿îi—vÇ­Æs¯Ş÷ÜàÁ,E°Pæ|i×Sûv‚aÓ•õIüs¤áGşU½HIŒ”òUµ`‘¿ò>³ÍÍ~…'ôm)[İÛ&XÅ"µ_s¨×ÌKÊèêl?~U±ø^º(ı¨W¡°.¥IÏÚ4Ææú&Lfjdjl.æ^]>ôŞå#5“Éúq¬·¼£iOõ#w¾yD|İ¹èÌâºSUÛ÷Ö?´ä·‡YØÙÙ­|×©Q£×İUV•3ôÍ_·}ş»¢‚µwûb3[›_ıï4hh³õYzƒò™ÿnŸiungÇèh¼Û2AyÎxi™l•‚\çÏw»MJ·çZù/•Y­¬ÄV<(İæÏ¿V¹}şÀºû7n¼İ›»N¦â9âeñ‰ø‹81‡}ùö»ïµyÿ]«†Lôuú<„à)ÿDm˜†Mº)/\g£hMc!Ñ`pDÛL^B¦Í´GÛlf¾ÃÔ™nÃQ®FZ‘Í(uuï<îV~>;hş™é²¾rÜ÷¾4éYÓÁ0×Ÿ`g†YÉ™w³•¦a2Ó4‘‘ú0Ç­úl‡m.›k×’í,ÙÎrìL¿CÔ°–6Ñ"¶±Qó:ÄÒôy]wµ°Åm¢#³G,]!âõÓ¢„ğ_£…éĞ2_W}ôõ\ıôåLQ=c†ZËöŠ/¨Şğ üáÆN<æ3A1™?³eŞ
+Wg{3´H¯':9UËæAõëÖ®]×¼íá‡·óbÔŸ>#ÿt‘ûà,;Ş†Ü¥¯Ô· i~/~fgÍüg&…jq:úÛâF¨ëÌèöÎÑªÿRƒ@H¶²ÿaö1îIQÀë[DÁ^9ØËƒá çmp Õï¥mº¶¯7±ÍnK6É,ÄuF†‹LCÙ²±KItóÜ”Iœ9ÙHñ›ñŞùê^½~JË¤oÚöZ8Ü.¾ ´ ¦ÄÁd!6Äè§ëL§*Tr¢<‘^ÍLîÉ¦±ÛÍëÖ®5<íbôÙsbtûÇìåÏ³—e¾*aóô•´Kõ ıü¡z³¡5ÃÆ™›¬†Ùİı§T>12±DO¼|V~µĞ§µ|)œÆfÒ^Z­úñ~'gt¬·A×]·¹Î´¿¯šÑíÙª|Ë­~æô3¼­«M,¿`l‹8§}Á2ÁeïB?Ç.ƒtCr=¨X$%G°K/í(c™oˆûØêş«Ÿ~ÇU½Äv;*ûˆIšÕKtZ]av —ˆpç¸­|ß]Rµ,®ıáÆƒ‡>u×ÓO²'e3![	måå]OÎ/—­„ì™ }&oƒnôGÛìë±-Ü@¸İ¤ìĞ¡f‚+ËãRµÕJ‰™ííY)¾ánWjb²;B¥ğAÌÍöãÊk'®`^9›Í
+Äa±WœŞs™Md“/_^Á3ÅÃbø¡xDm4¬»ò¡¬ú´AXê¿Şa"Înâ@ŒÙèIÜä{!¾ñ:Ù·…±=Öé0B|ºyÓõ®éoÙ–d?ßÑ)Ó˜Ldî<jæıñY²|Y‰YIÍhfÍZ³£9dWTstsLslsœsn¯®4wD¨ÜaÃG±\«åZ­rÓZoüÙÏï]òè3ìàÁQ¿ZóË×/ÿõ+vÿ–;ÜVy¨dÓK7¦ú´œ»j+jßz~Ğ”®ûö”ïÅ]‡Æß¿rø°–´´™3³·Xø>è†v„!Ãk;€ĞãÇpÔĞè4%„|
+&;L§ëÌèóVŒf¶gŸïTí©rÒÜDw"Ë‰Lf`¿cÕKYµ8Ç´´èó:3›š(_wAúM9 Wëó` Â?ˆ¢u®kÑLãòBšƒEF¾F8ÊNãz
+MWG»Ê¨ç³¯™OK“MÓdştÊg#›®s-EÓæ²¹9vÙ—¿À
+ÙøÄ²Ïôy³èéËÍ`hôg/Bğ’¤-Únã7£ƒÛ£I³E›6Òx´Á5Òôh"-ßÆ5¢£xÌaØ¸N†FdÆooÏdüöóWe|Ûg¦Şïe!6e!ih6[”Ãcl¹Ú0>Ü6^«Ôêµ»y¨l¶XŠÖcx¬gÆØRh¢Qúg°M¢"³Ô(5Ó"}‘±È\I÷ğ•ÆJ³ÿ\ÌÈqËºÌLwr{+ûğ1‰sbÁ†VÃÛÙÀN‹[»Ækù÷‰1Ğä{½†·ACòıX…(,bnãŒÖÛY¨	6İ½Îéêì<£ZUi9
+Gõ¦‹Ÿ(M²³DÊqçDÊD“˜«ƒØï?yå•]ğøÎOéTgÎn±“•¿ óê@ûˆÁu »4y\’•ÅrÜÉìBg'*Ş@÷™Åğ~ëÌòØµÏ,í×<³¸ÿÁ™ÅğvíV‡‹_šâ7ÌÇ],ÔvÀ`xÌiuh&ìÜé{j9Ÿ-ã Û#ùF&'ñ¬»jÉ¸vºl*»O¬n‘‡–§~ex·ß¼°¬©3“N7Mk‘¯´@Øèwò›7ú“c±ÍaßæYÏ¶9şs€;$v@„Mãp&DñìşCíHğd%º:¥Úg”Æ*å©&PµØVCMÁAJbvT¤×0U›7ˆ±»ş²oëãOşåÓŸ¬½ïa1‰=ÿÑ×k×nyB\ãµ]hØü“Z¥¸©vÕ]å{^şõ†Ç½Qo4Ÿ|Ub¶~Ÿ>4ûÃ¢aiÍ*#ÄíÇî‚¼¸]aÎ°ğh§3,ß§½Ñ<ævp»ÂÃd'ê±yŠœ…2Yªèq©*‘—çù»=“jiUİà‘a§»îvi6·Í–êL¿Á]ä.ò”†9dk˜šédƒY®L£22rèÖŒ	eIo¸úæÛ'ˆéÇØ6á«ªA|=rÚ´w×§u>LK¬'kÎ	Ş†ló'ÚR¬übp+` 0;K@V¨´†ëH ¿¸×¥ÀSLÅ£m©<Õ6\¯İ¢Í±•ØËµ{ùJ[ƒİ©ÓMC3å¢4>Äl¦ÚFRM0&˜·Ñ^b”˜sl‹é^ºÇŒ¾*â7œÔV|ÖuH›İ!bwœäm]UÚ£]wnÖÚwwÉ7É^”ç$•ïÔ¹-&ÔNáöÆÈíá­ı‹…Ç3!&Ô0âzuà½Ïm½ûí^}xZd²;‡¶®·zîõ]y¬òµ/œ,ßÑÒ¢ení™%â„ø‹øT¼4§x³|…¨aƒ˜©ĞW(yrüı»åißŞïXìÑx%Íx<7õœ${Ÿ	zŸY¯et®Ì"SX·nÃ†uëĞâÒ·Wœ¸ğñkåÛ3ÔK‘ÚŞ{·kcq)ÁÜ,ŠœSÜô·KVŸí–ı¿=õÊ÷ÂG‰6é	x¿ôúï¯—×w1Şj	ÀM=VûÌjè§/¯¿âå­ŠRï?¦ŸFÚØ8†JùfkÑŒj4 ›Ğ*Ï"l/Jp‰İ.ßš³™laÖáY”£•ìáö 
+ğ¢ôM¤b'Î³,Ÿı€`Ÿkıµ]Ú'tÖıûúOôVıÅóy>/ç÷óİü}#Êh4˜†ù#ó¨ùÍe›bk¶GÙ`ÙáR§i¡ŒÅ0 Á…í°|sƒCWÿ¢±¦Ûõnß3øĞk°á1õš×{9bğ§ÀØ@ˆÀØ†$‡`$‡E¤²»c'ª¼;15¨ÅJ,Ã",D–Ã‡(Ã ø,d!>,ÀJøEX:,Ç2T`>ª1>a)ÊÆb	–À‡™İ´êÔ]êPe¸(G(@îÄ|ÌF=|(Cæc)ª•>ÌWô}X„¥ğ¡õX€%X„2øPTc¾zv5bEER˜Š,EòQƒ,ÆlÅ¿‹Ô¼Ô,9Ñgpwpo_Ú•jÖÒhy@{©árÔb$2‘‰òÀú»QÔ¡õX†2T¨½Ë”vXŠ
+,Çø^Ô‚ÚQÿ6Êò™DP®Z€
+,AV`Âüÿ’Ò&kr¶›_™¿í5¤ÿÉıÂ}ÿ@çE¥ÍåŒ´±ÄlÃ‡TşCY¤f3½jE­Ç-ÚUêYE@¯…Š‹DYÊ'éTª§İÜ,[Ş$Ÿ/G’p©Ú_ğs‹C`yÀÂò»0 KY é ÍåJŠ¾>>ej]5jÔƒäjKvË“*TÔXœÔËK’”åäŞru•º× ‹0? Ÿåƒe¨Gµ¢"e]ŞO%aIÀvËØÃAÆ»”9Vü\rìÁDÎÔbjPz%g4åJi±EX€z%OŸƒ¤.q(ÃÔ+*&+”T©˜_@FÚ»¯FAú=^×-m½ÂpH/ëÈ±Ä¥ÇÖ=ñ[‡*5s-=†të™©òOQ¶âÁ¢½(€j_ë·ÖAä,i-?³4ìëu=­PxTÿS‚ÑP©ræÒ€†–XÔ¤§HMj”4u
+‰;Q2EÏZÓÛ—²dĞBRs©Á¢n{Ôa¤ŠÎY]ó± 5*3ôØ w.êAàÛ™@ÖIWzY]ŸµÁX©½fè½Oj%cÛ²”Ìó}}ÍBÃÊäó¿Ã’²•/¤í«Õµ'ü3¶X•JŞJ•$íŒ>H}×^‰ÉÊnù%w‰¹Œå`F“²K?]Ö=cI*1j)íÙÛë‚õKr±ğªÇu×£‘Ü+‘]ğBKß…X¢´©
+Ì-ë•C¥v–$uİ<®Æ§îêÔ;Ç•÷ñ0©éµ%ønIúò»—kÉh¡¸Tq’šüı¬nYIşJùªûĞÎÔu{f0n®®"|'%îá´BiU®ö']£.&uë}õ¹>Xu“zy›;S®ª3«6e•Ş°¤—%îF]±
+Ü£p¶¼w>jQ¨b2úeµ	îèmKæïiGùL^ë2J>ßå/–v×Êáòi½ZÕá¤ïìW’úØğÿ4fe]Ò]³{¢.Q²ƒ°bOÖ%«¾\MQî)ÃbÌWk$e«.J¯úvÿñÿ"cı}­¬NËBQÖÅÊn¤&¢Pñ™i˜¥øLÇxÌÂŒÅLõ¬Åğafb:f£(D²ËXõD>ORÑ8EŠâtÜ¢hY4fb¬¢]
+Ÿ¢-;Õiên2Š0jo!JB+ªÓ1SÑŠ˜‚"ÅÓê1§a¦à¨ñÕZü¦aººÊõS•,–¤³0½×¾RIÊÅİ’ME!fb&E>Š=)¿ä?^§uË9> éX…‘¤,iÃ-˜¢îäì-˜‰˜b…§¤\všÒa<ft)TX–°$‡é˜Rµb&b–’BršX)ïg)}¤e¦*®“Õ¬%Ùô€•å¸‡Š<H–ÿÙİœ‹•şS0Ea+õ-V
+1S»é}g‚¢ å¶Ğ¸Eé'å+RJò™DQâ9¥{åÌ^V‘6«ì&%—û¥&‘âkj¤Ö×:×ò IKÚM"5E­.Æbœ¢dÍXşX¤tÀÖ¢iù½åÖZK&iŸiÊ²7ã–À
+‹ŞÕZX"åïÑÂ²ÀØÀï¸^˜õX_R”2å‘Ş,½ìÛ¨Èø“’ÈUÒä]écÒJ–äV¼X<‚v¼%àŸÁÈ›v¾Á8
+®ûgr‡E+È»¯%'KB+“Lû§èZ¹«÷¨¼W¨kußªÜ½»Ç®´wÿ9¤W®íİ	XYx‚Z[}ÕºY+?[5«çÌÓ»‡»Vå
+’‡\Õı»+w[g£Şİo¹êÓ­^°®»+±êGMwg"»«cZäiPÖ—¾ç½:Å×ÒÌâõmZV)×YÜê®æwU¨«OˆR‰‘¤¼Bå»$«c˜¯ÖÈµrşŞ«NÅ–ÿ¼‚ºü#üålª¢²]¤–ıdF€î²îóY&ëíVõUVïñ>Imä·úP‰ÁÂ^’ËóÕcÈ¾Bòtüï×2Ş‹±™JF¹÷d¨.¼™Wu”òı¹ú»òn¼¹îû—`6nÁxx07cªD²zG1nC>Bà„¡êM-G8J†LA)¦!nUßSp;2dÎ;¨­a‘Ï><—íÏ"±Ä"±FıÿYbê×ˆ¹ÕØ¥~Ã±Äœjöì§øØ†U ŠA6ˆ9=»ZeƒÄL56Ô®Æºš'5£©æ/$u­¢NA—}“M;D_¯¢¯.5ò¯}uD¿ôe)¿ÔH—Öè_v¤ò/KéK¿Ş‘Jı"“ÿõú"“ş[Ğç‚ş’M½ôÙVjÿtoÔŞrå´ÿŠşéúäB9ÿd+](§ıùOıøŸı©}$èübúPĞ¢sÄòsßĞ±tv+ıQĞ½ÿ^$_Ğ{‘ôîVúı;‘ü÷‚ŞÙÂß‰¤ß­¢·GRÛæŞ6’ÎzëMKĞ›:-è·‚ŞØèæoô§ÿE§½¾•NnJá'½&èÄ*zUĞ+‚^ôÒ0~\Ğ1AG½(èÈæ~ÄK/„RëoñVA¿9<—ÿæıf~øP
+?<—ûõC)ô¼ ƒ[©¥i,NĞ¦±üÀ7ôëa|¿ _•Ó³åôŸNÚç¡ÿôŒğwÑ¿zZĞ/=´WĞSO:ùSÙô¤“ØãæO¤=núÅîtş‹U´;~.h— Ÿ	jşi,o.§Ÿ>îâ?¥Ç]ôoÚ)è±aü1A;Âhû£|» G3h[ÓX¾m+m}äß*è‘‡çòGÑ#kô‡LáÏ¥‡ıúA?ôĞƒ)ü¡Cô`
+5mJáMcéÇ›Cø½´9„7¥ğÆrÚ´ÑÍ7¥ĞF7m´^Ğ‚î_çæ÷Zç¦	Z+è‡î|şÃbºOĞš{hõVñÕ‚~°ŠV%Ğ÷58é^A+İ-¨~y(¯§úÿ»úòPZ~D¯óP__&è.Aµ‚j–óš­´´z _ZLÕi‰ ÅÙt§ EÙTõ-<D•‚*•*[ÀË-€‹/H ù‚æ	ú ;náw8in9İş*İvk¿ÍK·†P© /Í4[Ğ-ıbù-Ù4KP± ™‚n^E3M÷Ò4ASY:Ÿ*hÊ!š<&ÅğI#¨hœ‡ÅĞÄÂ>QĞ„q>¡œÆÆğñ‡¨0†
+ÆyxÁ—ïæã<4®EóûízşØpï¦ü~»>ÖïäcÃil;â·ëş1¡Üï$[ã·ëcBí|L(ia~¹~“ Y:¿ñ-hÔ@)(ÏÏóÊé†¡qü†É4BĞğt/.(w2ËŠãÃ&SNVÏ”íÎçÙ‚†¦{ùĞ8ÊŠ£Ìt/ÏŒ¡{Ï8DéC"xº—Ò[4ÉvˆËÍ‡DĞ)îV}ğõ)|° ëíQüú¤äƒ”&(5œR¢òyJ!]NÉ‚’ÂÃy’ D_:O\E¾t0™Üù<AP¼ şıbyAıàâıb)NP¬ AÑQù<z<EE¦ó¨|Šôºxd:y]ğ’ÇÏ=‚Ü,»óÉÎ]nrYØ…;Cyx8…[Ø9ÃÜJN»°P;sPXóï×Cí*}k„"ÈaâAö(²¹Èd°tnâ^"m$§oHcé\I.ÎÒ	.b-¬|İf6øÿŸ?üOğ/şÅã}VX
+endstream
+endobj
+
+259 0 obj
+<<
+  /Type /Font
+  /Subtype /Type0
+  /BaseFont /GIBJKH+NewCMMath-Regular-Identity-H
+  /Encoding /Identity-H
+  /DescendantFonts [260 0 R]
+  /ToUnicode 263 0 R
+>>
+endobj
+
+260 0 obj
+<<
+  /Type /Font
+  /Subtype /CIDFontType0
+  /BaseFont /GIBJKH+NewCMMath-Regular
+  /CIDSystemInfo <<
+    /Registry (Adobe)
+    /Ordering (Identity)
+    /Supplement 0
+  >>
+  /FontDescriptor 262 0 R
+  /DW 0
+  /W [0 0 280 1 1 659 2 2 778 3 3 389 4 4 572 5 5 278 6 6 490 7 7 469 8 8 389 9 9 681 10 10 485 11 11 622 13 13 444 14 14 500 15 15 394 16 16 278 17 17 556 18 18 500 19 19 444 20 20 681 21 22 597 23 23 389 24 26 500 27 27 278 28 28 500 29 29 833 30 30 529 31 33 500 34 34 458 35 35 828 36 36 581 37 37 651 38 38 648 39 39 579 40 40 451 41 41 458 42 42 298 43 43 557 44 44 530 45 45 878 46 46 440 47 47 546 48 48 715 49 49 640 50 51 778 52 52 643 53 53 500 54 54 339 55 55 528 56 56 500 57 57 332 58 58 569 59 59 500 60 60 750 61 61 392 62 62 556 63 63 539 64 64 849 65 65 675 66 67 875 68 68 500 69 70 523 71 71 570 72 72 572 73 73 970 75 75 477 76 76 278 77 77 438 78 79 569 80 80 1014.00006 81 81 681 82 82 544 83 83 1089 84 84 778 85 85 500 86 86 778 87 87 738 88 88 278 89 89 833 90 91 778 92 92 569 93 93 601 94 94 667 95 95 722 96 96 567 97 97 542 98 98 718 99 99 490 100 100 521 101 101 465 102 102 510.99997 103 103 554 104 105 736 106 106 872 107 107 778 108 108 569 109 109 778 110 110 361 111 111 437]
+>>
+endobj
+
+261 0 obj
+<<
+  /Length 12
+  /Filter /FlateDecode
+>>
+stream
+xœûÿ  h¥ó
+endstream
+endobj
+
+262 0 obj
+<<
+  /Type /FontDescriptor
+  /FontName /GIBJKH+NewCMMath-Regular
+  /Flags 131076
+  /FontBBox [-401 -1245 1140 1745]
+  /ItalicAngle 0
+  /Ascent 806
+  /Descent -194
+  /CapHeight 683
+  /StemV 95.4
+  /CIDSet 261 0 R
+  /FontFile3 264 0 R
+>>
+endobj
+
+263 0 obj
+<<
+  /Length 2382
+  /Type /CMap
+  /WMode 0
+>>
+stream
+%!PS-Adobe-3.0 Resource-CMap
+%%DocumentNeededResources: procset CIDInit
+%%IncludeResource: procset CIDInit
+%%BeginResource: CMap Custom
+%%Title: (Custom Adobe Identity 0)
+%%Version: 1
+%%EndComments
+/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+/CIDSystemInfo 3 dict dup begin
+    /Registry (Adobe) def
+    /Ordering (Identity) def
+    /Supplement 0 def
+end def
+/CMapName /Custom def
+/CMapVersion 1 def
+/CMapType 0 def
+/WMode 0 def
+1 begincodespacerange
+<0000> <FFFF>
+endcodespacerange
+100 beginbfchar
+<0001> <D835DC99>
+<0002> <003D>
+<0003> <0028>
+<0004> <D835DC65>
+<0005> <002C>
+<0006> <D835DC66>
+<0007> <D835DF03>
+<0008> <0029>
+<0009> <D835DC96>
+<000A> <D835DC63>
+<000B> <D835DF14>
+<000C> <0307>
+<000D> <0063>
+<000E> <006F>
+<000F> <0073>
+<0010> <0069>
+<0011> <006E>
+<0012> <0031>
+<0013> <D835DEFF>
+<0014> <D835DC3F>
+<0015> <0028>
+<0016> <0029>
+<0017> <0074>
+<0018> <0061>
+<0019> <0032>
+<001A> <0030>
+<001B> <002E>
+<001C> <0035>
+<001D> <006D>
+<001E> <D835DC4E>
+<001F> <0033>
+<0020> <0034>
+<0021> <002F>
+<0022> <0028>
+<0023> <D835DC4B>
+<0024> <D835DC4C>
+<0025> <D835DF13>
+<0026> <D835DC65>
+<0027> <D835DC66>
+<0028> <D835DC5F>
+<0029> <0029>
+<002A> <D835DC59>
+<002B> <D835DC53>
+<002C> <D835DC5F>
+<002D> <D835DC5A>
+<002E> <D835DC3C>
+<002F> <D835DC67>
+<0030> <D835DC36>
+<0031> <D835DEFC>
+<0032> <002B>
+<0033> <2212>
+<0034> <D835DC39>
+<0035> <0036>
+<0036> <002C>
+<0037> <006B>
+<0038> <0067>
+<0039> <0020>
+<003A> <0032>
+<003B> <0038>
+<003C> <004E>
+<003D> <0072>
+<003E> <0064>
+<003F> <D835DC60>
+<0040> <D835DC3E>
+<0041> <D835DC62>
+<0042> <0028>
+<0043> <0029>
+<0044> <0037>
+<0045> <0028>
+<0046> <0029>
+<0047> <D835DF0B>
+<0048> <D835DC62>
+<0049> <D835DC40>
+<004A> <0308>
+<004B> <D835DC54>
+<004C> <22C5>
+<004D> <D835DF09>
+<004E> <0034>
+<004F> <0033>
+<0050> <D835DC5A>
+<0051> <0032>
+<0052> <D835DF03>
+<0053> <D835DC40>
+<0054> <002B>
+<0055> <0039>
+<0056> <00B1>
+<0057> <D835DC38>
+<0058> <007C>
+<0059> <0394>
+<005A> <003C>
+<005B> <2212>
+<005C> <0036>
+<005D> <D835DC91>
+<005E> <2208>
+<005F> <211D>
+<0060> <D835DC97>
+<0061> <D835DC92>
+<0062> <D835DF4E>
+<0063> <D835DC53>
+<0064> <D835DF49>
+endbfchar
+11 beginbfchar
+<0065> <D835DC67>
+<0066> <D835DC70>
+<0067> <D835DC86>
+<0068> <0028>
+<0069> <0029>
+<006A> <D835DC79>
+<006B> <2297>
+<006C> <0031>
+<006D> <00D7>
+<006E> <D835DC61>
+<006F> <D835DF0F>
+endbfchar
+endcmap
+CMapName currentdict /CMap defineresource pop
+end
+end
+%%EndResource
+%%EOF
+endstream
+endobj
+
+264 0 obj
+<<
+  /Length 13455
+  /Filter /FlateDecode
+  /Subtype /CIDFontType0C
+>>
+stream
+xœ›	|SeÖÿ[JÚG Q!ÜpAAQQ@A‘}§”î{›®é’¦Ù“_ö¤é¾¤M›6]¡”Ò²VVAFe\PP·Ÿ[ŸÎ¼ÿÏmÕq>ï¼ïûÿ¤Ÿ$Í½97÷É¹çœß÷œşZLîâW_ÌŠŸµ:&.;9RÆ¿º„»››‚ñnj°äÖ )0z?>ìŸÍSnŒŸ2ñ§)®	¦ß1‘¿Ï½}jPĞı×øü?ãïå6Œ¿/($88Tx>:mgÌËÑ1©Y	Yò™‹œöøì9óg=>ûñ9ÓOÍJKMÈœ¶63-9-%!+!óÑi·®OÈœ–›&Kš–9M“™=-;5:F6-+>fÚÒukÖN[’–š5mEBTLjfÌ´Y³¦eÆÄL‹ÏÊJú±Ç²²ãM“Å=›–š•ùXòè>™ño›µdåkkg­xyñK¯­yéÑ¬¼¬i±i²iÑ1Y‘	É™	
+JªÄı(Îör‹«i*<şP¶Ó&¹uìÚ´ñ·8ÆßŠñãznõºí6[™İ1~|Ï¸G…Íî°ÙñB‚‚ƒ‚‚‚ÒùEœdÌü¢M
+
+z†_“»ÃƒÒùCŒz7Xœ4æ‰1¹!¯„ì+û©`GèÜĞu¡Â$aï‘ÇˆŸüpË•[•·^·tœ{üÜñí˜ğÒ„Ÿ…¾‰¯Oüé¶Wo3İöõíß‡5LŠ?+~ÿ'î¨¿sá'}×?=õ§SwÇŞİq÷¹)íSNÍ’„K§J§IİÓ›Ö=}útÿŒ¥÷¬ºwê½ê{¿¼ïµû:ïŸpû‰3WÎÔ=¸èÁˆ‡]|8ï‘ÊY·ÏR<*{´ÿ±×k™]>ûÀœ±sæÌY;çúãŸ˜1÷Ş¹mŞúäŸŸüø©ç…Í«÷|åü/¾±À´àÔ3÷?Sóc—„ƒê.nrWø.*dÁÜ$*\9 ºÈıÀ‰¬ï|M²±;rYïšÚÕ ,|)›˜XT	·´NØÊ[¾z¯uv¡F$ä­UÅ‘6UPøZ\JtÈBn%]é*­é€xóãcS7¯?Jrİ{Ëk|‘GóĞğwèÄöŠB¨¤ÅĞ@¯H½8e'b ¯AêË¸»I'"¨<Ùè„¨+$¢‹q%òÈHvuf»¤³»å€THïê¡öÅÒïÅ•[)ùGh¨R¥R*İ*t(4Ôãv{¤lıØÿq›%ÿ0B?e*1¬F«ÑrÏ¥%t+è\ò×0Ğ¹çèÖ¿_²X,VXa×Ùu0Âh2šØ˜y3ØV°Eä©0°E7ØV:fÅd1Y`‡İ;&*½åWhä•roxËÕ×|ô§«k|¢Ÿ¹Fn¼øğë	’Uˆ__œ%;»®4äÕL,+)¤.X-wÇÍ³¾Ô¢S…UHÎ_Ë¦¼-²SNDC>»·~Òœí*L‘e$m;˜Û'9‹®w­²Ø®è“ ?£b_©
+©
+F½Q“8mif¢QĞ†x^Oé S¦†«ïÂFÔ+ˆèç4]®™¤À“×,ñ¶ÕôH…ì#Ü¦/{Ch„Y|V¶;:1W––^—Ñ.)C¹­ÔmµXÌ `1¡ÏÇ¯LLT*a„hìz»ç£‹ô‰…±Hoï½^n^®ÛŞâ×\‹?ã9I—Ÿİ<Â)¸™âš"w¡¤ZU¡Q§NÖËIî‚íl™@_¸ã¥—±Ê>t£¿úÍ/ªöØ<¨#¢¿Ù—Ô½é‘XvŸŠ_8I)Ì{Uó×=­p¡H‚¬$C“5]¾[ñøé” »ÑQí÷+6oZŸ‘“ºEØnÍß]…rT”ÑOGJİ¥å¨%t[IVbÁæM}±oJ~ÂO_ù©€\çÂ¶
+Xà$B6Eé¥ÚèopïYÚq6dÒ§ÜÎ >+§Òû˜”=Ê:™|VùŠN§Ğš%yùM16«7fÎ$,&´úLİG=ç›tİ‡p,Çj²“ˆ•ÛrŒY¿4fó$"§×Ğë8Şô7"dÉT1B÷Ğh1ï™‹fĞ­lÌe£Ùh6B:,‹ñïÏñ9wÄ3ç.a[ïYh40@g×ÙaÅl1Ó1—oğ^¾ˆ?	êÜğ¶½?§üH‹†î¦3ÅüÕ)QBÎh„Q+Ë]˜B¨KÑŒj[Uiñ~ÙpEàô—í‡õÉ(@¬JAV³<6K“j”Ë3£wnÄë0DN.ùß#¢J›¬NT“ã«ÚÖNßÄ¦äòF2`ÚiÈ`iœ(rUœ¦/&¢Èyk°,ôû‚hAŸmğPÛæãÚFt£¥¾¾‹øzÊù‹Wz¹YŞàÿá3¥'é+{C¸xˆ3ªä²ÌŒl	v­GYŸ[8ù“³[6fu–àhó…Àegµ½µ„÷«Y1ÿîW-?ìmhù—_¥käŒ(¶aaA_ôÓgÑ¿–«•ïqãsÃË4óìú#4o¯è÷GÄhÒyËµµU…b(´%%ªJ”ØÔN/»<ñÅ&…¡8köªÇÁ$îR.÷—¶:[-n‹.Tê<E ¢oóP"ÓeÑu²>Å”š¸nKôZ¼†Œƒ8:kƒİ[y²ëè®#V›ÅCo×YŞ´ĞtÚ«eËV”Äè¢§[^ıä4÷ízÓójgÄÛø;NSq+@<{Ë¢‡‡äŞ¹ÌÎÿÂâ†ÆŠ›³šRrÓdé­u~ŸDÈş¬ôÑö«İ¾ğËtÃÕÂ&Ñî	:N\Zƒd$øhS}¥8dı{éŸéSŸô‘ºqÚÔGDÜNƒ6
+’Q“ëoª«n}gÑîgÙí± v›ôİLJ$ôOmt|©T8Céãf{ƒı—iëå.‰&Šé¤n²	ìö‡X0»‰ÿş0½…NøáoT$™ç#ë²#²·G¤nÂDÔ§÷Ëúp
+]ØÁÆ¾æşú>ìÍnÚÑ´«C„,Néå¬oß¿¥™Z}YûEWè0$Æ‘”Öâ²Ä¶hW¤kgY9£³iÏg ¢ktìs,Éf• )‡½VúCX5œJ	Ÿ*Å}‰JoˆñïD!˜1Ë°ñUiÍÙm~í{EDtÁ«ÿ¤ ‹±1>j!BÜ±¼Oå&[	ˆ¹”MË‡Æ#±Ãl®­µX`©©í‹Ügª¡aıo¿7Ÿœ àÉ¥â›áŸşüôYÑŠ;a/ëí»¥àB¢lšÉ‚·ÜÚÍRæÛ®Ä2	’é« Æ•¯å~ø·/VÂ³RáæÓJo8sÆœíãÚî„m€¦VB×„á3’»ŠªëVálİ‘ö*Áè"›Îğ]—f³”Õÿ~@•5  X¦Ä>)]&Ú÷÷óGÏœö¬[-aEØK œ ×8“LÓßáº#6Çàé–rÇÃaÉ’¼ºü	$$‡Õá7‘áÊ°8CñIRrh§õsô Ÿ£Ó@x×ôrÃg‹ÚÃ÷ú¾ù»s¢¹C‰Q®.UX‰è@¬;²4*¨LjS‘¡P_¤R¨•Åš"U¡!yXXŞº†ìTEåÄ§lÚ‘°ºh•6Ç˜‹\ÄºjS›#2â¼÷Mãßˆ»ÃŞ‰vT™*•ªœ´Îˆc+ş‚}p˜V»İír»íÄc/5{°ÏèOÚU@DÛL6“¨t;Ë‰ÕaqÀA˜px†4MzŞqÏ¬ÀN¤4v¨kôõğ¢ÙÑâô—®;ÒÓK›u7±êuq51®H[9ùDø!CÁ`î—–¡;)Ä6ƒS%QÁ¤Ó$<ÁBÙó ³B‹`„Ö\b6˜á‚{¡wsİw—Õó5H«µeJè¤l¦İehŠ‘«t£V
+Ô£ÚXct› €Şd0ö§áAI´QıH~ÉÈ~5R.*´f8ªÉ_h²Àæ B5]ú^×õñbØ6ƒ•- ·3B¿İM¨2t7%ôkº€ŞnµZl°Ã¥u¨a€Ád0±Ål2{’]$L6HŸd×éb6Ùj²š¬pÁá€‹?Æwï…pOÒÉâ‹ƒìIz-¦“fƒÙ 5´Z¨¡³è­º€İN	ûl÷¨ÅİŒ°¯Ùv»Á`ÔCµCË/Õl5ÓÅt2}’^äs±ÒÇİHö†ÿıœÌGÿä] ŸÒÛÄÇdkÃO‰‰]†¯ª%4@ï	„‰Şb÷Ğ²PÑÓü”iêIö§¬%ŒM¼VÜ%9ï?†kŞü Mªo¾Úïo»¸å*}êÜŸ¨@Éå^•­	[%Ó*õûìº5½Ø×½{SÕùK¶¾œR—ßä¯©k’¢L×¾ÍÜÜyÀÓràXôãÒØ°†—+Rˆè ò¹ÙDàéoe§qı=µDT ´E5G€ÔŸªøXÊ‹*Yœ°}óÎÎƒ¼Ñ{™Îwá\¤7nü?xƒF|%ó‰npëèbY¨.EQR¨Q¿Œl¶7ˆ8:›JNâ{BCç|Ä„Lğüc¯9kugÙ&yS¼DÍ‡¦†·»ã+ì}ó±`Ó3k_%l-KŒÔ™„ÎÈöMöï¾L]—C¸ô‚é>ŠÛõùU‘X‰2v>š´D·ğœmÎE{Ÿ¾{ dÖ÷}ÓvÎ~	!óÊÄxK•ËY²Ñxİ'¿®<‰«838ë¬¥ã>pû@ÚqV^;³ta­y?»B×·d6¦¦ff¦¦6f¶´46¶H„3²ıtÌßè
+/½órøÁï¶hŞÑÏÜ:ºMLÇÍÿI¶`GA\<¡Âê´íš6:ñİ¯Ê»F
+¾3äª6ç.C¶9·Ö«­z>w”@] eÂäPWHœ°XmOU÷àÇ8ß6—¼*ÖMˆÇÊÌÈÌèØŒm /`õ‘ü¼ó{@D¿´Wûó}‰Eñšm>÷+¥äÇëT$Ò¼ã4æÜ¤)¢Cƒÿc0
++ócŠ>Ş³ııãÿÏÀ~à?ößë
+ş‹FK¸ó´ò|§£÷ˆy#)Io(ÊEşúN¤ÃĞ„:x-.Oñ~ÙE§	œ~X`Cuqi>2Q˜mÈ–w§6oa·°ÛØìşYo¼|IZ‡ƒ¶“ç]‘‰ûÑ‰††ª¶ê®òÓ aSé*1´F­IG6±ÆÂüˆµ;Ò°	Eo`7¶Ñ‰ıûº{ğ*æCKxWø†Ğ{›hØoúÂ{éØ'¤®.úIÄ)¹mt‘Ÿ¬¸tO=± Oš¿‹¿O8úğı‹V.Jôæµê¼-·¢P8p¶¼{ğF6æ Ø¸*#"eK‚AfR›2¨MJˆÒ‰jI_¨hXùI÷ÒÙ”%©Òx®:şD§.àÅ.Ò•^—š™T1ûÚË4XB…_}õ£”O¥ôO.;7˜9Ï—MóÅ¸-aupHT0@]LØÉá$ÓZ`® Î¨|^’“ºÇz½èÅì1@NØóFO—ôó°bf 5p·„3î¦gv‡p«†RGµ·
+AMØÿ\+0a€¼Ö†N»ÕEè¿¬˜-|¶!Bö ½óx'eWÄ°ñº›ÿr>U€®"tRèªO¨‚ÿrDzÛàĞÙµ¼=^z‹fã˜la“ÂÀ¶ÑqLAEóêÛ
+¯¾DH3G³àĞÕ¡¹bÀ£¤ ÑŒXÄXã …È…ÆnpšÜ¦€i(R*Ô*Âd/<E·èÊpT×öÚJÍ¥fT£¬ìÄC$dxÕ*Ñòù°åÒ“p”¸³	½•µ±8–+ĞêL&­nóú­
+“
+È ,G+Ú­tc·¡ÄQ†ºÒb3¤*s²~TUV••“iĞ—û©íE¨óò£õJ“Ê„|RìMBÃ­N| Î2Ô–•@-]f6Zó{Ó7ï¼{ƒkó·4îj<i-7»Z"üm¬COˆ]:›Z’TC:oMÑ*§,5Ù-Æ)ò³2ô:Â
+YC
+´#»ñ J+JQç)†AÂÂ‚ßÎ_ñûùÛTn¡Ù'³Áªä“uû³N®Xk2,0‘<5r•€”†[é$ƒÀY†:
+yR^Şå[r,ZÊàtwÚëI'.°×š­.7¡fº«¢BĞÚÚŞñİÃŸNö³9t£—{ØKí¹á-ş7ÎÚOëéå½¢*‡&rD|4½"_&Ñy­[íQú2°Ë7Ì{âñåˆ¡ó‡î˜mì(Õ˜u(É¨—öô?,rÇtã,êĞ4H§ÙÊœÕ¨#ÿ2|ÓÓò;dÈ(‘)â·°pd \Úy]KÔq0­'¢(ÊÜ§a À¿NXlV‹Ãg­ »èƒ‚n|¯ŞÓ_ßçi%nŸ÷sôáŞ?'õ‡ïÿöù.î¶ë«:E¹¸±â£Ë«£$›•˜#ß³­u»œMLQTÀ*-‡Ùf/÷]:½÷ ÚÑ,ÇäoR%Œ ¹’„Äua@
+r*ˆèÊrkÄ›_™•–š»éhÖI?ö´øz×¿!ïáeÅ)z»¿\ƒ´&¾8gÉÊk…œfìBSãW~RwqŸ¯@;ê‹ˆèb’ª8r’]]Ø ih¯í•
+3Øûµ?7'×âè´»óÃºù}ÑÍç¸cÜ=âº‚²|‰y:eA«NÒå’œyQìÏlŸ»p)Şª‘`°átëE"úöHY›½ÕdÿÎîu÷ogSòùS–TÀl·z|—÷îîA5\Jd"K•­SÑÍç¶0aI,"­»“½ºfô «²½U±V¹)=9*q=ˆ[‘ÓND??7èÀ€´¥:Jd‰¹Û6î=/ùtâ¥ ½|Ã	G™ƒÙ£¥9ô“/Ë¼Á--t×µn7AÜ™ÔºQò
+"6ç¥©÷ÅµmÅ6äE«äòÅJF¿÷R˜Í/©>_·¿Õ¨P#9¥bYÅ
+†BmtW¨*Q†—³Îbë Sl5¤Ş!°•û½.gKÓ^4¡ªHÑeg"cÑ5ûº$|(õ¡Ñ×Ä#¡sGLtgC¼è×é …gCtüœOøĞ¹j4t®šÏlüœ<¤‡Ö®sğ±™ÇC¢ëtŒ·!;©ô‰{ƒûÎÜl
+¡¡E£á4/¨3Œj“Ò„<¢,Eå~³J-1ä²ğaƒÀ 4jP€Õ}ñh‡¯®º«fWÙI~%øŒ3šÉIş+y¯G!hCÍv{-na;üÜ;]Ôè¾ğ-ıòÛî‡¡	âşÍ¾’l–¥oÊUoÏa„<š«@vQ9j¤ïã‰á.;Ñ 2ä•ıÁÇÓS²b¶d”œAßÙ2o×Ût¢¥Œ¥oş‚ºrx+Km "W¿«ÅîõÖ7ğ£¶x§ÂíˆW7·6ì’ŸóäpüÁ»éåë!œ›+>¼¶~£d¶çDl’Ÿz­4±e¤eE­‚¼£¢f«³™TªØ&8³‘<U¬&dÏIb“z…V²kJªP‰:·«Îâğô9|¤™	Ì†/-v‹«å`[£ÇÕ\·¥ğ™ê¸àøëM"¤M¿r¯îı“•gšC†®ü«p‚AWX¸>éÅµÈ‡¦ğ¹İŞÚÃ½4ÇğVTïs ÏacDìzS¹¡#­QVŸd—a6/ÏÏÒ‹lİş«Oy¼âõwêQŸ®BåÿåÓfKÙ€ÃG¼_
+^‡×Ş@Ê
+*G¾úûàE"dš4u
+IcDPkÒªõ¹ª„ßLàğ¹ÚÈIªXËĞñ4{áI@VG²ĞÜõªL½¹dkgüÀ×İô~—DÈæÿª‚µCOˆË”ĞKØäQ!Ë'.7j{›ù¤ƒÑ¨"ìîá.*ÖPòH–
+¹Ê2X¥ôN+ı“Aàâ“­ÙR9tÈµäXô6xà²¸,NBÿÄµò‚¹ô/ .ÔJ…¯—\Òø©Ã¯¹N§wÒNÑ®†{^\¦€¯¶Œ:5=’¼-§0Å(4§´Ñ”„lgÈ‚usST¥§´Œ/ş=•G-Uh@“¶Â@Dío;áCFº\şÈ¢…¯¦ËòrW¾ŠËaC),»‹ˆV4ï
+4t •¦f™)u…m ?¿M't”)ÍZi1Œ:½2oÓë™›‘™]æ ¢­ÛJÕÈ‡ÖÔÔTSûé;õÕœlñ“S'wBÒ1Ù¡Yàƒ_qÙ¾êö!óĞr±ÕèTI0™”JòÒ³UÅ¶XËdÙ,ƒ²ùôVLgI?Ç‡=Gú¯}Rı¬(-ød4ªU©Y/.YµdÍŠü s¦¦³¥8VOŸüŞrêü×¯àGœxŒ Ê`B	J<°¡#¤BØ9êî{Ş§ûßşÜÂ}Ç‰Ä0•*G]._‘¸hëëäÍ0:çÑÏ³©l2»‡Môä¢%§ñ^Ã‡§Ê×·'ï9x£Ê©µj¥|s€dàß¥´ìkzk=½…×kY·ø‰gŸUFa%Röá4Ñ ¶Ck;ñÀîÄBÄb•%Ÿi~O0'è	Š¥ÖÑÊ˜õÓşPşß’°~Öö{'Šö³şPşß’Ğ~Ú6Ú™âÍüËÄl^íB€h xH94]lmÖA2¬Íå0µİ~È¥ĞÃ¨“6y¸éwN£D^ñˆ›O¶Òwj]Z+¤³YÈ†2KªÕ0²äpÙ*É›Ôò-¸
+R¥Ğ X“bÔ™´ Ô½ƒ‡õV{yƒ¦¬ğ%>Œ>Òëô9³äO‚ÌÆê¸;Í¶>:9”NlH|VŠ,èéFO ³jÜğÀì°Ôh+nFÃå¯z|á½WéÎ«¯|)ú…ÛFwˆ©èñë,D²±s·Æ0ê ·u’4¢WëM ¢áÂ(lOn,ôVµºwŸŒØ?Mbw31Ë`u”¼xMJC¾ùšN–Š~™cc6åÇ¥¬Ü¦ËÂ
+¤œÔVÊğjp©íû/Q…~^%5±ØˆÍDÈjAÃ‚iœ?„ªâ73¶%ff$'5dt6VWA‚µ%Ë—.×ëèˆÆ¥qT|ú'>;"¾iFÀ“~ó¬è"çº#‹lÄ!LD—
+L–‘Äk;²ÔuúP¯¥ŞLa©Ò‡W-Ef’Vk*UBÜ¢bµ†°éL.K ºÆîı]Wÿ®¢ƒ­tÌïJ?yCpqzïÈI^¾>ß!È*hA‹©ÅH„3ØÎºúÄåŠ¥7Ü8÷ƒ×[iÄ‡#‹¾©çäÜLquq[´$ÚÈDô“2²=ÒšG±d	E„7Æ—CD_+…òDÄ#¹<&Ë—m+ó“v Š,şn-Ò[ÿ~è’E‡6ú×ûWá5È°3}]ŸdË	 64T×íNÛc¨Å5œ;‡‹è.è–5tutÙk@øÚÙjRêuJ“üòâ*Ii­³AÊ^dAb¤›’
+eêâ¬´(ğo.¾o¢ÙÜVés•5øyŒEDWĞ1ÃãÄë^ÜôàıK‘ WwŸ•œıŒÅŸ¥BÖ$ŒÃ§ôÛ›×ºÂOß¤êo:D78}EœjÈ.y]Q¢Ö>‹"¶"ôÆµNÿÉ"âŞ?qîM|Cè„éï³Iì¶§æ>¶q¯®´±¥º«FÓ¹A8ÿw ßãğB<¹¯.IŠ#LËT‚ŒH#Ülsù‡&úÂ{fõÑ¦¾¬ƒ¢cÜ6úŒ]Ê}1½yõ¥Ë{ˆèâ{İã,¹úø±Ù<ıü£È-Û{·zŠ»e¾|"º²*õÏk0“LÿqÙ	|sùg©èâ‹ôG1VGoYOØm	¶µê;PMN½Õ{^ráÌ†ÅRÑ•úa±øùç6Ìÿóâ7/Kp¼íÌ§„N\(ğç¤à5"¤÷fQ:ÅÏÍ÷‡íš&F€İb`·X‘,ø	[Ó¥^ÄnrUU™ÉœÂMn	­D©ÒÔ`0óÅápmX:¶ŞËûİ-Vzï˜÷b YÊU‡Ùuf“MK¸G†¿¸‹Í&'HœµRî@X3~’YÂoäêæÙ›Ÿ‰öqAÜíâ¶ä–’·¬hÃ÷¤ÿ	K…Z=@Ï¿ø}4L´ï»Ş+ò€“Á”[Œ’V_è•ÔøÊÚ¤ÂÍJ¯2Àİå¥±üåÚq™V¥rwÂ^R;HÁı] Úû‡«%‡¥víhZÂnñ 3ÑßfÒPéìëğµ‘—Ã¨x,ä0*óS¶lÏŞíˆkÊÜ•±Çp{Ğm9Ù²¯>°«}¤½…í|!'Â—Kü½_Ó{şÒí?ÿmáºğÌk‹nr‰ôgñ[‹½¯±Ùi,,Y‚ØúÌŠâ¦Üı¹b"ú¥^¦›¯Œ‰”EgoF1¢°ÚÕŞnóúà'>yYNjjVÄÊ3±ßÒ4|·Wï¯‰uª,2›ÖBD7cr¾ÇĞPÓì­h®î´T£‡Ş„mArIVª\RºËqH*¤†Q¿øeÂĞ\¾¿ –dCfÈD¢­q|vø®xnŠ OÉÒêÈğŸØ‘èûw—¥ôˆÏ:·Ú¢•²I&)ÍòŠİ¨“–£ÆTfª2:Pş§Ãï¹Kd=cxá5Öƒ8ËGÁBlj¤p:¼ÖJÒCçĞ)¡„yeé|Çƒ¤ì0©”ÊQ&!éA¯µ^¼ vŞ€*éN³Â]ØIØú±ÀdÕó ÔTz\„.¦w¾>·ÛÖjuñ`¨†ß-ù]ãäî»E"ôqy’"˜ôšôâ­y+#‘MšPíêr6öÍ>Oìà¥0b¡IU'‘,Z ËUÅMyÉQë^Åà-Ôà„ÿ¼ÿíuÕ9*QEGtl|`;›Zğ)ÜøI_Ïîß¥°:§$‹ˆş²IŠtäc[wRKænu'N£££½Í»ümc:ĞTWÛN¼»+ÃJ„´¶ş2tf
+›'†ÓàĞÚ˜‹®eË¸>pñ„3„‹§Ë¸>ê¢k6«NxJJ•ĞAo4Y=ÛÎŒÃıVaC†Ô8ÜOëÙv«Ñf´ÃƒÒRxø£pšC¸oî1¨`F®ŸÕÓí‹Ş¢ãâ%PBcÕ:ôÔÅÖÒeÃ}5Ï–÷1[«Õ´Ğ@YZâ6‹ÕBëévjäúÁ)ˆp†)‡ûìbğQŸË÷æÕN>4YÌô¡Lc¹¾–ÈÈvú °V¹O——9—PB£ÀÆ²ÇsØİ‰LŠûH	¶÷÷c_©äPŞ°¾á´5T|Ö÷&¡wÓÕ|±dA=Î§³Ï„p‘Ã<Â´,lÚ‡i 4ŸĞçÂ@ó¯Ó vÃj±Ø`ƒSëĞŒt²ŒFö aSY˜°çÂÀôt*k£°‹‘ïd9ùN–“·ôLBç‰GìéÙTÚÆ !/ì5|'K½Eo5Òi3®³ Xş¨½ü‡Y€M›a0õĞCãĞ:G„½ÕB !t*mÕa|i7éx8½r0ò¢èSî÷°¸1yöEh6b±5>:ct£ôÊ‹Íá:pñ8ê@…&±	ëØ„ÈÙêB¡A^•šGœ.YwE?,åÉQšA$²™ªXFDçPˆtWBi„G[‰:Ô× X´Dôiê{x~qzZŞ…)?@õÛ¸Ğ¡3“¢¹ï­É[‰””£Ş²W'ñÓ µ²t—­ÒŞPºğsEĞ!Ã¤N Ï±AIµàl@É>tã¨ÿ/MçÊZG†>Dşéó}¾«{Ü¨2!	™ÊTmaìÌœW±œ“‚œE×¾j¯gggÆŞ_Û	ä×~‚ş5D¶Í{J/a“C3`Bq~{!wZ`h0"ƒï=„æ)ÿ—Ğ'vJ¢ò“6Â$W9.i:­íè@—¡ı÷È¥‘®6+ëĞ 'ÂõšñÙ?‚–b³²8<v'áfM0ƒİ3üî§·Y{°×°ÄñoÑÔ6Ú¾kDîZJ? ià?,?òş7ÁÃ÷}ûñ·!ìØ@Ü˜Ó,—eËê³š5¾	]rÇ{MÈ&±HoéçŸy¹ŞğÊ«	ç©ù“—ŞıÄ¥rR1ßÁ‘ˆn– ]£“wÇ7E°Pv›Æîyêõ÷¤'00Pê!fS"›,Ğ«fNGÍin"ú¥ÕíiB5©RÖ¦g'É£vvç^—ĞÛñŞ¥Ê“„†p¯Ì‹N2ÿ51tF­IO¶°5mF–,;/G,Oı¼©ğpû[è­Í‡šìíéÅYT<ß¤›~mRëè²,ÒË%{+¼4Ñ[á½”ÜpÈÿÑ¾–7B¸ÕÜqS„9Z¢@&2t·ÑÉ³@{@\:»Fm	r…fı´”¥ğ,bk"Ò‰¢DÀ‚gÏB¶4§Ym‰nıi'3-8‘U©©Ó Yò”d$6*]Z›É¬Q5úâ#qGßì=~@Šı±5J;y­AëÊuå8ÉÊFÁöš”ôbÏîÏÿÚÛ­hE=Hëi|;,ÑR9R[œÑ¤oG-v]ü »&» ¾3H3Lbµ¡D<Cé®²×ÃƒØL5:²”ùÄj}‰~² ‚ÜÕàğ¢£…qè¢“ºÂégŸ.¼$:Ç5Ñyâ.Â­«‡3[R=JŠûëğÄ	DŸÒù¡	(~Z’J²Ñ‡õèJ‡ài”uH?	[Ø%fÕ ÕÜ0.·í]B§7Óæ–ğA²à'ºùÛE?‹~ä<ôy1.-¿ÄÆ4ÑÏ7víú §È_fŸ`!,äÉu¼y­º¿-¹õÉ–Î¾snìÃélÌEdÑ¶ŒäÄ˜4ã&ƒÌh„ÎDPbT¹Q-]:ºn»mqì*iğD°xÚQOÚ2’ÓÒòwÎúûkt‚„J¯_û^*äf`ıàİMhñZtÁüÁ!¿lâ+Åh¥ Õ+³ìØ…è+P{yÍ¾²À›8Š*ôÆ¶üòÔŠ­˜ƒµ¯'Eª?}±j#æaÍÆ”(Í¹×½;±YÉŠ,’[´úßácå‰Úÿ'{¬AU¹İmw»Úìõÿ¢t=WËÏÀápæÈƒÌ (ZC"Ù3|¡Âºÿíí{a©´8xìÂº™X¹ƒ…D*Óô*ä“õ}‰‡¾ï£’J‰ğC\çúÂ¿¢·ĞæŸ#{E×¸Ïè:qd¨!¯äÕ‚µö)‚°¡g¼ôdığå›=›„NbÎ³{Øİ3>¸¡OUÑÜV³G‚®Œºd«ßñÖ·ñ->^…ñÔªåÏ¾B˜E	JT&˜4$…‹	¾Vâ§gºèğéè¡ø)NW ¾EÇ>ÈbsY=“³qı^¥ĞÇiÍ’<wBŒhõªœ§+=D“?û†% A‰a)â4œµ.esò†¨­XÕ‡ÄÙÚK¥İDÈå¡‹£]ÁSÆfÍWC.aSBSa2)òÈğÃoÏäN
+tM0§€°{F	w¼Ò*ØPc¬3ZŒ( Ñ>l¨
+ˆZaÊ¹¨BÚŠ^[q\ßb¯„·\aVI—[Ğ„
+Ø`·Uñ1¼ÅŒŸ‡o¬r‹ªpyœÂÍ
+1›ØôáÓu‚Q½D^Œl ¨JZ‹kÈi³Àóz?ˆ£ŞŠbäJù"_nÉâiO)ÖR³ƒĞÉ\£Àİmq½R_z©æöscúcaeJ	ÛK÷†zŠİJe1ÏÂö²½aJU±Ré.öHé^¶7TY¦òxÊx¶—îó¸Ë<R^$w]ıkw¯/¼÷ËW®ÒèQô‰˜zYØ;KÖb³|ÇöÛ³"ñØí_<HÇâöô6'IaLqÏ¶U’|¬³¤wÑÏ}®–ê@fevAŠ*zÙàÎO¥TL…t
+M’>vU</á¡'$Ø†äÓDô‹¼q ƒ¨ïn>¸«¼ıhO¨Ş^–d[mDøTmşõ-ÿõ5ó°ÏíöğÿKÿô×ÌÃ¿ÿÆõè]Ğ“ÚŠl
+²ıîYşÿà?¬ÅU…6ÀlvV‘«4Y`±[İü¤6<ÅPÁ¨5j_a3c—±E ìşÿ4ömú‚O‘#ûò$¶iùT«İVIQ…À¡³køAO­¡8g‘<ë1YàYıo¬oz(¶¦Î—"F}:´&?±üGÖÇ>¢ãzBè,_üËÚ°ßWëŸkÃ~£üË‡ÁCM.1 «ÎMØWCO4åF{>òaÔi„}õ§:¾Å¢v J2ôJh•.)›üx¸´ë‡^R‰‡÷Ñ2n-4zò»dJ2|‰ùùjdV«	Ç?÷)«»2yµ’Ûÿƒ-SHş1&T1êªåÒ¡1¡å#®—ÛÆ‰ı4¶%|ğ;ªúféuÑÎ3‚)ïÿšİ"Y€ˆõÙÛñ‰óı]§:»Ï =êºt"âdÆœ|¤YuvkkM]ËñÈÃ3Ù½ì6™%±2*\HÇH¨ğæ5z§Ttãá;DV#2=:3>)o36!º%§¯°U}'ñíñ>âY¥ÜKcÌ‘XE„z¶~€JùÙîà¶ÃÜ]TÂ]¦=b:ñ±Şy’±!º 0fğe(‹Ôœœ8Y”btà'±Á“v»ğÓ¦_İGu>xP¦G"
+Eú"Ânè‹ŒF@kTB’/GšÒ¥öH[ĞnmE'v:@œµh©.0—H‹P …™ì¥/*‹Ú³€Ğh}œN•2Á16$°‰ÑÉ/l–íy=sÀ#µTœ¢6AKÇ@`?Ş„}²‰ğÍ=´ˆÿşx¨ÿšõë·.”İüS	½ƒp«B›táU¡¥ôü½„®ûÃ¹.”=Éîdw²'Ù“ôNv'}Rúëv©Ş‚NÚÖI;ƒot^ë¤«:ì¡õômqèC¬PPZĞí)t[ù‚ˆJBk*ù
+Ù¥uª,±®Íg3Û4¥›Î.£AWª>Û:P){`?»UÂŞ•@_×1»f“tØ¶I§Y­ÎC¾¼
+5Ú<bª:ÊÕz×)]GÅşnëôa¿öHÒ=ªï’q?^IÙxoaëh‘¸ío~ÚÏneâä<ö¸„Mao‹]5ğÃM8KJÑ¬®á•¢ ¹($Ã0” İ%'§mb§Ùfv¡^K¥¥2“±%—ç‘‡B…1£¿jèû9ùGúâÑnı§ø«¥@T\d‚iõÅn]¯Ì%G.É^ÅÒØ-‹q²F‚ãşmÑ·®:«Uÿqº¿)¯ù×tªAMD7¶1R¸[ÈôÏÒ>—Ğç.ĞîÏ¤Âÿòß}¼óöpKÄv}y‘XY”œZT•Ğü:{±ÇÙT6ñjäeé~ôÔÖ—“öˆ@_h2iLJc”|_:­NkÈç›O¶â*t ÛÚ	Ò]ü8ÎˆŸæ›U¿ùi9gCoÒ˜d%+èòaT–$%EÊãñ*tƒğâpXµ;pá€oN q+”DHj:&Ü{„¦İ|ø:Íz[tmh)ı§]ªÖ´jµ½ÄªäOYY«,ÒòLÌUP©òË3@ …Ö¨‘¿°tù‹ˆ@\u¿²ÙÓâlµ8ÌN8ĞXT—	"º˜ÌtM
+]ÓÈ2dñ§eÖ&¦FÊ#ñ*vöâJÍ«§òÔ®c{‰İauÂ	·Î­¶ë-º‘a¥N£ÚúZÊÒü%štC2È£}/|%97ÚöîoØÒ—t4ŸÑñ¿ş ` »Éè¯wj®pézß•oğ‘«ô«!Ü¡ÛÄıÛvJ°B2S›c(ÉdádÉob¶VzÏKò‡ògo€ïÌ×ô[İ]¨$ò²¼ŒÔì˜í}™{$o çDÍ®¶Ót‚ÙINÒw?ƒ 9*A¾t^¨ç¸Éè9n«¯8ï(s×VWÖÃ†&ÔÊ#ô%ñ($Y5ÅµM-Ş]áSî:|=˜®¤a!ÜÜƒâİq¼êş$4;°~K|RôF” ˆÂ•0›İ]gQò%â¦G³029o=”HóøàÄ!”%t€¾
+A=ÊQUYW¯ìÙ4åÛ./-óºŞ¦·ûhYSÇ½(.UßãU¥lÉ)ÈD&Š+«óòëAÛöhÎªuKİ°Ø-ÚşãfêQ«iP÷zĞ„¸O-Î+ s,]¿šÑ.»‹ÃÓĞÙÚÜ†”ª|©Õ95- ß§¢f»Ş®æŞ¥5h²^Y—ÈdgBy¡-€*Ãàñ_W€ ovu}sÍ»6"œ…îÊ@0wzh¶¸¬ÄQ,‘!Ã(Y`šgd İ"QÊ‘Ê&i=Ù=Ãoô&S©Ø(‡$'47©
+Î#õ¡ÉâùØ|Ù$hB“ÑRZ‡–š|äKsB5H4+Ì„ÎàÎ
+lÕfs¥Ò\JúĞz˜Ív›Ãf­à§k6ª»èê.údWğJ}'C8×U±« F%ÑÂhĞ¨×­^˜½‹‘Ñƒc¨µµ{ö¾Ğ·ñ–£·âÓ–Šch#Ç×îšÏ^f“Øíì1vñ:YÒ„sæ“Çzö Œ,¢UâûÙÃxHRs¡±¹ºª³³ß éÚS°]*¤wÒœ/B†ıç\1»ŞÊè\6“[	náH¸qt&·’&Ğ¹6«ÕJÕ®èGá§Œ—şÃ«1<•“0O¥‘Ã«©Œ-àá'ßŸw¹PJ„ôNîé/B8çñˆÅ©,’[ÍdtO?õ(Zh­:›&°¹tæğJµ8Í^ÉØ\½ÁÀô”¸Ô¥°ÒO]@#¹Õà¦!­ËïÊ .çĞ™ìV:5ŸÎPî=>´š;"ônØPT´=ùFğ-Ø*,Àaéƒä«¯1O*ê§K‡·‰käĞJòaĞéQq11¼‚ôà *ÍUåQ–¥ÌZ7vçì{¥‘ˆdtéş¶opˆ|?í{HÂ¾qy9Z¤õ¨5Õ›Èï$7æ›rQ€¡7óãBzÀ,¯Ç¯îtÁLg.¸`wÚí–j 5EHGòÌ9fr¶Ğ	ˆö´¼«yNŠ"UœFFDı%‘úB{èŸÔ‡%7»¿¯’
+ëá~è	àïC†–R«‹Ò^Úº°-tä&Xï	‹È½4WÌ¶ğ7ºEpdà]ÿ‡øï¦ÙJX.İ$Øz$í]|ˆıï!Ü³ÃÏŠ×o})má%ÿú2b~ãÓUlÅV±Uly¤³Ø,ºŠ®¢³è,ºJÂ³Î×L‡p)wtÅ„=€òv)w(¬ÙhN“,_1Û´$.¬gñ†Ÿ;Ã¡x@J—ØÂ¡±•b—åjaQtä&p¹P®vj\
+¨Õ„Eñ7%P»Ğ¨Õ(\jBG^eQµ
+—Æ©.‡ËEFßÏ¢.u9œ."d¥—»+|út½ÌÍãñ¥\òDhaç¡íÈŒµi&U<‰fOÌ‚ ·yÅ.ÔI¿]Ìºõù“u»b<Fïw•ªGF_LrÇ=ë3~¶§­š¼O÷=î¥BöŒ;‡¦5-!œëwİš‹hDlMŒKÛ~âà4úÏ­.ãAö¾@_¬ÍJgí°û­•ämú}‚Qœüÿ Ú|>v
+endstream
+endobj
+
+265 0 obj
+<<
+  /Type /Font
+  /Subtype /Type0
+  /BaseFont /AQDNYY+NewCM10-Italic-Identity-H
+  /Encoding /Identity-H
+  /DescendantFonts [266 0 R]
+  /ToUnicode 269 0 R
+>>
+endobj
+
+266 0 obj
+<<
+  /Type /Font
+  /Subtype /CIDFontType0
+  /BaseFont /AQDNYY+NewCM10-Italic
+  /CIDSystemInfo <<
+    /Registry (Adobe)
+    /Ordering (Identity)
+    /Supplement 0
+  >>
+  /FontDescriptor 268 0 R
+  /DW 0
+  /W [0 0 280 1 1 386 2 2 678 3 3 358 4 4 562 5 5 332 6 6 460 7 7 256 8 8 307 9 9 460 10 10 743 11 11 510.99997 12 12 460 13 13 409 14 14 562 15 15 486 16 16 818 17 18 510.99997 19 19 537 20 21 409 22 22 755 23 24 510.99997 25 25 716 26 26 422 27 27 716 28 28 307 29 29 897 30 30 460 31 31 307 32 32 729 33 33 743 34 34 510.99997 35 35 525 36 36 767]
+>>
+endobj
+
+267 0 obj
+<<
+  /Length 13
+  /Filter /FlateDecode
+>>
+stream
+xœûÿÿÿÿ ïõ
+endstream
+endobj
+
+268 0 obj
+<<
+  /Type /FontDescriptor
+  /FontName /AQDNYY+NewCM10-Italic
+  /Flags 131140
+  /FontBBox [-25 -250 1002 750]
+  /ItalicAngle -14.036209
+  /Ascent 806
+  /Descent -194
+  /CapHeight 683
+  /StemV 95.4
+  /CIDSet 267 0 R
+  /FontFile3 270 0 R
+>>
+endobj
+
+269 0 obj
+<<
+  /Length 1110
+  /Type /CMap
+  /WMode 0
+>>
+stream
+%!PS-Adobe-3.0 Resource-CMap
+%%DocumentNeededResources: procset CIDInit
+%%IncludeResource: procset CIDInit
+%%BeginResource: CMap Custom
+%%Title: (Custom Adobe Identity 0)
+%%Version: 1
+%%EndComments
+/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+/CIDSystemInfo 3 dict dup begin
+    /Registry (Adobe) def
+    /Ordering (Identity) def
+    /Supplement 0 def
+end def
+/CMapName /Custom def
+/CMapVersion 1 def
+/CMapType 0 def
+/WMode 0 def
+1 begincodespacerange
+<0000> <FFFF>
+endcodespacerange
+36 beginbfchar
+<0001> <0049>
+<0002> <0045>
+<0003> <0020>
+<0004> <006E>
+<0005> <0074>
+<0006> <0065>
+<0007> <006C>
+<0008> <0069>
+<0009> <0067>
+<000A> <0056>
+<000B> <0068>
+<000C> <0063>
+<000D> <0073>
+<000E> <0053>
+<000F> <0079>
+<0010> <006D>
+<0011> <0070>
+<0012> <006F>
+<0013> <0075>
+<0014> <0028>
+<0015> <0029>
+<0016> <0044>
+<0017> <0061>
+<0018> <0064>
+<0019> <0043>
+<001A> <0072>
+<001B> <0054>
+<001C> <002C>
+<001D> <004D>
+<001E> <0062>
+<001F> <0066>
+<0020> <0052>
+<0021> <0041>
+<0022> <002F>
+<0023> <004A>
+<0024> <004F>
+endbfchar
+endcmap
+CMapName currentdict /CMap defineresource pop
+end
+end
+%%EndResource
+%%EOF
+endstream
+endobj
+
+270 0 obj
+<<
+  /Length 4349
+  /Filter /FlateDecode
+  /Subtype /CIDFontType0C
+>>
+stream
+xœ¥X	tSe¾O·|@'HKŞ;*&7PÁ"Fì ;È2¼Ò½mÓÒ5]ÒìÍM~ÉÍÖ$İÛĞ=méB)-;2(Ã2:êÃ|:ï=¿Û¹™wR`Ô§ïŒÎ;9çËÉ=÷Ş|ÿå·ü?±hâD‘X,¶&¥héê§œ»<?!S™¾ËßËÏD¤œ¿O,Ÿ"R ·ÖÈIÕş%mf„hæÄ×˜ûD"ñÄiá5iú}"Ñßş9+üceäƒá¯¥‘‰$bq„´nIrvbÊòäU¾2¿x‰*?[¥Ì‹Ù˜—™¥ÌWæÍ‹Ù˜®Ì‹)ÊÎÍˆQæÅä¦d¦$ä¥$Ç¨’SrcòÓSb–mÚ°1æ—Ùªü˜UÊ¤U^JÌÜ¹11y))1éùù9‹x"¿ m^vnÚ©Ùªü¼'2oİ”÷Dø¹¹¿\»fãÜUË—Æ®Ù;/_“š“œ’Ÿ ÌÌ›'M‰EğŞ£Ê
+‚üR?ÍsÔ#äS&nÌœìœ‚È©Á)AÎîê"#OLí¯³;íGµİù3‰H,‰D…s6ÃØÃ9ºO$-
+ç`r”è¡ğL•‹³Å¹0,™#éš¸lâŸ˜’ˆÅ»'Í!“É™ÉoO	NùzêpäÔÈ¸È?üL'•şfÚ–»¿+mzìôëQÚè¼ÓfÄÎ8#›=%:‡Äô£YÀˆ¢Õğøå <ÎBïåûo—»òH“=,Š$$°‰HD<—bÒ¢¸ÜƒÆ”(ÀZËm,f2ÆãË …ë<Vb/öqƒÄ»ÄS……´!z*D»CâQE¯dt)…Ì¯+×Áf3ä¯äé+„ù ‚4"œG7ç³»ÉÚ~ÌyOi&[™QE`5²ZÜ
+?8‡³¼Fs;çğhaA9ÀšÕ/©,Âijc¼İ{7AE-Y/)c-gól6Xhıp¢v§£ì¦±×jF!ÈXZD‰şV´'a4( -eD¸g¬›1*ÍÆe ¥:¨µ•¨Uğy°Û=5ä4›±;8@¤Â¯¥è‚üÜ øJm8Qº·KÂ_¡È|F˜äå€ÕRfÌÉ™³…°Õ -¾Vosã±A:'ñÁÆà6çğ«µåjÓ!eg<ÒP”_š¥N*_@ïƒU°Û]AR±áP­€
+:”²jK)yQ8ÆXÍ¶
+°ĞyË@ÇÓ@öÒgWĞİä
+V½®£ºyøw±8bõaª&©\ÉPHv´§ü¤‡ÎqÉ¥Â]¿;$¦SOÑY{$”¿‚°‹‹•ôâ+ÈZPj=íäwôğ50u~4(U<>:›qVÃšJ\zäB_h)#ÉÂü`Jî¤ñ–
+{›ÅR
+ÙÚtô¿ÜÚ@œ.Hs‚ôù ˜F\ ı>ıK™Ëè7Ê-°ÙŒú%sŸ¶”`t¿Å ú}Ã62Ñ‰sÜÁ†÷»p2’:°r–ğÀÃBìS|Jg\ùÏy<õÊîÃNyaÄ]øçÙ»;G©=ª¾P$¾qê³	í¾oÌ`+ˆ)—)‰U'dcĞ†jxPãn&ôşü>¬4sF°ĞÛX™md´6j¢ó¡ú Ã¤gYäÂô1–±Y*ŠP†W{S¢mU-u{ªßG¤ïœ›7£®tNx-•Š×uEÿ…^ı_í£Êyl=ŒĞØÑ†Öªîª>ò&}ñu8¼h ¯¥´¤ÎU
+s*ÂÍ"¯‚İá¬®ìnıä$üğW y:•IM²¦Îf4)ŠHrsâQùnú¨Sıç6>]ÖTÌÊÈÈÌ(¨-ìwu…ºR!NHÒ•A~V0êØÕœóÔò›èÏø)«dTÌ¯`œ5pÀy«ÌZä-*MGN{<ˆ0Q˜$Ìî_p`Ù;Š#Há³Œv«¹0[™´=	e(G&rü$ú«Fo 	u¤ÊĞ°«8S“œÔW|UşŞıMÃ»¤”n–3Ö,ŞıÙ&ë»~vÒÉMZï 9Uù¬QÁjée[áè‚x”}F«_'ÏC›‹,ìäT0C¨¡óÂk«µ5›‡r]‘ÅD„}cE[ø&¦ó˜İWn`Xy*’Ø(‘Îí©(‡ZëCµâ0G.956Æ8ÔöŠZà²ûë	ış·ÌŞs{ü}œ×îˆt¼˜ÔU$¦×nó@×Oã—‘™EŞ¦Ã?¥Çf]glV›€®²¬M¨ªãüdˆ.¹Í•½vG}Wc×Ğÿ!„AØy((¦.Ò„k?ŒÁMÈÆIkûªõ`ïÙÃ{†áÇ°µ&‘l5# ¥şÒİmÍÁşCñ}+…»™0KxxöëËÿı"¥‚[<q™Î»p(õî5Ó	õëíoGÍßGŸ’áúâúÄÊlwšChn:	mèÓû“IôÍ‹1z¢s—4×µ†F–“Û,ÇÏÏjÚÍ$úÏûõÃzlBFÎó¢ ë]¥G¸° åU…ùÙ%qkN¦ıVNí§Ò…ô‘‚Ğè“íâß½?rî8/á÷Pƒ¦Á]]¹!-÷x»Ú•YYáPÖ”ta|ğŞ¯İh_¶D]6“¥€Ø4Ì8ŞüàìÎ:r”&1v§İ'`óéQ–;‰ÛÀ$Ÿ{É^aqx™„ÍÁWOæ¸Ù ¹ÆBi˜£e^¶®Ø¯ñ <¹ø‘§_|±÷K9v»Ú8?±»¿f¹V«¥ŒlR«ÉÆ‚…ÙeqÃ»ÃëóZ»|U}›Ş,;
+*¡÷€F©ğ’¹4äU£®t—ôO×œˆ¾©ãç³²Ïy9cw;\àà7Ö!&•ÕH~!`Lª¤µëÃ~tãt÷‡-ç½M®j4èÏu‡w†âç¥³Íßbo¨íÓq¶a±yúMò®Ø]K°ÏœTA¨¹ª*ExnÉ­ Ñ_ê~¥éw) »Ãc¹m¨%M¥şbm²yÃæAåkò/ñÑ-"Rúä]åoëêèÖÕ«ë·ƒÄbë¬Æ›â°Ûv*ÿíûKîbwÿ)‰=G ©ãğĞÉ¶ 9&•Õ@VU?ùÉÿ–¯†èãwLÆûç$¼‡È¾^{h­|âÓTJíÉ¸@î´f”š²‰1Ç3l²´P›\E:¸vt¡‡¸«Æ½¡fÜ>ÜVg-é¥3’–Ä£ TL§ÒÙtB˜&¼,ÓæÆÇnÁzè¯ÁÎÎ9¼ä ]Ïx{Î¼ÿ†á{HÈ¦ªVŞ¦Éq~	\”ğn’}ºîÂ3wxâÁ7V_¡wQE‘ÇÈ_ğ`ÆZÕÆ-qÛŒÔŞÂáV*é:Şwú`ç ¡}Ö©0]÷÷>8]s‚šz¢¯ğ'¿116›¹@³A½Jù ‡MÌ[tq¸íß‡Á0SQ«¡\­ÊÚñƒ`8òO`áz:›;ë7™Ğ‡¦–š©ïœ7’núøa	mL2 N“oÓÆk¸:óu~5Ñøêj»<Î„I‹fa‚°<SØˆ¬«\U¿µåå¡õÕpÃé„{ü•×Kø(~«¯Ş(>œ{.ş¤fX,0°xôÇŸó.@,„™ëÆ&	&!h46X˜œ¬~ĞI—¯ÓYt]¢ñ5‘~rk°}ùŠd´–_!£,úoA&ÎFŒûd/BmãS¬îÛû=MOEĞõtUÒÅÂ~Ö©„µÙöÊK	Ïƒ<ø¹€ÊùÃLåq_ÿYÄå÷ã„UÜîŸÏÏSö\u„şÃŸ§-ßñ¥0)mê¡ŒÚA"L^0û¢û›öòoë+Üs»<·«#,SËŒ«mÄv_G'‡èäú}-§Gb?Z6#°™¬æo» Ñyúûo™€Üà?á*×åLY(§-áGïşåB™1sÍó?¸{/vÛê³}¥>Ô¬ÍâxAhtnHL½Î/IFŒ.–}[Ş :²j	a}íV!QÈ
+­°ğë©œn¦bºó`Xf˜À·‹…é+âYÌ?:gZèS—è„ó<òn¢÷1<C°«"#y˜¸nËªT0ù
+é‡—ªÇ‰oğª„×ğÓdGWøwÊ‰´­¥ºcÉ;ÿ_3S'</9Kk;7Le€íhÔ¤ëØTòJuk}¨z@.=/„Äté ßw4ÜüY²NºŒ±;á‚“„G ù˜/¢(¬ÍÅd°Œ©(‡%ìÉàà„çpØí¾Öôşö&*é‰Ø‹I“Õ`5‡gÎÆnĞÏ)—p)àwGqœ=R@£_2EYD)2,²¹ŠğXËÁá¬&ô~ãéô:¼v¯£uø»5X-ÔúuVİønÊÃÙ!Upp\}x ÁM1e¨DBóÈº5­I¹éªŒİú&y#jı.gÙÏ·®Ü¤ÕÚl°–3yêé4ú3:U.¥ÚÛLp©^VeBÑzx+ÃGŞ[GıŒ·Ëë}¤©õUF”(„á¤á“±3ø“Œ5hEˆp÷sÇŒ± £Ù¢³£ÎVlp³E'z¸º°g\¡¨˜ìZÅ+k+jÀÁí¬%ôn¾İÓc_0˜jP—Çí'üäQ±Âıco|‡üà}àúÑA¶Ä@}xúùÆ“~MsÎIøw$7ÊBe¹H»fg)«OD
+yvß²·éD:™>J‘K=s±³	ï`åái†£¦±coOÿmı$P
+	ÁúË¼:Dç^®Šs¯Ò3W%ü–ÑhÙPâîDùä
+ÿbR’BaÂr0¥:é|¨QœÁ/Æ&3ÚÕúDs¡QY¾9z¨9]M§«º$Xì+ÍÍ-J*ì“‰Ašêé%©ğ˜:ßí.F]ÀxûüÇzáE“µª4«B“‡"RP¯¯miiÜ#—+"DéÑP_üéª÷z>ÌéŠMûXæ±ºËåå°U°Ú’Y™ÈÛ†.´rÍ\+‰.äv»ö£	'Ò÷m©§³zÏ_ÇÛäı.ÓåBİ“—p5û±—ëÇ Ù[Õ¼Ó
+8Çar–ÖR˜}GK—* aš$zD·İ¢š,9ñ†üjçM¯"úéÇùTÌ–y›6e©¶æ/ygií8À<£ o~¹
+ée„è¶°(ÖËªŒ(•oëµ¶’øÑÆ´q¥(…ÅdÖáÚØLüñ–t«Îf+ÀÚ~´ ƒkE]lç8u¡Ào„Ñn¶§9B¥+PYGŞ¢QT¿°ˆ)ÊÓÆë´ãüÀÉûÆÃİƒ^¶ç"ÂK´B&¤€®¡—)?6ª’ù•z¹fÖPFÆöÿu)c*7 ºJƒ^¸¹ÊÂïÿóRÆS÷¸¹¯ xös^ßøB2:at¾,ÜãòHc•ˆÃvnÆmã¸ "êàG½5Èzm(ƒåVmÈX*£~ñ•ØHDz‹qĞasÀÒìii-ª*d×áçË'½©¸ß	~Dèd>“ñ´{¼Ã 5şğQâW­£[Ätö‡|Ê5Éh¿NF>ô™%$I‚^(»CgÒí4•P³|Á>æ§	w¿úä
+Aòôºñ$6| :#Õ4æ"•»ñÑÛ×ñ{¼µÂ=Dú?¯Ch«
+endstream
+endobj
+
+271 0 obj
+[/ICCBased 272 0 R]
+endobj
+
+272 0 obj
+<<
+  /Length 258
+  /N 1
+  /Range [0 1]
+  /Filter /FlateDecode
+>>
+stream
+xœu±JÃPFOŒµUªv¬DœD@¤`]\Ú
+F§ëMkŠIˆ¹‘RŸB|êê&Ø¥n‚à¤‹¸º(¸H¹rëTÅ³üË9ğ`ùÕ¨a”&åÊº»ãî:Ùl
+Œ3Å¬*ŞªnÔ ”h)™&C|>b™û°ä‹ÈëŞìçº«é»“æõAçívØıCÆ«+	ô€y')ğ
+ÌµÒ8+¤/<°ŠÀâa­RkpÂàØ´óA¾mWÓQ”IhÿãŒœ%–Álş½E5VW~ªüdµşX€ì)ôÏ´ş:×ºöôb‘ˆk#&¼_Â¤3÷0±÷ØIì
+endstream
+endobj
+
+273 0 obj
+[297 0 R /XYZ 70.86614 520.94214 0]
+endobj
+
+274 0 obj
+[297 0 R /XYZ 70.86614 355.09534 0]
+endobj
+
+275 0 obj
+[297 0 R /XYZ 70.86614 257.45416 0]
+endobj
+
+276 0 obj
+[297 0 R /XYZ 70.86614 152.16797 0]
+endobj
+
+277 0 obj
+[302 0 R /XYZ 70.86614 701.00964 0]
+endobj
+
+278 0 obj
+[297 0 R /XYZ 70.86614 391.49973 0]
+endobj
+
+279 0 obj
+[302 0 R /XYZ 70.86614 292.05865 0]
+endobj
+
+280 0 obj
+[302 0 R /XYZ 70.86614 328.463 0]
+endobj
+
+281 0 obj
+[306 0 R /XYZ 70.86614 643.84827 0]
+endobj
+
+282 0 obj
+[306 0 R /XYZ 70.86614 680.2526 0]
+endobj
+
+283 0 obj
+[306 0 R /XYZ 70.86614 396.26602 0]
+endobj
+
+284 0 obj
+[306 0 R /XYZ 70.86614 296.14966 0]
+endobj
+
+285 0 obj
+[319 0 R /XYZ 70.86614 664.6956 0]
+endobj
+
+286 0 obj
+[319 0 R /XYZ 70.86614 635.8812 0]
+endobj
+
+287 0 obj
+[319 0 R /XYZ 70.86614 585.8422 0]
+endobj
+
+288 0 obj
+[319 0 R /XYZ 70.86614 550.4662 0]
+endobj
+
+289 0 obj
+[319 0 R /XYZ 70.86614 500.42722 0]
+endobj
+
+290 0 obj
+[319 0 R /XYZ 70.86614 450.3882 0]
+endobj
+
+291 0 obj
+[297 0 R /XYZ 236.96822 182.67096 0]
+endobj
+
+292 0 obj
+[302 0 R /XYZ 384.96033 668.1914 0]
+endobj
+
+293 0 obj
+[302 0 R /XYZ 524.4094 259.24042 0]
+endobj
+
+294 0 obj
+[306 0 R /XYZ 227.92964 611.03 0]
+endobj
+
+295 0 obj
+[306 0 R /XYZ 136.71214 315.94965 0]
+endobj
+
+296 0 obj
+<<
+  /Type /Annot
+  /Subtype /Link
+  /Rect [236.96822 169.09595 248.58423 183.75891]
+  /Border [0 0 0]
+  /Dest 286 0 R
+  /F 4
+  /StructParent 0
+  /Contents ([1])
+>>
+endobj
+
+297 0 obj
+<<
+  /Type /Page
+  /Resources <<
+    /ProcSet [/PDF /Text /ImageC /ImageB]
+    /ColorSpace <<
+      /c0 271 0 R
+    >>
+    /Font <<
+      /f0 241 0 R
+      /f1 247 0 R
+      /f2 253 0 R
+      /f3 259 0 R
+    >>
+  >>
+  /MediaBox [0 0 595.2756 841.8898]
+  /StructParents 1
+  /Tabs /S
+  /Parent 1 0 R
+  /Contents 298 0 R
+  /Annots [296 0 R]
+>>
+endobj
+
+298 0 obj
+<<
+  /Length 4411
+  /Filter /FlateDecode
+>>
+stream
+xœÍ]İ·ß¿bÒØN.‰y"©O 8)Ğ¢)ZØoI|n.MÑœ[çŠ¢ÿ}¡½i(inGŞöÅë»›Ñp(òÇOq¯¿|wÿóíë7÷ÃWß¾8üó€ƒÔğ§À[‹zpAÛáÍ/‡ë7jxñò †—/şx áß=|{ˆ7ürĞ†ÁhæA?¼<üùğÍ·/×/ÿñúnøüóÃ0\ûâw_êğÅÃW_'OBåÀ)gİà´ëLõæ×ƒ~}swøêÕA¯Ş®oÕ€È¯nçâÇ«_ß}ü½Rê{¥ğjğ<Œ?Ñé“¯òÓoõéÓœ>íxÕéÓ?oÿŞÿ½{ø>\q›¬şnqB›=ÙÔ(@—<Q‘:}ârM¢=ãµ'ˆÊ¦N++ŒÏã«áùLÄ% {õÃğê÷‡o^ÙbĞ‹½Û%&ÿ÷‡×w?ÿxw%ÈYíÑùÁDÁÛŠĞà€Ø’¦µÄd²Â™YËŠR”30E’ŞJ#/å	”%ïêšP}©I\J.+‘üéµøAğS*!ã:Ìéu¹ ŸÖ½IWQ™¢k1ˆÛnl°n°Úƒ÷Œõ]gP¡Â#I¥ß¥JŒîjà	LN<}×¢]‹0Ç'U±Ä€¤pÇæ*ÌdóD.=|Ş_ÏC RÁã$Ö¦`ÒãÆgˆ1îä(ÓşOp·€¹ÛY·Ù{”Éa}>
+ËdoÄÃ2['AÉ¤íLÿv"¡ö°Ó^Ş·äĞrÈÁ‚ÒÚÒ9¤Áƒß$ˆçfn$o’»ï“¿¥Ú:^‰-X: h´Ù£‹¸¿^ı­òxW‡åA‡fğÈÚñ³ ˜'!%tŞ^é[§Ğæ:?êW"¾ŠmâØÔD|T–L*&Ò\‘„Ó%·’ú?<rØ@ëm†KY:Í¼ÄËwğ&E£öÛLÆ“ÛŒ‰]©Pj°Å};.ñ›°3ŞíØ’+'\Ù¥ct»±|U]L`pAï±œ¹ôOÜ•µ&ÇfUâĞŞ¹0™_5Ãz~iÑ®×L°o’¾,àxxÒ‡[Mãê)ù¥PÜ´É¤üF!òoìgL·y„Ùä¯.‰jjf[Jù|{
+ÆE_›!2·:×ÏãÂO2alèX¨ë˜€ŒçëØÓ„àT¸#Œ1 -ªÙÑTÉpPg×Ùâ3n“ı¯\!8¢+zWúa³-Ë¶J–E¾ó'¥2U€¢ÌÎa’8L|ŸU0Q¹6ÃšÛÊªëd}œ)àÚ¬µ]¢ßş@Ã³4~©òoyÿËÜNK©PÕµÊjĞÖ£Şô¥ø;îtÊçF*ëj@†,[·3Ê×ÉhÉVé±+LW^Y², ÔPç[)‘A²™.Yü[‘W2ëÄ·Î#¸&‹lé‡ëÅ/7×õ53 ,Ùû572Dole[	±®„:€W†Î×Á•±¼
+dMşJ5'¡à‰SiÑ¢HŸEK™[µ-˜}ÛÕcÄ\ÌlïêJmá²Ó¼¾tGœWzîM‰òãQ
+ÄÒòÓB¼u‹msÍ•…×$%+d´§oöAá!mÔ:)—^™06€šve8¶Å·fci$aÍÊÍíkæm&¤İ§Afn¢²=ÊÀúv‘eX¬VĞşdeùšÜxï›¢mšeËVäf!¥DıT2J;çjÛÑ0èrŠM6’l(%Ü½Ö¸›†©’G'vY4"ü4!`òÛÌ3›W:ıÜ¬‰ ©ñZ;µÛ¡jQX<§ N£›óQ=áş	ÉÔ6DÂ¾tÅJL—=zŞ°ÂV¥ [ìÖ¶I9hbŠ}Ø¶o­D|šöyÕ,T¡”&ã€b ƒ@‰û¼²Üéïg‹¶x5q×²H¨ ¬%½WA„í(TRÊ:3^c™_¸Ms÷¤l©FRZ¹.rµ(„fš0şŒ2<F@|nœC?û,¦öG[“äl{Æm“=ÛY2t“‡¡
+©&@0¸…#UˆY¯<áêE™£šùãS¿º>7;ÄÌ†ñ@Ì›ÔLÉÏ%£A3ë9­#f¯Ÿ&Ö)oœ1¥ÕRÔÈ’Ê§ÛE"Ò $¿qùÕÒû‰à'å»Š"ÛÖÁbe*CÛŠ%fvÊ…ÇÜˆV8TLL¬/İ÷Í‘g‚µ)¤¬ÌGYKŒiiV±E ïïiò)d«¦”´”…È˜$:{íwƒ>BğF[·éåÚÀ™Åá“c0‡S-*¥àµÖ:ôØ(,: “Âğ·$½¥U1ÉPVÓìÂ«ÔşÈõA1}xr½¤·ë“…Î–ı$şóiüç³âƒËAuµr&f<ä4.’âL­Bˆîr™Ÿv`Dùœ†…3ÔtîIŠµFPÎõ€Ÿ'e‹Î¢8e¯4åûáRk5!yÒd­¢3+°dö¡s¦±™pen•“uYrH¼¡Œ·¾V6Œ®nMŠÊ¼^¿Ğu Äìë{Ë¾ÀêÚ<NÏŠñÉJJ@Wè4hTíB¦°hfìÓ5Ì®›¯jkf~J'okà‘YüÈ>B’ÒZ‡¨!è7éJø6ôúMâ™ç(3g@¥IŠİFÎ›.`°µ;ƒê)–Ü:ò¤4¥V(!‚€JÍ§*j	ÂgU@s…5Å"ıÔÓ˜Ê)¥•lMráóÓÿÅ÷¾pƒR’†ÊI)–Êvñàøî×3½ªH€X\Ë[Ó².€µ •œ:Ìq5em…1£ç´j)½÷¹á«ª¦*
+aŸ¦Ü¡ågr2¨–[ûÂ#K´Y›~]Ó1r}ÒŒ¤ –‡Øòææ™¥)ÈîKÉ¸pD¥½ÜØ$"
+lR›ŒqA «eA‘‡[zšgµŞR@<£º¡ÀÇÕ,;ó«F©VàÛGCmX|¥’³ŸìŸâµRõ NÊ†ÊW«¬kIZaƒÔÎSŸ’zÔ<XÁR04ÚĞ‰¤Q‹xÙÆ‚ÄÆZë@%åh}Æµ¦L¥TÍ½™Üù'ÙÚIÏïx!·B<gz2wA­/y¶H¥r÷Qs[ª5bÕ!çĞm•Ò
+¨ÜÁÔ"QŠ¼C ãİF¹z&çx ³'ò±œ > ëBµ(O:‚Q†l¸E‚ØNœ×dúĞ 4h±¸ÄÊY2]H0-Ä¦A¶gÑ{`[$ˆÉtM`­éDB“r¦Ü16P\‹ñØ¬!ğ6t!á¦E€h ö;`gê,'!m–)»ÙàıÕ[üZm©ÿ›·ØQµ‡3;p²»!³uœZ²L¬‰'göFë§–ÌEôpHi}{¡%{ÁÚG¯è"öBKö‚
+®	wŒd,ØDŒb¥/“F2§QhÍ]$!Fmu$cÁ6 Ëö0i$SÁãì6İarWH„Éásk'¸–„È³û…L†…i¦ dıˆ\lDv  Á;ƒtö¶Ş¶¶U²~D
+|]h{ƒFn”T@ÚìBBgØ©¼Eå:Ğ9	èI@£ô®çŸ”k=á¤%™î“5ñ0¸3]v¥åZ	ù)N¦Bíöqe+ò[	ù) Xe»p¡¥ŸVä(G¶¡§Xq(O`ğdù"êi%”de@sğæêiÅ™*Hà(Põ\uÚ¶3qVö=(§_FAe™=›Ëè§è Ç&ck#¬¯ÎyÙ©¢s¬hÚ'»Ç<*e/¢Nvè8A°MïØI(iPÔ]ìçœ%>RZêéª¹{rÂÎ@µÖŸx˜C)ÖqoqM€ò£WÇ ××¬Â"™SOÌ–^áA…é¬µLhüÉé­–hÅ²®•´Œ´ôÁYÖÖMZj–!ÌX•ÒS˜RÙ˜ìäLv¢¼ÙlYàÃù-äEW}c-õÔUõ´tµÕTO·è‹%åQaFÅ"Š}öèÓ¡éšÙ¨©¤b\:‘U8»ISÈ¤÷ M)¦:¶qÊ†cTã@™xÄxËfµÑÆ~8êá]©}wšİ8F Ò~— ›Ş4ß®ª
+ìCÌ„w«2³j2Å×ªÌ=Hú¸G5÷ê%ÜE%9†c¡ùéÕÀ!&[NÊôD:Sœ4¬F-ØM5bWí1$Ô`ÙT™úŞkÄ^ÕjÄ[HÜ[#öX«÷  ¥ª5â$´ÜiÏõqZYA¯«5â$´‚Koª5â$´r/ŞVkÄá‚«Öˆ{ĞŠq½¯Öˆ÷“Ğ*~øP­ïÇÎË•Uƒ˜TU
+¼ã.¼l•Uƒ˜REMJ_bƒ˜T%ÅZñE 6ˆIUrÀÈ]Hh¥4ƒXybgC'´%ˆ~=;°VqI æ6ˆµ'MtZÈäÊ“Â“gû‘%/«_]÷CWàIîvÎŸ¢êã1³Ğ3ıkK
+Í)²=é©•üğ@KÅQš!nÜ¼– ·Ü¤ Y&m4RÌÁïŸSá°5…IÉÅEGÍò€ÇÜkú½%áQ‰E)0šºPĞöVQ‰&å7(ô]hhY5T²M‰‘;İ†–MA%·3xpÕ>.œ[ÇF%Zmâ4€Li»¯¨D+cTleÓØ…†–­E%‡@:hºˆšŠ=VƒCÓg#ZÑ*±©ÁqœÒìe´Tœ|¬è{2t	-¦R `‡~Î/g£8P’ã×„!ÓeôTœjÈñ…Èvñ¦ŠScM]«p¤!–´õûÔSqŞ “åõ¥6BNŠĞ†_HOÅæí@YK]„ÚÂ ·7pFù“î=B…Üı«Á1ó€ŞsLôspKß97?4j -?}éœ­“ïs 6¾tNtÆ–Iw‘4jZ%qb;GÚî³ŒÓ™âñìv<g=±QƒëÂ™Vtâ$§¹¯£gÆLÛT¶ùR­£#°Nû^;¬¶±æY6™Oµ/ËËÖÚäq&[R¹ÙÀ–E§@~åãúUš[&'šb"ßuØ³#c$û61rÊÉƒñš¸‹ ÍƒR¾^÷ÿê&§ÄÄîPÄX®Úò:{s (raÅ`nÛ~ÚŞ‚8À…Ñ 9Ã]ØĞ¬ã£8š‚IëFC±Å¹L™]šâ Î`&Şpyà¦ç&İgM±b´‘†öÂ5§o’Í;‚õ.™”Òp­9ÙÊ…Êß[QÀø|üvá+
+_/Ò²1ÙĞUÓ4dãT,äºı7”ŠÏ‡ïÇ|?`A_ÍM'“,ı…¤•,ıZ€ÇlAmÓÏoú»¯çÈºÚ¹çÅ‰
+±‘X‹fÓ>·GRæƒfßˆ“²qº:0xFÓŠÃQOüRö]R¼İ\UûÎ££ıN}gŸ´™Rí:ëAĞ§nûLl…eaí‡“å‹¥Šãkò¡şí7r—¯@¦ÍÛjóYl°bÜÿ´ùuµûl{»ÏPWÛÏzĞTK]ï?ëACÓ‹Ô´D4İH]ï@ëACÓÔõ´44ÓSºŞƒv>Ô›ĞöÓĞÌ„Š£Ğ0(Œg /Ã…RZPº“D6Sóâ8ŒmêèºĞĞê˜AqÆãfa«^ş¿4ã¡8Ö!6Ãan¶ºñĞ”šœuş2G‚p<FÛh.bqL½­1kĞ g´}hhCLa‚?=Hh'ıåY†Áš.$´Fìˆ0{,|¨óñEn©šJ^D|yÿúÍ_üËğİõWoïïßşòCüíËİÜÿç?×¿}ûöşÇwñW¯?ÿéõO?ß½¾ÿùí]!`õŞù!ìAm|­VX¥:5ÿ†
+îã
+endstream
+endobj
+
+299 0 obj
+<<
+  /Type /Annot
+  /Subtype /Link
+  /Rect [384.96033 654.61646 396.57632 669.2794]
+  /Border [0 0 0]
+  /Dest 287 0 R
+  /F 4
+  /StructParent 2
+  /Contents ([2])
+>>
+endobj
+
+300 0 obj
+<<
+  /Type /Annot
+  /Subtype /Link
+  /Rect [275.00125 639.9534 286.61725 654.61646]
+  /Border [0 0 0]
+  /Dest 286 0 R
+  /F 4
+  /StructParent 3
+  /Contents ([1])
+>>
+endobj
+
+301 0 obj
+<<
+  /Type /Annot
+  /Subtype /Link
+  /Rect [70.86614 230.96942 82.48214 245.63245]
+  /Border [0 0 0]
+  /Dest 288 0 R
+  /F 4
+  /StructParent 4
+  /Contents ([3])
+>>
+endobj
+
+302 0 obj
+<<
+  /Type /Page
+  /Resources <<
+    /ProcSet [/PDF /Text /ImageC /ImageB]
+    /ColorSpace <<
+      /c0 271 0 R
+    >>
+    /Font <<
+      /f0 259 0 R
+      /f1 241 0 R
+      /f2 253 0 R
+      /f3 247 0 R
+    >>
+  >>
+  /MediaBox [0 0 595.2756 841.8898]
+  /StructParents 5
+  /Tabs /S
+  /Parent 1 0 R
+  /Contents 303 0 R
+  /Annots [299 0 R 300 0 R 301 0 R]
+>>
+endobj
+
+303 0 obj
+<<
+  /Length 9623
+  /Filter /FlateDecode
+>>
+stream
+xœÅ}[—$Çmæ{ÿŠ¢†3ÔHLà7‰+[¤$_é•—³ûbùÃÕØÚ³"½ôìññ¿÷Avİ2™ˆîˆJ½°9İUÈàûğöëûæ»ÃçŸ?o¿úòo~}¿üåá‹_ùğÿğáğX2„c9äX@0§Ã·zxûm8|ûïáğïß~÷ğÅ»‡px÷ÃÃÛá€xx÷áòmıñîO?ş}á÷^ŞıŸ‡ß¼{øÇ‡ß|õåÃÛåğh 
+>q S€
+¥Tä# P@ˆRíà;gx1‡/+êşŸÇÿáq0æ×ÿ|x÷·EK ŠÀÂG,Hvf$Yp€§DG€l	HÊˆğ¶d±†Œ2æı“#@5ßŸAR®¸Ç–DË(RŠ
+J¼ÿDË*R&àÊ€=0?ş¤pü‰Ş®DËNRÉ‘ÆØIo[¢i(+C ˆ´Ç¾DËV22Üá¨´,#‡¡ğˆ%pµÒ2ŒŒb•¼Ë¶´#S
+…FìY&´l#³ê`"¯ƒ–qd5T‚„@Dé~ZH–mdQ-Œ${²¬#Ç¹ì¡‡dÙBNBÊC\ò´€,[È9BXÒ!§%ÉıL™–0dV%P2&é˜‚¥ßş«>şñÃ7ß~<|ñÕÚ¨	ÓeŞ¿üú!¾şòˆşãA_=è—şôAª>àÿ>|½ú†¦±-LqÌ{¶†Ls[2Å4Ä £ÀÍ^ YXB‰#¶>±7'–ı€#ŠŒ˜“ÀÇ9yœ›÷îŒXö8()¡2'=œ¶ÂMh¾R'éÎ?OOóŸÈ3ÿîãëÃ›!%©ñğãÅGxí#N7èÙXÖ³Nnäñ#§/&ó¯âñAÎÔ²š¨’´M-
+”Åşx:smŞl^Ş_¿ü:1›ı³¥xıíOŸŸ¯ÊqX>NG8íÂåÚº»‘Íƒ	¤¦Ø¯{æRó4Y/MÕ8ıœæâÕüíNš¹¡E§?iæq]N_=iÕi+Ä×*3Uõ5Ê:¸+„P…[fì©§ÖÖÁ-T!ÆXó 	üp“ut‹èÑYãˆ9`ô$°V‘i”Ş1ÂÖÑ*R!SÖƒ¬S‚ƒ7¼yŠÆ%×GL€ç?²uJ*„Ú&à9¦CVÎƒ¹i8ÿ]ocç¾8=&Ë»~ûˆ&„ˆ”øù/»~PrÉ€CZ9)/ÖŒgï*×=YÒ4;˜FñòµO6F•¥e½±G‰¦CíÍÂt‡ÛÎg¹Â§ñN¿?u8û÷SÌN¯½ö‰ÓÁ4?2díã?ÑÿüTÿó³Ù¡ìê”ıß¿ÿæ»9üøß½6ïƒ!c.MÆ›öfæ“Æ—s·áèU]Ep_Àò$àTr±+lMœ-Ìy7œ^,-ôC–zúÂØgGakãõ:/Ü	¥M+©õÊT,~^9]·Ft±Å’9×]YÃ<Ï¾s¼>,oÇóÌáí^óã´òŞİ8ªÔB”›+ÊÜù?êÓâg/µTáÓ6<?yîÿú†ÅŒìD‚¹Mz]T1c;) Šh˜¹S‚O¼áÍÀKÊ 9Kéşùa1C1%MR÷¯‰ç°Šù®¤´	à—Ó¹§ÿkğ|/üĞ¨Å¦Iˆ¡I^çêşò‰òKÆë|ë^XÑùµÿñ¤=\½òî+[^fDÌ9õ,Ñy…‰aë J¡FÙŠÈòhSKÂÙÑ|ë¦ñ-£
+¦:Dœ¹É¾üE8åÑ ãü,[xR¯ŒPk­éxà|zQ†Ãe‹¾aºñtOÇË•úül.ØyÌÙ9}í9§İçqÈÅY<R.œ¿ÇOOÛ®Å_$C®Ÿøòj°×7xµêvNÿøÌU‰M)ÅXQz\¤³ß8?À_Ş^ñC/>Çb–iò¸ö<û®z–#m¹7O{¿y;š;—¥>‰÷x¼˜ñ<7€Y®o[3)^é/nß(nİWÏcÜ”¬Î[<_Ã3ç1ëŠø‹¥:¾{"EÓ¯*5æ~å›Ä˜¦¡¸¢˜VMsb±fÁ˜o{İÎ·ŞÅç§?óÊ³>4ï5Ü¼®-—vqU™í<Ës¸w²70D*Ò3ÓÏÙr:EíÌ)S^»Ÿı•Eèdy¿¡•5ÆñYïéÆ·„Ñâ3?½Ö­å-ït3_ş:odbv¶Fi¢YÊ—#„€(À4ù¹m×›U}%AÂ<D–SÒ‰Öfqœ³BÍúÊÀ)6î(/áe¢Y ÃY³yˆ£ì
+˜
+T˜R¿?òÆ·ë_˜pÄø/¼ñíò†ZÃˆñª ’yš§¥à 	>õ†·Ë_2ÄŒ;M€]B ‰*õ‹ğÒßˆTÈ1¿e
+ì˜ˆ@’VƒÚW•LcX+ÔB¤Æ0@ÁM?.2äU^yã[–PB„XrÙG³e
+H¢Şd3‹
+
+–ş%øÌß,(  5æ²Ï
+ØQ£M8b	~ì	`Ö°Nàµ'€YNÀjÅF2Y_ê³µ?¼´|ày•6]ôÙµû&3[¬ùş—Óæµˆ
+¦®8ŒO™ŞX 2V¹ÜH—5D+‰”Å=ârÇõ^6{™Zä”BŠ-¯¾¨Ue½ŠšAÃ)Švz	3y
+9F÷İL¨Nkj{Í_¬Ø"°¾\—¹Š’³š×÷ºÃó‚_¶Z™¹³èóØÖ<»Œ?,ªT®b+‹A?™˜/ÿz¹.æJšv“76û‹"ŒÓ\y*e: §˜TƒJm[óøÌô(b€”bîŞ¿İÓ¥H”+‘ÀKöÓ©H	b,z¿ê–À…¹Ó©˜ğgy’ b¼Ÿg[LŸ"gõ¬K“]ëu«ŠéT‚’…àf|‹Y¢X
+`!À{ox³D±kˆºßE¸SÍ­ÛÏ7K¸óUÊ¦kƒ¢e®ÒQÕt.xYÖ¸İšàÃÂÄ/œp=È˜"/Â§…Û„ÑÍ7nêN6\+øz­Ó+Cá›¦wS-âƒmD@Ä¬Ã#ˆbĞk–~êoÂrA¬µ”ş×o°KÕ„á†	ĞD¼Ã
+˜ \SÆï\‚Ÿyã›tŠA&±Áíİµ²éYë;ëé±Å'ß,®z§œÜú£oó¬éiÛ¸šÑCb(Ä’úµè·ŠfôdÂ×0ÓëÓ×æ¦/ìñJêò¨Ë+CãÕ´ÚÌ…â sŞ*˜EZÕ·+ı[ù­7¼¾ÌPc²“7·ĞvˆbşÙEPf¾ø/{b/ïpg?!>­¢Õen›…a±VˆaªëºDÆÅù+/³H[?ÕÁ`‚ÔŠ’Z^gsÓ—Ä$¢Rã!Ö¹Ôû9!¬#™Ac>MëÙÍA¬S¹@‰¹”ÖÀ:¿P4èMÓøkày!¬5J©mZm×–/1³4+'Ôü¶ñ¢Ÿ{*l·àF§’¶=š¤÷öŞŞ6¼ÏşÍ´cºrÑ±&g
+¹ö'¯DSÉA1'­“Oñ¹ºï•?`°NmTz&z€AÈÀ÷Ùó(Åş÷o¡1é™0E¨¹ÄxˆE'£#8âÓ3™‡PF`äI ‚¢ã¹õäÑ¤cÂ\ Lİ3à¯€y•
+5ˆ*açøŞ-M&&C`¡iüŞpwIÆ„µ(äUúgÀM»¢ÉÆ„¹‚¦CLb-›ø½ŞM`ZB}o.XQ9h´gTx æjãç¥^ŸuÎê!”ºMƒ&ß“†['G£×ÚyQ`4é0F]æ~sëF¢Ñd|"bˆu¾Çir>‘»‘yc×ä|RVÄT™¹ÿØu]N“ò‰"A$*uŸƒ×¤}R^Dâ${¼&+å …w“Õ½ûÁk²2QÖ¼LíŸ/ÚUÄ0aåû¼&My¡ZG,€¿L‹X3ò€ğ^“–H5€Cª{¼&íV^$=”ö:x¯6ş“^%Qõ^“©‡ƒÒfÕ³=Î“«‡Q‘ÈZãÚ-ƒÄF“ªGÃôÌ¥8s\cg2õh¹I)ÒwM“¨‡9‘²Ï¡g²õ°XFÜø]›o’õpœğbaÀ•Û·™:Zğîrq‘*aá¼?“-…sRê]ÙeL{XbŠeÀ4±›ö°FHÄEv°‡&3…)©Äì¡ÉM!!A@‘=.&… ƒÖ7ïbM&
+­7—˜§+ø½­¡M-ÁcL;XC“èA	ô”:#î &ÑƒH„œ•†õşÖĞ¤vHŠº˜¸ûĞ&lÏÌy`%ÉnVÀD—_R¬eÓ#nE½›ê#xvšÄÄ¸cÒ qÍxˆêÂß“+ßŒÏ*CtIù™¡¤î‘DyŒ™A1)±{üKm±Dˆ$ûEpï©&XXù{K¬…‘uW8:ĞSEŒ&TXcôTKîZ„çö¶A;L(Pb¥{Q<Ø&šØa"QÌ Şè:ÇwOo;L¬˜ÅZû÷eC3Œ**É$@§Rº>¤‰&Éš¹«tò9½]L41%&ŞA+í j€ÈiŒµt/7&š˜*B©Ú[äş–‰&¦"Ú]…¤{<H;šhbª	˜kî·LMí]ÌkşT8%yînL8±6ø¡¢|6÷?±L<1SĞâş3a¬1¸Jº¿m0ñÅ¬µ^A‡íßWJ3” 1‡ûë¤M¤šw8¯²şL‚üyœ(öªtœiâ[¾¿JšñĞJP“Œ1•îqeÃ$1B¨)«“ ŠÜñ¸²a’ÚŒŒhàÎk`ƒ$1gqV4X%Ij‘.O®1i¢$¯¢ ı§Å™fòHæîL6‰ê]3s9Ä)TÊï¨—æÅ›õ‚“†Hàl:‰\¡j†úÕè~^„	‚D)E0-›Ã¼{+‹tM¡ÁoÖgÃ“Ã.+a"1„‰/­{Üe0ñ‚
+)Ç]¶ƒ‰Ô(Š#Áõ`LÌ VÅ&½rwÏk©M¼òt¤pÄ*´ô4ïØ„b2®i6ánûÊa*İAÍ;6Í#Oëp]4oÙT€„ÔmÙÁ4“‰›B`Q7$jÈ!”{eqÉDp‘$(¨uŒˆP²æ“ïµd"¸´¿6kÊ¨_ /™O&‚‹¢Ö“†Û¿Ï½R‘‰èR¦TBÖ¬j§R´´v4A]T*—@İ"øÛÂ4•¡JP`áİ÷…¬PÂTc²ÃÆ0ïÕA€µĞ¨[/±K&¶HÁPÊAjÑ&ğAFÓWKÏÖ0ÈéÊ ¯W6¦(ctËšè%íÚ8õJë>Ü}f‚—´ª0E!€ß<Ø/ñtqÖŞ÷÷ËÉÄ/±Şë˜’ç’İK+¤ªñ=\B²ÊÇ
+\&$ñİ]B²[ÊG†EkivX;¼‰PQpÌn*ŸåÔğx5ıd·”W¶­“ìáÙ=åµÙv)a‡£×î(_*Pœ
+\ïôÚ-å+CÎeÒû¯Í¡NŞÇş>©‰6Òo’˜iŸÔÄiµ#ç d"øã›õœ€3%º¿i°û½ë)§}yw‡ĞÄ‰É€	ğ-ƒYìPÉiÃ`¢$
+ŒD{,	7$ˆ¢Ù¶nŸÜ£)¢•®İ	Šm¤FÈ18GôSˆŠÖ.WGrû­`ê0„Ñ½˜`£«dN‡#2ÏæÄ¶T™à£sI«„€!Ü©[WFåm¯'æä'qœXpOn¿p.”XpŸi¯	…­ï/x·†¸é½Í|m³«lôôùjìf?å{?k¹:€I/³ ÔÚ|óÙË÷vo¥2ê6•ÌÖÏûº-Š«Oœ9Ö¯GtÉ¯ÈÄã‰²qejÚ”WwAÈÂÉZ[ëY©®›»‰Æ‹Zw¸ÀK*’‰ÆSC]' L—gò§øÔ*-21z‘$Ô>sİÆÛM&Fïr^¤,y3¦ãRb-»3, /ÌÚ5?TëÖ2~ˆ¬he¬Mò{ùj7`‚ü5o?J÷Æa‚ü”_/q¥!"¸>·	óCÖ®Ø'Â\“>i¾‰š¸?”
+¹”6‰Úº­¨M§PœØoŸ¬ñ×ÇÕâa Çı¬ù·åAú¸3ç}ÚüÜé¦Õá
+WäMÇ‰9?œıËOigMvğHJSÿ¶ğsÉn "`éİÍqJy© è(å2/ƒ«,<Jß>™øK.yÜ<øG…	ÁÔx!ï(ƒy/%•†º­±&™àKEçD©ms63	»²˜1K¥§åœÛÜ ¾`I\‹XfÊYCbïŠĞCëL&ôQ˜¡y5º-•	}T„4IhtF½İá¤ÉD?jä0“Á·Tvô2œw-LÄ£$8¾vOŸ<`®-ÕUÛrv{w‘	…”ŠÀ‰QïÒXzâš?w§Å4œ
+ùJAd_ÃiÂ"cÊ¨Ú­%n¦Ã„@j\A)]˜M7ÿfb £¶²œÀ»ØMy¹ÃGÔ‘d¸ïà™0È¬*9Hÿ
+l"!•X•dîáa"!KQÆ§A"¸Å!&²f56Š0Ì6˜¨HZ8\SìŸ×8˜HT`jÉ*€¨,KnÎDAâÔè6Ğß:˜HH¤Â!§}Ìƒ‰†DÖ"ÑA2øöÁDD¢6œ-J+Ñ-ƒ¿5m|O”Q“àË`³ÀpàF†Ù©\/”…Jÿ|x”Pd‚!1 X)°®÷`Â!1'È5ïcL<$–‚!ï²k@Úqï`¦Mü#i=+E––!­QÌp©ı"üÂß¬c§0±–1NşØ8Ÿ8h
+šD0+ÙwœşH¬u3»‰`c}´7{è”áñ”øüœÈùoG™¦Àş/İ3Ãn¤˜#¤TJ›±jnqêÊÂ^‹r…Á$ÖDnƒ\Û-ÊßXÇ[ß>•<L¿_p› a¢¬0‡šË!‚THÓ,óZÛª¡å'—õ)f‡ùOnSVóª—Ş8o%OãÒI}Yƒcd¿n¾{Û.|ã}­fâ:7CœÔ;î*;7`·»ñçášq›7qM?ÚïöÇ&èVQğÔF0@î¨×qá&æV;¦H	ñ±Û"¥ã_¸˜w•T5œVvÀ¼¨ä¬Í-Óˆ5ğ]2¶· Iñb‚BõB½=u[lƒnQi{“&°QKÚù+¶û&Ö ˜’F0C¨}Ùc/Â6ğ6À€ª½2øŠ`·/FÀ æà/İñÍû	@d? —(÷¯\l‚Œ!À3l£l9@ÈI=Òn5ô·bY£ÀdRPNwLû°²å2U™u¯Asã®ËæG®WFx½>*}ìÔ|k³M”-	=¶Š`õ]ğ›@[eúäš¥9y¼0›P[JÚÚy:x:Ep	´U@·hß˜şãß58&ÎöñG;¸lblµY.i÷ÃDÙ*µ'Ö,Ôï~xÕkl‚l§M%Ô»ı«Àş«·n¶9
+wsíÍ”F@ú—ùwŠÍÂ8¬PJÁş%öRdlCx‰ÕÂã ÿÒ½²áU´h	ºÜ½JæEŸÙ†ğ’ÀÔ–»ÿXıi+LíòÎí*¤ >q”ÜÄ³–vUÒ<G¯–»Gª		fÉ@Ã
+D¡ÜQÉmÂm?¨³ .wKò°‰V*Ü\%ï¡áfr$È¹æş³V?¿ò!G§ë›hcVb¦È¹_½¿t'Øn´U€rÉû8Œ&Şx*°f­+à7»·tp¬ôº¥°†•÷p™lÌqª¥Í½"¸–Æ„«»š³ò uû­®­1á¿zŒç€ZÆÛ;ş
+Ø…Ì	ò*¹ÿ
+˜eÌT¡–)\Õ»®Cc#Ïˆğ˜#Âİ†gùxñ« û2fi–J±ãğ¯íx¿&X¯Uu™):f=ŒOäKâĞøë«‹0Ÿ¬±€9Mp²«w˜!³–ÙdfeŒQ^Î¾0O€¹©6¡¡HDIM×ò2±¡#ä¢a Îb*÷Œ>›ğNƒp¥Ğ6-©Ê¥r,’”ï]•=«õcû*ÅWkÿŞÑI¿úœí†’¬¼h€RøüÌl7”˜«Ê°ƒZ˜÷‰¨oØ	.å¤-¡¸ö‹àŞ©ll£öğCm)¾‡y0ï¹@–TGèÇ²Ã6´±0”âˆ9ğµ¼l,P«ZÈnû4AŒWÂ&ŠÛO¼¿ğ¡õk§bc²~ığ¶Ê<–ƒ=«Å³Œ&¼óâæ¤‰¨¯’a»>ŸO¿_ys›0:5Ir”âNâò“p›dçŒõ6}˜+ÕZ<¹¡:æV–íêwíÄ‹ † &µa	=«îZUKR€µ}¿®Q5Q±
+OçJ¯Ÿ¸˜™eå8b"	&–R‚Bi„ï]ìÆv§u¦.	ÎÆäÄ2ÔÌÃ&<–j€”rˆC–Æßf¼F¨Ò*CƒC¾b¯n„‹OÈu)éªµüÉì1·„T7maT[Lõ-­×º™<Ÿ#³sãL`5¿¡šôVŸ,èºz’eaââ‚|¦í0Y·n<W™«W<{9»#¹A›íâÙÃ¢Mr¾şå¬¨òåë#ÔZ5^8/~ÿú€I/ßÄ|¹±.*4•Š¯HÓÜé0áÖ –¦)ğ÷N0ŸoöÙÊï/£f+}y9»„õJçox²vNã£«{ûÌAÏâÁ¯¬Ïúp[–ãxr_æÆ84Ï¼QÚkÌÈ9ßö¨qÓí\à%?Ğê`mLG»„{ú×/VÔm9‹îŞÂMëÂèšô™Ğ›;Ùm!rSÑTê††ñKúÉ³½–İ¹CÍ-ã
+âEÍÃ`Áƒ¥ÿ3ß0ìMl7NJLMG‡ecå¾»RÁó»Í¦õlÙg$”/­?¾°ŒÄiyùêÌyœ€ü	0m©@Ä¸KsÏG›çğ™—Í²vZN[1>h½òó3:&ÅC`Án	Õ@VfÜÀÜ¬±›­ÓÙ¤^iÃë×‡7WnÁl“¬{GåQœO}íI[+G™!gŞh}Ş~ru46Ü_LšŠ*@¨íCF¤Ptk²NËrB€Äù:°£z\²ù^úu2û—9äŠ&ÜÈ°´Şs±4WqJK°ik¯^â”‡2üÌ_·Í"IÕ°ûæº=ŸRšˆ)ŠlsöŞpÎ½¼ÓçŞ¯>¶¦eçu.ßŞ¾-‡}eYOC_…l/S³ğj¯¸fg‹kNİÍmvù‘UçûöY-ù.s¢˜¶sğt@şõf°ó ¼ş‘¹sv’gqÛ^ÕÓ_Kø¡Q¾_®ü>´©âI×oÆq÷sİÜÏÚNIDïOrıE	 ÛŒ9Rhˆ,S¬ƒ,JçU?s¯p·¯kéÖCÍ8ÎêeÑxÂiØ››7l Ÿ`şfÀ“ùºÙÄ³½ˆ¯5W&hşóº‘ãë|°™u—O£È¯«|fÅš2ÂH©mÚç%<Ê(6I’XPä8D×Å7i’8f(I¯İ2üÆÀLç+w…†L‚›s0Y’8U¨HaÌB¸Eœ&K%ŸÈœÈà5vc“#I¨” à÷Y	;©¯­¢ì´vV_©¢R¦!2dO“‰+Õš÷™“I™‚#¦iOd`©÷ÔG“‰'0vxÛg!Ö:¬Å #¬Óo]ÌšŞ¢æÜîä$õ/šŒJ¢«¨\gû,œY
+,1q¾Û¼­7:{d6{î¬d/w6u÷ÊZoÜò–ÛÉ3õÓf¾ëÑM=!|iKs¦°‚şt{v´—Ñ»Eˆ[CŸOJÑ™ÔPˆ±YöuRˆkÌZ«ß^j2F¡RwIP¿¡A²îÍfRF!È¡T"ƒëÈšäP(˜HÊüxy5Ùô$Bi–á9Zbõ-[|f½àæi7Ñ0ƒpèÕZW¯Ñ¦¿ıhñd#UùÊ¾üÒ2'ÕÈ/É&Í•
+˜õÚeW˜•L5C”„cv¦¯‘æ­"TÀX3÷ËğW® æ¥bÂ$I¾Ÿá<+ºİnk«œcn·e³×)OŞü†ºë&{U7zµÔÚìP@
+¦)ö¯ç_»ëi¶'à¤¸&ÚÇÔ‹IÍ¤L¡S°±¼[ª˜ÌLÚ£¡nàyŞÀv€rQdl>Ã .µnŠÉuqï‚@­E°'Udw„²¢†úßŸoİbü'>s“uybŠ˜V˜”šgfS_ÿÆÕW›d7@*ã¥9ÌíÑğa³k³’¡2˜])El~¬˜!VÄt—Ùm¥¿¸ÍI½¸"=ÙX¦£·ûÊŞw½ì0c„¢M—û×Ë«)“ÌKK˜yÄzÖ)šÎÈ<ußPİÕ¾›i …×3äÓ¶:$±™ÇAŠÄù€… jöò™«õ·Şj™¤`¨o2Nã@©ÏW—O^lV0mfÁµò\§ÇfCåÄd),joÒóâï\Lp
+iz ô²r§£ ½…®ØTa cÀØ?+MÚ±z i´³[–!6UX,P;5be~˜—KøİWÅfË$!§ÖÅ„«ÂN…Dø{w|Ór–™èæW &¿)ÓtJµ0Oè¡Íâ­¾“Öä÷RæĞ*2B /¹,&¿1i‹I€A»É=¤ü® ¼-€âÚ2Éó%øï­$zW/­0ñ«Y_'`à‚¼MÀ$´f‚3q–şEvíŸÉğE‘1ˆ¹‘ç
+`à„P1s×øÏ¶¿&í—‚	'È@”rÜ”)B\“tçÄ4¾9CÊ“ËÔ»(ÿÃÀfP‰P'•ş÷µ'IËEI Jy€ï\	Lû›Ti„¿kµ>W»±ÙúP… SrÉû¥İ7jÒŞ^İè·­/yåŒ”zu!XÉœ@
+f‡ªTLn1…Ş“/Ññ*BÄ¤Ó\B¨L©_×Ÿ1éÅ”:“ÚçfRŒñ#9pêÜØ³I1Æ‚RàÕú`ó-„Fxµn¸Í¤ÆbmNL…r¿ ®Wk2cqÖJ=Tj mQ|¿Ê(1™±8é‘šh§Û•MF¥±’°"ÄR«ÛÃ‰/6UÎjêŸ+ a³SU©H;­Œi&%©EÏC‚XâİÒ6;UÒAáşñ]µÂM…9L7’NŞ´rŞ^ÍAÊ)—è8&ûÕ…i²ç,œgÛ~ÑVé%&%–<Uâ¤¢÷½Åq•°0²:ü½4”/‹Íb”¢6«"«û6‡‘6E‰–ÁuÒl#…ìN\òİ¸á ›Ã¨&'=(€Tp“ÁHÛ
+ «ÑéÀuPL#­¹I•t+F½ òóıd+š8T¥'œlAç´œ‚&Y+ß»ö•íáÙA™hz®Ì€¡"ï3-&×‡ ºµä€*wäó\çÀ$ä` N¥|×@šÄLˆ+q¿ ­ÎÁµEb¾2‰YmÓ™RÊw`’G\yFxîüÏFï`›I1CŒJšy¹+še®« r«h›úppÒ²ÖU›-ßãü“™C5SÓMO³ã¤²¥7ËĞÂ,§ôÙÏ^gò×¿¨®³°R=vá5X?çÚàj[
+ı|ÔòòQu%é	~Eä:ÿ÷¥Å¢¯º}ÌZÿv¶W¸¾æ¨ıá’ùŞ.ªBL˜<g‚ÀS]Aï¦ oG˜ØxÎ	˜‚ú
+Ú^Èñá”Uj˜3]RÖs¬ßRøÇ·	™–J±0®wo¦5«3È\úW3ıØJ)â…`».&fZH ‘Á½å˜€i¡¢DBCÂcŠ0-¬´ßJ`„#9à®¨	—Î@YßüşÎƒ	–™ÚK@I<Ê*`”şn°ÑÒ‘Ÿ0\ğs~ÛÙ©övq&.=“ëÒÓî¡~ÃbØêL›˜í‹ŸJâ\ÄºŸ¤%¡e*W9îŞ™;°de
+wˆÍµI*×(£–`\pÉ"÷á)üˆbÓµ=y	TZ&ºïoÂÒµ²+EmÂÑ;~‹'`¢Ì•–€W Bƒå14Ó‚±bê›x”¤˜Å>Q	\lºfÔ¥³ê'%H¨Å>½kâ:g&L›rjÕwĞJ­<í•³¦f»EpQÈb¢±§pÓ(\ÕcS­ 5jrx‡½ib±9H’µNa§½iâµÇoQÃ;nNÌT ÈT×¹(®Ãnc‘9æ¨™¡=v§]<“ —¢Ù±=vçZıÁßfp#F`Iqˆğ¥Ñ„ğj-©ƒfÁ+g‹&ˆW{h¥„m³Ğ¼3-ç¯Ã»íÙ^n×ªk¢‰Ö®S`¢ÿ—;ıfE›íĞ.î[4a±zi+ƒDp­A4Á«’jNmÇÃ¦Ÿ»ã›A”ŒZ>èxj¼:ÆàiQRÛYµMôfƒİ{A}¼‚ÿfI	H¨]wßsÃYËMj×R€Bèá$0x-Ì‹ìÙ–™š: ,³[wÿ•´ƒI |^Ş¤Šşıü‰+T¼àÚO–êqÎû>.Ñ¯>~üæÛıÃÿ>üÓÛ/¾ÿøñû?ı³şöëÿÿşãşÛoûı÷ÿğƒşêİôïß}ó/üî›üş;Ó‘(%—ƒVİ¢Ä’Ÿ«Tósú¿ |¥S
+endstream
+endobj
+
+304 0 obj
+<<
+  /Type /Annot
+  /Subtype /Link
+  /Rect [227.92964 597.455 239.54564 612.11804]
+  /Border [0 0 0]
+  /Dest 289 0 R
+  /F 4
+  /StructParent 6
+  /Contents ([4])
+>>
+endobj
+
+305 0 obj
+<<
+  /Type /Annot
+  /Subtype /Link
+  /Rect [136.71214 302.37463 148.32814 317.03766]
+  /Border [0 0 0]
+  /Dest 290 0 R
+  /F 4
+  /StructParent 7
+  /Contents ([5])
+>>
+endobj
+
+306 0 obj
+<<
+  /Type /Page
+  /Resources <<
+    /ProcSet [/PDF /Text /ImageC /ImageB]
+    /ColorSpace <<
+      /c0 271 0 R
+    >>
+    /Font <<
+      /f0 259 0 R
+      /f1 241 0 R
+      /f2 253 0 R
+      /f3 247 0 R
+    >>
+  >>
+  /MediaBox [0 0 595.2756 841.8898]
+  /StructParents 8
+  /Tabs /S
+  /Parent 1 0 R
+  /Contents 307 0 R
+  /Annots [304 0 R 305 0 R]
+>>
+endobj
+
+307 0 obj
+<<
+  /Length 6164
+  /Filter /FlateDecode
+>>
+stream
+xœ½=k³·mßï¯XU–œ›Dğéz’X²3“¶îc¬™>,·•_Çi,¥Êítúï;<¯İå‚‹½‡<çË9÷±K‚ €x>ÿæÏoŞŸ~3Ï¿~ù»/só«_/¾|yóß78˜ÁÏp@ô`Øa‚ó@ÎøáİO7Ïß™áİ_nÌğ—wïo^¼º1Ã«7ÏïÌ€8¼ºßÎ_¯~ºùÙkcÌ?ß¯şxóÕ«›ºùêë—7ÏËÙQšDCÁ6ÏşÚR  	 kÀ¡ç!xŸ‚çó  ^ÀFÆzw> Œ _|¼ÿñîÍ»ûáÅ×•I]cF¬¿üæÆß¼üûÖÿ{c‡¯oò;?İ8pƒştóMmqV\\ ÜÏÓ¶»¿S0ë¤É½k©}ò×wÊì^šİEH&v˜İ«Ì*«'c2a Ë
+]U>S¦ÒôÀ[2í[;TIš=ZÖÚt•cf„kìqÖ~'EÎØZ›7ø™†^‰o“A0†vm›ş+mz‰k2PL¦W™JŒ•Œ‡àœ»wA‰¹:°	S;SO—Ä]‰<Ød¹ú~®M/1Wb&…İô	ŒsÜ~‰»%:,ÿµ1Aƒ U00jàÛ=÷€ ?|‡Ûï†W³¦ÈI—ƒÆ¸kà„$–H.BˆÜ‚ßjÓ‹,Ñ[pì³Èõ0‘¿˜Ä'‘'„Bh'JU‘Yb´`¢ÉúŞd>¹u®(ó'³ö“ù$rİdÀGCöâ2Ÿ$®ËÆ sì Ñk2Ÿ$¦Ë&3}$wq™CÇetà“İ!ÿÂ2‡%şÊ&ûÔã>¥óW–ø+£‡yáí2Ç`8œtsøFMê°Ät™¢óé*H‘¸.s ô)]\æ°ÄtÙ$¢ty‘ÃÃeg€}f³—9,ñCöÖ¼ñ(¬BpE3NÚOŞ°Èq}ãƒi×(@C®Èq»İ:óYÄ-ë¸ì4ncEœRÄËK +òßÀ;—®rë°"·M)3Û‹Û´¬Äk­1`Ñt°Vk‡İJÌÖ"‚EÆË›\¬Äl-!˜€š§ÿ[mz‰ÙZòàw˜^S¿¬Äi-%ˆ©í³€Ä-[@gÚvÿÜ·•ø£u‚Á«\¸Ä­‹`]Líh;â$~h}ë±‡ïJ•şNb‡6XH] x«M/±Cg,D‡ÖöĞÇ1qûï·e:‰SÑïÃŒÅ5ÀPŒã¿¾Í.÷·göœ¥a÷êçâs¹òükC<{äôÊ7‡¡¤Wu…Â‰>2ç }`¿S«$ô/ÕœdD®ÃôÿªM/ûÈpŒš§×|ßNö‘y@c®|ÙIF@È	›§ÿ7Í?*:ÈC¤`Û‘¿}zÙ…•€;AÀ*²ËpÁ°=ÿşü­6¿ìÆ21šó¿~­ mÑAD·í*œZä¨Gz&Gmc	:üv¼“ùÛâñÍ^‹<}P|­.vSQØ¯L;“ËG~?~‘?~™?>9Àª#W~m~†—İ‹Ogxxp\ù£óÁ>ÍgUÌe1Ûb{[ˆÇ¡&{rW_ÿn¦¿*ä¼°Ò§òtÇW¶ÄªQìİªÎ‚	8Dß¢´Yi¹¿#x“#SvÏ>ÍŠ‹ÍÒ”êx“1|¡½L»z#˜•YÔ¹ı]õí*Å	óŸ)0r"5/ş}3¦À&¯Í€õË‚üÇ¹° å³w`±¿T¬®°°c¯®`dƒM{Ç­à>Á_®#LŞÒÏ²_=ËÆB@çmËY.nÒî—‹ù[ˆ$k³Ğ.hD~<öx«“Ğ‘iÓôëÏïöåÉê1›Jù~•N±•¸È{"€si$Ó±ö#?Èl÷ùèviwÛËİªıëyşx‘?^ôÔÎıœQ<><XíÿŸ¯dgEÑHõ½EsÉ¦çÒ}dlÚñkÇÛ'ÆQ“yÁê“Ì¸ç\°­ÒÈpâ×|`$_Ú
+¼uáSÿÏÌ…T<
+şºo®T.¤£,G>˜øª,î®òÿ*óX õlô“*hs9t'®
+QÔ*h‚‹'­Äÿ"àHv£®2ß‰Ú3Íd‚vÖD³wvõRÜrØhˆ·ÈÒÃ*J;ØÅ‹™qí#G&~TW$Ù]1„¢ka[ÍÁ¬ò/—ÀÇQS‡€‡êY…á¹€dy‰Øb3 ‡]};ğxE<2ş“PšÓ?Ï¨û$&Š§NÔ~Ôç4 í{ U¬“…”%3P}ÉÏ'2C\	’é'Y ô©4%¿>âÔÎwâ$DœîwäqeóŠßCï7ñövx6Ùıºr§¨|ªâiÕ•àsÄ9·èñÕ›\$‡4Ú%ÊeŸÔğBB®ß\–ãjzõıù]{qÛåÓI'XD[m	A³¤ ‰’oŞ²•E1’8›owÍÄ1ŠÕ9ÒISÔ¥}ŞsµİÃ¿UR8ÔB/SÊ"K[èªü;MXˆQ@ÙHm²‘ºmò×&c€s•§ÆÉÿCË¡Ã}(Zòƒ7r€ï¹ÆùĞfÃ}rÀ§D¨{£a4ŠA?Ö@èZ‰ï?5$ˆá•Î€ñ/L{Q®ô¬ó>\šöÄĞJSôîòÄçk±wÉ¥k×İB2|2X…Ë}~ù†(¯ÓF¼/\0‹a
+	t¬ÈÏ—
+IŒ9åN¬ÅUË‡‹˜­9;ŞôF’(Ğ†Óëtñ)¡@® Œ©*jN¿<:ıôy¹¯åH¥_böëªÆÑ;¸ß¡Ç¢Í’Â´Ms¹Ğ Gc:ìªG”ÄÌ-Bà^Û<½Æf“˜¶Å<ºöù5N›Ä  Nà}Ìó'“.Æi“`-xï¬»Ø¡ZØ\—ÏÔìm
+9'›ü»7ï~öıûÛJJûa´eu¼¾º-7MdQØ"RÚå9{°M^Iï~º²±ó{éâ^²y›OÒè¿8F©
+OÉòp4YšÒF+Ş`'¾ìÅ
+è9xV¢Sëª«Ğ„œTÑ e»M6— Ÿ6íâ'µ—8=y#–†èÙ›ÚãÒ«†s1}#Xv´émâNNŞÎGœ©}Ë¹²;uïE¹‹3ñ¯+ŠäÂÒ£»ôâW'&!ØF>¥sB¸Sa¨û=JX¸îiœ:¾Ÿh‹*V¢ILxïLæ7
+E|ÖN²yàÉJ«ÜÌ0&®†„7>T¢Dª|š†İø ÉÆx|v¦ZE16°mBÛz$ê½Z¬F…˜Ÿ ØPÒÃˆ¥¸R.„È]`Ğ2:ĞˆÕ¸’‡Df#¯ÂğN@.ìÂÀÆtB‚Saíë&&´ˆá÷* ¢] ÍÑÈíHĞD4YCH`‰6¢@adklf~ñ/¬üoµ·â½TsgÁ=Òûó–l·Î<Ñß‹'·Ú?¶pL938§NXl'ïUúSƒœMÛæßp_«mÑÁü$FVß‚~ÏÜ‡*ãP£r#¾#ËÖ2ÖD£±Û¨‹X¶®Áˆü™¨VºB[›ûRO@ßíì”ïÊ)f…:sŠÏR±#JünDÏêRKX‰Üv¥êŒkÜŸ‡U!-_„€)$;¸rhìåÊxÉeÜ0»V²ú! ˜Îçcškå2nd!æ<úæù·¨}r)7ö`]®"ÑƒæáC¹˜›%ğ1ô `‹Ê%tóŒ¹\æ‰.Hˆ¢ÀyÖ]eäêm>—!ş:„(—o¹¼f;|+êåC.à=IÚĞ*, \Á-!Æ ü  òÃ ’ÃL\ ‹¹BP,àÆÆyŸÚ×¯“ èõFäw Á?¨ ˆq>²^Ívpä!ç…_êö+—X#vï­A„`ù|‰ülk1£qJ"0œ¶”3Jà]TŠæÊEÜØÑÎ×ÙºÁ?ªukÅ"k1ånà* bT‘Ë ÄØbå‘‹¶¹.…ÇLc@¹h›·C$¨¹p›O€®
+TV/—nÈá/ÌêÅÚmcñ’Ôª—ĞÆê%(VuË8cR°ƒR¤óïfº>(V^#cÀEx7†.wBD…Ô$H„æß¢ŠÅÖˆ<Ûh›,X®‡ŠÈ‹%×&0„m%< ¢ì8kLp‚ı–2òbI·\ÊšØFwJ‹º‡<mJû/u~Qçµ’Ï-Pzº*ÅÒn¹v6YìqÜ7ä$¡XßmW=»ú5\,ò–¯áÙøvT±,yË5´£	 C 2Ş+²dsÌU¶A¬ë–¯èOXH× ]ş‰¥İ(&ˆ>ç\ÄÒn9á"zº ë»å¨4Ëc;ú.ˆJ*fÖ˜2 É@r¬H¿–úH(ÖGc²£Ğ{@ğ'Ñ$@	R.B{é –IË‰ ÄŞt Õ,Jc›Ù2¹"RÇ€xmw6+D)^ˆÅÒò…1…`;°ƒŸT Äk{pBŠş
+¼@,•Æ‘À!÷Ğõ-¹aÊÅ1^E4‹ÅÒÆ+kÕ‚›¸ñÊº^½ÊzÁ­»Ò´4ıy ÄÑuªfÛ£X‹'™7A¶ÁUO91ÊpK@Tâ$Ë*E.ìÛµ2¾:İJù£ù“}“…„uïGüR°	ò×óãjÑa+äHï“o^ÄÁ´úÖ|ÀçÅÌEZö¾yèÂ
+Â„HËú³Òÿfå¬NÃ4ÖÒÁWg;¾)’èÖĞÆõR9¹X´qn•e­Ÿ¾Ñşó`ªânÌF±	’ƒh0«£ÓÖóN¬‚Á¡Í¦‚V ¶\
+ÄÚ!è Eî‚n)«‡ä¢Å¾ªB(ÖòÈ…‹}ô}@Pğ‰<rñâÈ‘Rû£6Õ@@±@†œ¤î7ÂÑ+SÅÊ=xLíû¢j©bEˆ?L²’x•*{D‹¶8÷ò«9oİG#n 9ï%‚A—Õ×¸ÑÏ­Ü¶€’mÄMÍ¾€A¬êÎ¡*ÄÚdDG`P;HŠuÈzÈIX×ÚÑøïrû®N0èÖN±ÌÃ>öŠC¸D€§ÜP§:MŠ ï€%šygÖW»Á ï…ìğığ°&E>sh,c;ƒ6¿\ ò.óo!G¹,@v}:ì‚*ÉåÊ i#ÑÕâ$Ö`“[ºZçÚ!PÍIö P¶{öØİ_IÍ`;ñEÙÀä	ñ’>1[zçğ;vÔ
+€ª#&LgÿCò¶ßE'¤­}sPLtåÜ/†Ô)j³eSó˜è¶İt6WŸSo£Vpc—mÓò×n<+ªAÅyÆŠ'óÏî!ĞW 6ÒÊmHBî­Û›ÙÂ˜d	—µuÒ:d1ŒN­$¦µZ—óL\-W‹ë%1«5›Ş­7Ùys…k1‰Y­6x0¡ÇíSm^-&µÚè 0e^+ Zt?‰9­6!ÛzïÜl¨YPia¯‰üí´¸ˆJÒqÕ°Ì8­‡Hª•–Ù•hàNÿ“³+ågk.%ù;íÍ^­h¸>Ñ"—s^	{õÑ- <_¸VÁ\¥†ê}…Ùo#‡¦„`“MómÁs>Ü­óoapbFgVÖÉ†ìh…A»1‘˜Ñ™;ÄGãr_+ *‡:]®ŸÖ€÷* òu%¥¸Û‚¸Ö¤b-`‰’7®T jñJ¡ ,($ft2» ac¥ªDÿwêQ÷ùï<šqÇPÖZe´H®—WÒŞ8ê¡l\Lƒu1Ç¶ÓNVµÚ»3˜ )÷d°Làƒ¦¥­`­5‰™°.ßEöQ>×%b*ì¨\‘@©	uÄdØKÀ¸ |Pç—dIÈa—”çÇì¶¢‹Ò$Kry„´ó–µ"@eäb.l2@}æu~1nË‚‹»ù¯°’I"R¸bÀ‰ağÎ›› Z€ILXÅÌ9ë1Í¨*•˜°Šˆ¹ÂİVl©!YŸtgÛ÷g«q(¼¹Rİ´x§ı[æqK‹(®Sû![k§U_	ñ}-Àñ·ƒ«6Œ*îÆ+­§Êq+íÌ%4mIÓ&äTcËÀl8¶Ó®z)”óŒm„rnùeHWyÛÒíyÈ'kuª„¦Ğ{ï@Ôòü®‡Ûn ^Õ€Œã}KÔğ²9\ÙÊ¯@BÅ.\”­ìÔuÄüp´9ºŒÑmB€ĞıtÎax¿Ş6vÑ$÷áí×HÌ<'ôLÛ–ÖÚ€Äìóyå¼Š`Ğ7t`ó*a­[·Ú"Îzñ÷YÛ®Kõ^#1¡}D¸M8‡n^¢“—
+)¥‘C—=†ç5gö±lÙ-MOÊd? Êâ²=ö—uÖ?‘_è]j}>ú§(‹Z»‹®äX[]ÑëYx¢Ò‹[ÚÃM²|³ewJ¼æ®=®Bp|¸N•2BıÇb3µCº°­7—¬ìÕŠÓ;£_pM{á‘îkºI–šØÔŠ‹3•OL/ÔÇZ4Ó›kæeÌÒ§UXzêp;,›ÈF¬B>vË^ÃÖ*¡IàÌ´tÕ-ŞX)–º|vC¿êª«o¹H¿É6‹k’xŠq?]_§„Y§÷é¾GvKõV¡¯F1İú5Ccb±–‘Ÿ»ŸÍê×àÈùIŞÔz§Å†*°±»çµËâ®ôÆ^QmuVn±-ŒÙµü¢7‚°ÜJ—n¹Mé£ê@ÆyÒ–' Ê‚cUÛ„è«³°%¥ÛäBİåê:§Ã¡ßšÎVı¹c²É7´Q*÷³I¡æërØÀÙÄT3öº,jğW›rxH,–„6Sì„áŞ–[ËOK7‚¬wŸmê“)ÿØdæ8ü÷ãìd¼?ßÄ!×sÊ!Y˜7mÓf‡XÏétsE!—#UÏ¶pD€UG 'n0Ï/»¿ÂªÊÎåRkí#µ¿·[î&71pI	µâm#Ş]6á¹eé¶±f›ÙÙùr*í¤n[µ*&H.02ôÌİv”÷¥ş|B2¯œ#ÄeWÇÓGæ!&rÚğ8©2Şoh,‡Qÿî8´e c'âC#‚qDöá`/yQÔBäs…µı>X;ßâGÈ§3™Çê¤A[3ØF44”wŞñûôwuÎè	
+áÀlš—ñÙípDúQöÏzäï¹sCwyy9-R_®R à©Iç-iÅ¦0AôŠ-cúúi.; `á}šÈíGb–‰>ä¢ål¹´1—}sïTvÓ®Òó_ä—£É^×ˆÅº~Œ!ÍÁƒ1öT6IJ}…¾6^_€]=Â=v¼«âÔhµ±»tJæÖÒ-¨qkÜ “ƒ\¸·%ÇCjz†ƒâ~Ôs¯ã:eT2Š37%ÀÙ¿ÉçLG©_=.=pºj©.KDíx@Ê±#lí&[÷Òz8÷8Î¸Ë|ä¥¿jb«9Â£b0¬c0š¹zØåÀŠ¨ä¹+‚jËa‹k|¨ËaSlÉ¸‹„Ë)&3zá6(¯Ğâz>ŒP5¬±°™ñj[+÷\aó„Êv
+)Û.»©© Š58GÖê	ÙÂ´¦ló¤^–V†ùŞ­6•+bíöFf#¸~®›Q²Œ†ªóiŸğRÅ*š&O©3»JóÇæîç )÷,†Ûid¿È¿ÜxÄ2§”Ú8¿îv<[Ä’––j%tP_¯íTbĞl{Z$QN§ÌõÁ‹‰9;^õùq;ÏDf9:XTÄÙUÃ‚M´08Y0÷“¾uiË»ív†İªÑ}Aßj[İ/"KÇ\3.\ƒä$µãÉíÀ9úÅJÓtÔRè\DK›0ğ€Dm$Ë’ì/®iGül–èbåÏÉ>¢/¬kÒ¡x2gÔÇ ”2„´òîÜºš=7æî&£cs]ÕìÀ
+Ê;Â‰ıÛÅ‚§‰’,yºÒ{Z¸ïÏ¾
+
+Ë¼¨RhO°êÙ£õ‹ûû7ïşğıï‡oŸ¿øpÿá§ïò_¿ùŸ·÷ÿ÷çï‡ç¿ığáşûùO¯v¿ÿã›~|ÿæşÇïÅ’Lbqp­‹á\ÇÚ¯gN­ÿòcL¬
+endstream
+endobj
+
+308 0 obj
+<<
+  /Type /Annot
+  /Subtype /Link
+  /Rect [70.86614 614.7932 82.48214 629.45624]
+  /Border [0 0 0]
+  /Dest 291 0 R
+  /F 4
+  /StructParent 9
+  /Contents ([1])
+>>
+endobj
+
+309 0 obj
+<<
+  /Type /Annot
+  /Subtype /Link
+  /Rect [246.72314 585.4672 373.23413 600.13025]
+  /Border [0 0 0]
+  /A <<
+    /Type /Action
+    /S /URI
+    /URI (https://doi.org/10.1109/IVS.2015.7225830)
+  >>
+  /F 4
+  /StructParent 10
+  /Contents (https://doi.org/10.1109/IVS.2015.7225830)
+>>
+endobj
+
+310 0 obj
+<<
+  /Type /Annot
+  /Subtype /Link
+  /Rect [70.86614 564.7543 82.48214 579.41724]
+  /Border [0 0 0]
+  /Dest 292 0 R
+  /F 4
+  /StructParent 11
+  /Contents ([2])
+>>
+endobj
+
+311 0 obj
+<<
+  /Type /Annot
+  /Subtype /Link
+  /Rect [89.63214 550.0912 217.34215 564.7543]
+  /Border [0 0 0]
+  /A <<
+    /Type /Action
+    /S /URI
+    /URI (https://doi.org/10.1007/978-1-4614-1433-9)
+  >>
+  /F 4
+  /StructParent 12
+  /Contents (https://doi.org/10.1007/978-1-4614-1433-9)
+>>
+endobj
+
+312 0 obj
+<<
+  /Type /Annot
+  /Subtype /Link
+  /Rect [70.86614 529.37823 82.48214 544.04126]
+  /Border [0 0 0]
+  /Dest 293 0 R
+  /F 4
+  /StructParent 13
+  /Contents ([3])
+>>
+endobj
+
+313 0 obj
+<<
+  /Type /Annot
+  /Subtype /Link
+  /Rect [296.45413 500.05222 436.71515 514.7152]
+  /Border [0 0 0]
+  /A <<
+    /Type /Action
+    /S /URI
+    /URI (https://doi.org/10.1109/TSMC.1983.6313077)
+  >>
+  /F 4
+  /StructParent 14
+  /Contents (https://doi.org/10.1109/TSMC.1983.6313077)
+>>
+endobj
+
+314 0 obj
+<<
+  /Type /Annot
+  /Subtype /Link
+  /Rect [70.86614 479.33923 82.48214 494.00223]
+  /Border [0 0 0]
+  /Dest 294 0 R
+  /F 4
+  /StructParent 15
+  /Contents ([4])
+>>
+endobj
+
+315 0 obj
+<<
+  /Type /Annot
+  /Subtype /Link
+  /Rect [186.20114 450.0132 322.63416 464.67624]
+  /Border [0 0 0]
+  /A <<
+    /Type /Action
+    /S /URI
+    /URI (https://doi.org/10.1109/ICRA.2011.5980409)
+  >>
+  /F 4
+  /StructParent 16
+  /Contents (https://doi.org/10.1109/ICRA.2011.5980409)
+>>
+endobj
+
+316 0 obj
+<<
+  /Type /Annot
+  /Subtype /Link
+  /Rect [70.86614 429.30023 82.48214 443.96323]
+  /Border [0 0 0]
+  /Dest 295 0 R
+  /F 4
+  /StructParent 17
+  /Contents ([5])
+>>
+endobj
+
+317 0 obj
+<<
+  /Type /Annot
+  /Subtype /Link
+  /Rect [482.85144 399.97424 524.4094 414.63724]
+  /Border [0 0 0]
+  /A <<
+    /Type /Action
+    /S /URI
+    /URI (https://doi.org/10.1109/IROS.2018.8594448)
+  >>
+  /F 4
+  /StructParent 18
+  /Contents (https://doi.org/10.1109/IROS.2018.8594448)
+>>
+endobj
+
+318 0 obj
+<<
+  /Type /Annot
+  /Subtype /Link
+  /Rect [89.63214 385.31122 182.68114 399.97424]
+  /Border [0 0 0]
+  /A <<
+    /Type /Action
+    /S /URI
+    /URI (https://doi.org/10.1109/IROS.2018.8594448)
+  >>
+  /F 4
+  /StructParent 19
+  /Contents (https://doi.org/10.1109/IROS.2018.8594448)
+>>
+endobj
+
+319 0 obj
+<<
+  /Type /Page
+  /Resources <<
+    /ProcSet [/PDF /Text /ImageC /ImageB]
+    /ColorSpace <<
+      /c0 271 0 R
+    >>
+    /Font <<
+      /f0 241 0 R
+      /f1 247 0 R
+      /f2 265 0 R
+    >>
+  >>
+  /MediaBox [0 0 595.2756 841.8898]
+  /StructParents 20
+  /Tabs /S
+  /Parent 1 0 R
+  /Contents 320 0 R
+  /Annots [308 0 R 309 0 R 310 0 R 311 0 R 312 0 R 313 0 R 314 0 R 315 0 R 316 0 R 317 0 R 318 0 R]
+>>
+endobj
+
+320 0 obj
+<<
+  /Length 2907
+  /Filter /FlateDecode
+>>
+stream
+xœÍÛrÜ¶õ}¿N[×Ö÷Ô¤Ø©ËJj½ÅyU+u¦–ÓÍv:ıû¹€ À]Ò¾ÖÎıNŸmwïnnwäüòbõÏ#”P²aDS0J1A´f ‘+rûiuzKÉÅÛ%o/Ş¬¹\5‹?­(±$òÕÛÕ«ç—«Ó±}‘Y°L/¿1×Lq¾ô¾j‡WSàÀ´¼¯¤àœĞÃvæŒĞêKlM(Í_~k¥+úío7÷äéÓ!§—/¿%tõÍ7äüÛøéÄZŒúSn_QòûíıêüzEÉõvuzG	cäú®¹¹]Zıôè¥ô¥¼»ëı›ÓwwÍõûŸ¸X“Ò½Áöo¼ïŞÃõÏäúÕêùõ,ƒ¢p
+´ 
+ª»ËÕ£à{-u°w×Äa÷`Mwˆò=Ivk²aœjÊH÷lÆŸò pP;ÂrÑÜI–êTŞCòÒö…w»}±L_Ácõ9†À"–OèîÎ"¸¹Š°@'W5<x®ugç‹É+÷{)~!Ö>z¯ŠD?aÛ{/œrÉ‡[Ù)¥2 Ê]¤j±ByµŠÖT…@‰·„$1]2N½ŠÅŠP¥‚—,š?TÀ¹8­¯bõ6Pft— X•hUÖÌ¹Ğ?k.§^¥ ¹À^CãsÀI`‚°“ºÀòvÅD‘¼n``çœ”¤RãÊ¨EUÔu™ªŒÅ>}YŸ¢¼5¨MQA4Fiæ]™7'yuŒåTYÇöQ8øX;˜ß-v´UQ±E¢Ï—”»Ä?î©¼+xG.ªaS1òSV “æx‰iA}Ü¥z¸'šÄ>ª‰¤“³ªagå°p6~ÓDÏG4¡…o>´´±{^ô¼CËÅhŞyRg®†e|Îw+%œ•£?¥m”†üŸCVŒõæó>¡{ùù{Â­½¾Rìx‰ŞYÌ2Ï$÷¢-
+÷—‘‘EU¥U.´3
+po„ ÆhÅ“ Æ©õ$âóºÃ×qÛA¤‰=ú”ÇİqM8î¥ãaµltçj6ŠàÊàÑbĞj[§©B’ÕŒÅq	HşâˆÓë}“ü3-ìTOB£’8Ü^|õØë½ğv©9¯úçD7híĞïj'bÑbF™ø^ãlläÅFÔÌZ/®ã›u^qèú€3i[ÆÂÇû¾U.©8Š•ã±N%g $ç»h]O=ñUX/ñÙ×c£\÷lº¨’”ƒ¦òx•ìU&‰Ğ’\È	h"­	C°FI•„h¸”†â»TåÓ|)qãàœ&2êä1NÇSÓ2Ügs|Ø‡(<d,¨ÅğûQjš0ÓüóõÍı/äÑ‡ûu.î”¶LO*¬EKIˆ1¸ó5a¬b’i’¾äG&¸ê5Ùè~yT}J–¦[dÎ»_“`³ØÊ½ÏFÇû5Û
+ŞXÆedŠlM$k­Õ‰ÚFú5¨&TkkŒõÆBT ŠŒuÖ¢ãÕ½3Õêl.cŒv"hÕÂf›î¯-¬gÍ¥}ô<³®«G÷ yÕşı×Íå¤¹\f¼¾V…3ÒS¯fgóB¡@#_„^=
+pÁ¬­_µ¬~Õ\\"ê¶ÏŞøÂ?»òš³ûÑc€°%ÊA'‰‚äßAC‰+`–	9­U…Fˆú#Œj™Ñåæ’R®9 ŒÏâ¡y\“ë_KbÄK©…T8Ú™©…˜”Z (š¦¹<²šKPŒ1>o]ˆóà66ïI¸9p?>˜­a*k™éÆoPi§à]±ÈÇz±Öm´0Àµ*­ïxb¸j@ìĞÂ·Åı’}8-­vQKÑR7ŞÈ»ì8¬ÒU–äòZ.$Áqé‹2XğÄh&¯ÏFeÙYa‘rÓ|¹Êf@íº®€1ÛÅ3)9(¥P-íáÎüå÷p¯ıŸW¾e­ı¿Z¿ÿƒÿí$^râİÚ3ÿàõT ‹€†ò¥İCT²Æ½M>ÁX@K©x·\+™.ÉYü›ìİlÑ»q+yïÏsoÏ&¹7‹o{îÎ…5¨À(äTÖ¡’}z’›r	š2zt‹¡›MWàÔQæ?’ÿ )y’Å›*P_WWĞüĞGj]½ÊË0•JÈ“–Ü~I¡­É/í§,Qñ%)xu%)´eY²,Év&ôºƒ:NÏiY œª—á¬¨˜Ì4¶îxÏ¿ÉÊâ®Íö©±Æ5m1¢àe“w]é¨%Òİq%,ŒÇ†œ'HDkPgTÅ’ıfTÅ’‚j|ôÂÃ’$ÅıÃï'ÊV`ÈAKŠS„b‰ú—ä`$ÆxÊ'¡nFosÅÓØ2$!ôvüÜA°Y“Ôµ¶yÁéx¸ãÓ,®r$=(¼SH%j¼çÓkd”ƒB|ó]àígÃTÈJoVÇÚr˜aUÌ%×L0F6±Ø¤ª®
+ôaéëà2[_ê+lWqào§}ÌŞ¿š8/7á¹–,ZB¶¥›Ù= üæ¬‰3”bÑŒĞ=ùùUûú›OwŞL®Ä¸# `}Ùj©T…sFsT‡Á(#ª¥8+ ®@³¹
+25Yáº”¬ƒ`™˜YŠ;™–«˜’œÉé ”F&-3½;õŞq¥Œ‘İ·$k_Õ€|;´8˜)¦$¼LPM›ÜŞ£fÚ¡î¸Ì¶>Šáéìj*,lOû¨/W
+õáIà}’îƒ±ƒºt aàMŸ®<»3ÔŒ°5¶kjf‹j¦ dx¼]Ì›Ú.ÅÒD[P†3yl»YĞj\i`R16‰KÄÛF‚R’ëñÄR–#4OéR =àGöè±B·Ÿ'ó äBÇnõ]öYî¸\ˆŸ,"¹Êz¹ú]2jéğB Yü :.© ¤™â4väAŠ»Ø;H0Tïh‹\aAXL)£ĞïĞ¹$ú8øe¤t?±c%°h©$iÌ¼ì¡ş÷â‹ËÌƒ¨Á¼L˜/ríQÖL•R¶æ‡vÙ7¾ÈJ­ö¨3ó<şÏ|¸ßj€b€4èK/ÖjG
+)êC°(ãµf„È~ø…Š¦f1rj|/ŠS¼‚#=cPOy^Wã{QœâIfŠ—ƒl¦¯sõÊÜ‚¤hõ”³]ˆøõÆÈG¨B’×|İŒ¿¡MJJ@ºšÙøÑO†ñÓÚ¾™6ÏÈÁéW2ŒK€—+ñZœŠa2U0~úË9C¹ñVçÅoWGFKëiÉ\ªºfä©ª";ä¢)S3œaìÕÃÅÁ¾Ş¿Q¨Dct¬°Ég>İ=0cÛ<{0ŒÅÓ¶—ÿĞ*^7k6÷ù(»‹H³€0í¾tOŞd®#‘Ü©İ¶Ğ,¥¸i¦—aÅ¡¹^u´XPJ
+3Idç¥z_…_İª€+íÀ‘Ò ’öÖH8}ˆWPRØY$ü²Ùç¹­š£~W}áñïôÀÃŞmÇÒ Û`õ1ı´‘s£T–¬	vÓtŒOª'´27ÂÂ•N­6“ï€)9D	¨´p³™ß’¬çªºÇhš9\«}–™oç¶—dÊl¡ ù¦[21M¡I2§f‚!híÃ´|&(‘j*õAG@“êJ§GkÜ0ÍxÉÑÄnÕìqïlÿZ›‹¿
+Ÿ]ÅûI|¹:xl’ö£
+…<š7ŸZTh—/‡ (ÃfïQïQ¢,Úc¸ãl·»¹ıû‡¿‘ŸNÏ?ïvŸ?ıÜüúö_ïwÿùí9}ñùóîÃ¶ùéºıû‡›_>Şßì>~¾Ï¶k›ş·6D"P&¤ÑÇÂ}ı_–©2‹
+endstream
+endobj
+
+321 0 obj
+<<
+  /Title (Technical Note: Benchmark Platform Models)
+  /Author (Ruixiang Du)
+  /Creator (Typst 0.14.2)
+  /ModDate (D:20260710090045+08'00)
+  /CreationDate (D:20260710090045+08'00)
+>>
+endobj
+
+322 0 obj
+<<
+  /Length 1187
+  /Type /Metadata
+  /Subtype /XML
+>>
+stream
+<?xpacket begin="ï»¿" id="W5M0MpCehiHzreSzNTczkc9d"?><x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="xmp-writer"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/"  xmlns:xmp="http://ns.adobe.com/xap/1.0/"  xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"  xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"  xmlns:pdf="http://ns.adobe.com/pdf/1.3/" ><dc:title><rdf:Alt><rdf:li xml:lang="x-default">Technical Note: Benchmark Platform Models</rdf:li></rdf:Alt></dc:title><dc:creator><rdf:Seq><rdf:li>Ruixiang Du</rdf:li></rdf:Seq></dc:creator><xmp:CreatorTool>Typst 0.14.2</xmp:CreatorTool><dc:language><rdf:Bag><rdf:li>en</rdf:li></rdf:Bag></dc:language><xmp:ModifyDate>2026-07-10T09:00:45+08:00</xmp:ModifyDate><xmp:CreateDate>2026-07-10T09:00:45+08:00</xmp:CreateDate><xmpTPg:NPages>4</xmpTPg:NPages><dc:format>application/pdf</dc:format><xmpMM:InstanceID>gnRXeNQntaXosNCFMIc+kQ==</xmpMM:InstanceID><xmpMM:DocumentID>H9mFVSdnUBk6Ukf7g2+74g==</xmpMM:DocumentID><xmpMM:RenditionClass>proof</xmpMM:RenditionClass><pdf:PDFVersion>1.7</pdf:PDFVersion></rdf:Description></rdf:RDF></x:xmpmeta><?xpacket end="r"?>
+endstream
+endobj
+
+323 0 obj
+<<
+  /Type /Catalog
+  /Pages 1 0 R
+  /Metadata 322 0 R
+  /PageLabels 16 0 R
+  /Lang (en)
+  /StructTreeRoot 17 0 R
+  /MarkInfo <<
+    /Marked true
+    /Suspects false
+  >>
+  /ViewerPreferences <<
+    /Direction /L2R
+  >>
+  /Outlines 2 0 R
+>>
+endobj
+
+xref
+0 324
+0000000000 65535 f
+0000000016 00000 n
+0000000106 00000 n
+0000000187 00000 n
+0000000280 00000 n
+0000000434 00000 n
+0000000557 00000 n
+0000000684 00000 n
+0000000813 00000 n
+0000000953 00000 n
+0000001116 00000 n
+0000001226 00000 n
+0000001382 00000 n
+0000001476 00000 n
+0000001590 00000 n
+0000001705 00000 n
+0000001799 00000 n
+0000001872 00000 n
+0000002299 00000 n
+0000003598 00000 n
+0000007697 00000 n
+0000009849 00000 n
+0000010246 00000 n
+0000010704 00000 n
+0000010865 00000 n
+0000010950 00000 n
+0000011031 00000 n
+0000011148 00000 n
+0000011349 00000 n
+0000011504 00000 n
+0000011659 00000 n
+0000011750 00000 n
+0000011829 00000 n
+0000011976 00000 n
+0000012061 00000 n
+0000012142 00000 n
+0000012262 00000 n
+0000012399 00000 n
+0000012554 00000 n
+0000012642 00000 n
+0000012721 00000 n
+0000012868 00000 n
+0000012953 00000 n
+0000013034 00000 n
+0000013151 00000 n
+0000013288 00000 n
+0000013443 00000 n
+0000013534 00000 n
+0000013613 00000 n
+0000013760 00000 n
+0000013845 00000 n
+0000013926 00000 n
+0000014040 00000 n
+0000014177 00000 n
+0000014332 00000 n
+0000014420 00000 n
+0000014499 00000 n
+0000014646 00000 n
+0000014731 00000 n
+0000014812 00000 n
+0000014929 00000 n
+0000015066 00000 n
+0000015221 00000 n
+0000015312 00000 n
+0000015391 00000 n
+0000015538 00000 n
+0000015646 00000 n
+0000015854 00000 n
+0000015946 00000 n
+0000016126 00000 n
+0000016309 00000 n
+0000016489 00000 n
+0000016581 00000 n
+0000016762 00000 n
+0000016943 00000 n
+0000017122 00000 n
+0000017214 00000 n
+0000017395 00000 n
+0000017576 00000 n
+0000017755 00000 n
+0000017847 00000 n
+0000018028 00000 n
+0000018220 00000 n
+0000018313 00000 n
+0000018494 00000 n
+0000018586 00000 n
+0000018767 00000 n
+0000018952 00000 n
+0000019133 00000 n
+0000019225 00000 n
+0000019410 00000 n
+0000019595 00000 n
+0000019776 00000 n
+0000019868 00000 n
+0000020049 00000 n
+0000020234 00000 n
+0000020415 00000 n
+0000020508 00000 n
+0000020678 00000 n
+0000020771 00000 n
+0000020942 00000 n
+0000021036 00000 n
+0000021208 00000 n
+0000021303 00000 n
+0000021421 00000 n
+0000021546 00000 n
+0000021639 00000 n
+0000021789 00000 n
+0000021906 00000 n
+0000022111 00000 n
+0000022204 00000 n
+0000022300 00000 n
+0000022440 00000 n
+0000022564 00000 n
+0000022672 00000 n
+0000022767 00000 n
+0000022959 00000 n
+0000023075 00000 n
+0000023168 00000 n
+0000023423 00000 n
+0000023662 00000 n
+0000023873 00000 n
+0000023969 00000 n
+0000024065 00000 n
+0000024185 00000 n
+0000024280 00000 n
+0000024374 00000 n
+0000024478 00000 n
+0000024573 00000 n
+0000024677 00000 n
+0000024781 00000 n
+0000024930 00000 n
+0000025052 00000 n
+0000025167 00000 n
+0000025286 00000 n
+0000025378 00000 n
+0000025497 00000 n
+0000025792 00000 n
+0000025973 00000 n
+0000026068 00000 n
+0000026176 00000 n
+0000026292 00000 n
+0000026408 00000 n
+0000026516 00000 n
+0000026656 00000 n
+0000026760 00000 n
+0000026963 00000 n
+0000027266 00000 n
+0000027479 00000 n
+0000027575 00000 n
+0000027671 00000 n
+0000027767 00000 n
+0000027871 00000 n
+0000027975 00000 n
+0000028079 00000 n
+0000028178 00000 n
+0000028274 00000 n
+0000028418 00000 n
+0000028568 00000 n
+0000028709 00000 n
+0000028834 00000 n
+0000028991 00000 n
+0000029084 00000 n
+0000029179 00000 n
+0000029299 00000 n
+0000029419 00000 n
+0000029519 00000 n
+0000029830 00000 n
+0000030023 00000 n
+0000030118 00000 n
+0000030258 00000 n
+0000030378 00000 n
+0000030498 00000 n
+0000030626 00000 n
+0000030746 00000 n
+0000030854 00000 n
+0000030962 00000 n
+0000031301 00000 n
+0000031568 00000 n
+0000031657 00000 n
+0000031984 00000 n
+0000032185 00000 n
+0000032297 00000 n
+0000032395 00000 n
+0000032490 00000 n
+0000032597 00000 n
+0000032713 00000 n
+0000032807 00000 n
+0000032950 00000 n
+0000033099 00000 n
+0000033248 00000 n
+0000033404 00000 n
+0000033553 00000 n
+0000033645 00000 n
+0000033749 00000 n
+0000033843 00000 n
+0000033953 00000 n
+0000034045 00000 n
+0000034265 00000 n
+0000034378 00000 n
+0000034498 00000 n
+0000034634 00000 n
+0000034767 00000 n
+0000034896 00000 n
+0000034989 00000 n
+0000035105 00000 n
+0000035255 00000 n
+0000035494 00000 n
+0000035615 00000 n
+0000035710 00000 n
+0000035823 00000 n
+0000035942 00000 n
+0000036071 00000 n
+0000036173 00000 n
+0000036265 00000 n
+0000036465 00000 n
+0000036575 00000 n
+0000036688 00000 n
+0000036807 00000 n
+0000036946 00000 n
+0000037063 00000 n
+0000037218 00000 n
+0000037310 00000 n
+0000037402 00000 n
+0000037494 00000 n
+0000037589 00000 n
+0000037681 00000 n
+0000037792 00000 n
+0000037904 00000 n
+0000037995 00000 n
+0000038099 00000 n
+0000038180 00000 n
+0000038270 00000 n
+0000038358 00000 n
+0000038440 00000 n
+0000038522 00000 n
+0000038667 00000 n
+0000038809 00000 n
+0000038868 00000 n
+0000038927 00000 n
+0000038986 00000 n
+0000039045 00000 n
+0000039222 00000 n
+0000040198 00000 n
+0000040289 00000 n
+0000040538 00000 n
+0000042394 00000 n
+0000050797 00000 n
+0000050971 00000 n
+0000051756 00000 n
+0000051847 00000 n
+0000052093 00000 n
+0000053597 00000 n
+0000059754 00000 n
+0000059919 00000 n
+0000060187 00000 n
+0000060278 00000 n
+0000060555 00000 n
+0000061775 00000 n
+0000069795 00000 n
+0000069974 00000 n
+0000071212 00000 n
+0000071302 00000 n
+0000071556 00000 n
+0000074020 00000 n
+0000087582 00000 n
+0000087758 00000 n
+0000088331 00000 n
+0000088422 00000 n
+0000088679 00000 n
+0000089871 00000 n
+0000094326 00000 n
+0000094364 00000 n
+0000094723 00000 n
+0000094777 00000 n
+0000094831 00000 n
+0000094885 00000 n
+0000094939 00000 n
+0000094993 00000 n
+0000095047 00000 n
+0000095101 00000 n
+0000095153 00000 n
+0000095207 00000 n
+0000095260 00000 n
+0000095314 00000 n
+0000095368 00000 n
+0000095421 00000 n
+0000095474 00000 n
+0000095527 00000 n
+0000095580 00000 n
+0000095634 00000 n
+0000095687 00000 n
+0000095742 00000 n
+0000095796 00000 n
+0000095850 00000 n
+0000095902 00000 n
+0000095957 00000 n
+0000096140 00000 n
+0000096499 00000 n
+0000100990 00000 n
+0000101172 00000 n
+0000101354 00000 n
+0000101535 00000 n
+0000101910 00000 n
+0000111613 00000 n
+0000111794 00000 n
+0000111977 00000 n
+0000112344 00000 n
+0000118588 00000 n
+0000118768 00000 n
+0000119067 00000 n
+0000119248 00000 n
+0000119547 00000 n
+0000119729 00000 n
+0000120030 00000 n
+0000120212 00000 n
+0000120513 00000 n
+0000120695 00000 n
+0000120996 00000 n
+0000121297 00000 n
+0000121719 00000 n
+0000124706 00000 n
+0000124910 00000 n
+0000126188 00000 n
+trailer
+<<
+  /Size 324
+  /Root 323 0 R
+  /Info 321 0 R
+  /ID [(H9mFVSdnUBk6Ukf7g2+74g==) (gnRXeNQntaXosNCFMIc+kQ==)]
+>>
+startxref
+126447
+%%EOF

--- a/docs/typst/models.typ
+++ b/docs/typst/models.typ
@@ -1,0 +1,106 @@
+#import "template/template.typ": arkheion, arkheion-appendices
+
+#show link: underline
+#set cite(style: "ieee")
+
+#show: arkheion.with(
+  title: "Technical Note: Benchmark Platform Models",
+  authors: (
+    (name: "Ruixiang Du", email: "ruixiang.du@gmail.com", affiliation: ""),
+  ),
+  abstract: [This note documents the platform models implemented in `src/control/models` (namespace conventions, state/control layouts, governing equations, default parameters, and the closed-form oracle each implementation is validated against), with references to the originating literature. The set is chosen deliberately: classical models that are thoroughly understood in the literature yet rich enough to evaluate the estimation, planning, and control algorithms of this repository — each model stresses a property the others do not.],
+)
+
+= Conventions
+
+Every model exposes the discrete `Step` concept used across the stack (`x_(t+1) = "Step"(x_t, u_t, t, Delta t)`, forward Euler unless noted) and, where the dynamics are continuous, the derivative `Deriv` used with the fixed-step classical RK4 propagator (`rk4.hpp`) for high-fidelity simulation. The numerical cores are scalar-templated raw-span functions in `model_core.hpp`, shared verbatim between the CPU implementations and the CUDA rollout programs (see the MPPI note). Units are SI (m, s, rad, N, kg) throughout; frames are stated per model.
+
+= Wheeled platforms
+
+== Differential drive (kinematic unicycle)
+
+State $bold(x) = (x, y, theta)$ (world position, heading), control $bold(u) = (v, omega)$ (forward speed, yaw rate):
+
+$ dot(x) = v cos theta, quad dot(y) = v sin theta, quad dot(theta) = omega $
+
+The model class of production wheeled MPPI deployments (Nav2); actuator dynamics are absorbed by the box constraints. File: `diff_drive.hpp`.
+
+== Kinematic bicycle (Ackermann)
+
+State $bold(x) = (x, y, theta)$, control $bold(u) = (v, delta)$ (speed, front steering angle), wheelbase $L$:
+
+$ dot(x) = v cos theta, quad dot(y) = v sin theta, quad dot(theta) = (v / L) tan delta $
+
+The standard low-speed car model @Kong2015-bicycle. Default $L = 0.5 "m"$ (robot scale); the mismatch campaign overrides it to match the dynamic plant. File: `ackermann.hpp`.
+
+== Bicycle with acceleration input
+
+State $bold(x) = (x, y, v, theta)$, control $bold(u) = (a, delta)$:
+
+$ dot(x) = v cos theta, quad dot(y) = v sin theta, quad dot(v) = a, quad dot(theta) = (v / L) tan delta $
+
+Successor of the retired `model/BicycleKinematics` (wheelbase constant $L = 2.4 "m"$ preserved); the reachability Monte-Carlo propagates it with RK4. *Oracles:* straight-line constant-acceleration closed form; constant-steering circle of radius $L \/ tan delta$. File: `bicycle_accel.hpp`.
+
+== Single-track model with linear tires ("dynamic bicycle")
+
+The standard vehicle lateral-dynamics benchmark (Rajamani @Rajamani2011, ch. 2; the kinematic-vs-dynamic comparison plant of Kong et al. @Kong2015-bicycle). State $bold(x) = (X, Y, psi, v_x, v_y, r)$ — world position and heading, *body-frame* longitudinal/lateral velocities, yaw rate; control $bold(u) = (a_x, delta)$. With front/rear axle distances $l_f, l_r$ from the CoM, mass $m$, yaw inertia $I_z$, and per-axle cornering stiffnesses $C_f, C_r$, the linear-tire slip angles and lateral forces are
+
+$ alpha_f = (v_y + l_f r) / v_x - delta, quad alpha_r = (v_y - l_r r) / v_x, quad F_(y f) = -C_f alpha_f, quad F_(y r) = -C_r alpha_r $
+
+and the dynamics are
+
+$ dot(X) = v_x cos psi - v_y sin psi, quad dot(Y) = v_x sin psi + v_y cos psi, quad dot(psi) = r $
+$ dot(v)_x = a_x + v_y r, quad dot(v)_y = (F_(y f) cos delta + F_(y r)) / m - v_x r, quad dot(r) = (l_f F_(y f) cos delta - l_r F_(y r)) / I_z $
+
+The linear tire model is meaningless near standstill: slip-angle denominators clamp at $v_(x,min)$ (default $0.5 "m/s"$). Defaults are a mid-size passenger car: $m = 1500 "kg"$, $I_z = 2500 "kg m"^2$, $l_f = 1.2 "m"$, $l_r = 1.6 "m"$, $C_f = C_r = 80000 "N/rad"$. *Oracle:* the steady-state yaw rate under constant speed and steering,
+
+$ r_(s s) = v_x / (L + K_(u s) v_x^2) delta, quad K_(u s) = m / L ((l_r) / (C_f) - (l_f) / (C_r)), quad L = l_f + l_r $
+
+verified to 1% by simulation with $v_x$ held exactly ($a_x = -v_y r$); at low speed the model reproduces the kinematic yaw rate $ (v \/ L) tan delta$ to 2%. Role in this repository: the designated *mismatch plant* — planners use the kinematic bicycle, this plant slips (per-seed tire-stiffness variation in the nightly campaign). File: `dynamic_bicycle.hpp`.
+
+= Underactuated benchmark
+
+== Cart-pole (inverted pendulum on a cart)
+
+The classical underactuated benchmark, in the exact formulation of Barto, Sutton & Anderson @Barto1983-cartpole (uniform pole, frictionless track and pivot). State $bold(x) = (x, dot(x), theta, dot(theta))$ with $theta$ measured *from upright* ($theta = 0$ is the unstable equilibrium, $theta = pi$ hangs down); control $u = F$ (force on the cart). With cart mass $M$, pole mass $m$, pivot-to-CoM distance $l$ (half the pole length):
+
+$ dot.double(theta) = (g sin theta - cos theta dot xi) / (l (4/3 - (m cos^2 theta) / (M + m))), quad xi = (F + m l dot(theta)^2 sin theta) / (M + m) $
+$ dot.double(x) = xi - (m l dot.double(theta) cos theta) / (M + m) $
+
+The $4\/3$ factor carries the uniform pole's moment of inertia ($I_"com" = m (2l)^2 \/ 12$). Defaults are the literature-standard set: $M = 1 "kg"$, $m = 0.1 "kg"$, $l = 0.5 "m"$, force limit $plus.minus 10 "N"$. *Oracles:* conservation of the mechanical energy
+
+$ E = 1/2 M dot(x)^2 + 1/2 m (dot(x) + l dot(theta) cos theta)^2 + 1/2 m (l dot(theta) sin theta)^2 + 1/2 I_"com" dot(theta)^2 + m g l (cos theta - 1) $
+
+under zero force ($|Delta E| < 10^(-6)$ relative over 10 s of RK4), instability of the upright equilibrium, and bounded oscillation about the hanging one. The integration scenario is the classical controller handover: MPPI swings the pole up globally, a DLQR state-feedback controller (gain synthesized from a numeric linearization at the upright) catches and holds. File: `cartpole.hpp`.
+
+= Aerial platform
+
+== Quadrotor (rigid body)
+
+The canonical aerial benchmark @Mellinger2011-minsnap. State (13): $bold(p) in RR^3$, $bold(v) in RR^3$ (world frame), unit quaternion $bold(q)$ (w-x-y-z, body-to-world), $bold(omega) in RR^3$ in the *body* frame — note the SRB quadruped model (MPPI note) uses world-frame $bold(omega)$; the difference is deliberate and follows each model's literature convention. Control $bold(u) = (f, bold(tau))$: total thrust along the body $z$ axis and body-frame moments. With diagonal inertia $bold(I)$:
+
+$ dot(bold(p)) = bold(v), quad dot(bold(v)) = -g bold(e)_3 + (f / m) bold(R)(bold(q)) bold(e)_3 $
+$ dot(bold(q)) = 1/2 bold(q) times.o (0, bold(omega)), quad dot(bold(omega)) = bold(I)^(-1) (bold(tau) - bold(omega) times bold(I) bold(omega)) $
+
+`Step` renormalizes the quaternion after the Euler update. Defaults are a lab-scale small quadrotor: $m = 0.5 "kg"$, $bold(I) = "diag"(2.32, 2.32, 4.0) times 10^(-3) "kg m"^2$. *Oracles:* hover ($f = m g$, level) is an exact equilibrium; free fall matches $z = -g t^2 \/ 2$; a pure yaw moment integrates $omega_z = (tau_z \/ I_(z z)) t$ exactly (the gyroscopic term vanishes for pure $z$ rotation) with the quaternion norm preserved. File: `quadrotor.hpp`.
+
+= Legged platform
+
+The single-rigid-body (SRB) quadruped — trunk as one rigid body driven by per-foot ground-reaction forces, massless legs, per-step foot plan and contact schedule — is documented with the MPPI technical note (it is that controller's primary legged plant) and follows the convex-MPC lineage @DiCarlo2018-convexmpc. File: `srb_quadruped.hpp`.
+
+= Choosing a model
+
+#table(
+  columns: (auto, auto, auto),
+  align: left,
+  [*Model*], [*Stresses*], [*Typical use*],
+  [double integrator], [analytic oracles, LQR baselines], [controller unit tests],
+  [diff drive / kinematic bicycle], [planar planning, box constraints], [MPPI wheeled scenarios, tuner],
+  [bicycle (accel input)], [second-order wheeled, RK4 propagation], [reachability Monte-Carlo],
+  [dynamic bicycle], [*model mismatch*, slip, speed-dependent stability], [nightly robustness campaigns],
+  [cart-pole], [instability, swing-up/catch handover], [global+local controller composition],
+  [quadrotor], [3D attitude, force/moment control], [3D estimation + control in the loop],
+  [SRB quadruped], [contact schedules, GRF control], [legged MPPI, GPU rollouts],
+)
+
+#bibliography("bibliography.bib")

--- a/docs/typst/models.typ
+++ b/docs/typst/models.typ
@@ -13,7 +13,7 @@
 
 = Conventions
 
-Every model exposes the discrete `Step` concept used across the stack (`x_(t+1) = "Step"(x_t, u_t, t, Delta t)`, forward Euler unless noted) and, where the dynamics are continuous, the derivative `Deriv` used with the fixed-step classical RK4 propagator (`rk4.hpp`) for high-fidelity simulation. The numerical cores are scalar-templated raw-span functions in `model_core.hpp`, shared verbatim between the CPU implementations and the CUDA rollout programs (see the MPPI note). Units are SI (m, s, rad, N, kg) throughout; frames are stated per model.
+Every model exposes the discrete `Step` concept used across the stack (`x_(t+1) = "Step"(x_t, u_t, t, Delta t)`, forward Euler unless noted) and, where the dynamics are continuous, the derivative `Deriv` used with the fixed-step classical RK4 propagator (`rk4.hpp`) for high-fidelity simulation. The numerical cores are scalar-templated raw-span functions in `model_core.hpp`, shared verbatim between the CPU implementations and the CUDA rollout programs (see the MPPI note). Units are SI (m, s, rad, N, kg) throughout; frames are stated per model. `linearize.hpp` provides central-difference Jacobians of any `Deriv` model about an operating point — the standard bridge to the linear tools (`SolveDlqr`, `StateFeedbackController`): linearize, Euler-discretize ($A_d = I + A Delta t$, $B_d = B Delta t$, consistent with `Step`), synthesize.
 
 = Wheeled platforms
 

--- a/docs/typst/mppi.pdf
+++ b/docs/typst/mppi.pdf
@@ -5992,8 +5992,8 @@ endobj
   /Title <FEFF0054006500630068006E006900630061006C0020004E006F00740065003A0020004D006F00640065006C002000500072006500640069006300740069007600650020005000610074006800200049006E00740065006700720061006C00200043006F006E00740072006F006C00202014002000440065007200690076006100740069006F006E00200061006E006400200049006D0070006C0065006D0065006E0074006100740069006F006E>
   /Author (Ruixiang Du)
   /Creator (Typst 0.14.2)
-  /ModDate (D:20260707214708+08'00)
-  /CreationDate (D:20260707214708+08'00)
+  /ModDate (D:20260710090045+08'00)
+  /CreationDate (D:20260710090045+08'00)
 >>
 endobj
 
@@ -6004,7 +6004,7 @@ endobj
   /Subtype /XML
 >>
 stream
-<?xpacket begin="﻿" id="W5M0MpCehiHzreSzNTczkc9d"?><x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="xmp-writer"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/"  xmlns:xmp="http://ns.adobe.com/xap/1.0/"  xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"  xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"  xmlns:pdf="http://ns.adobe.com/pdf/1.3/" ><dc:title><rdf:Alt><rdf:li xml:lang="x-default">Technical Note: Model Predictive Path Integral Control — Derivation and Implementation</rdf:li></rdf:Alt></dc:title><dc:creator><rdf:Seq><rdf:li>Ruixiang Du</rdf:li></rdf:Seq></dc:creator><xmp:CreatorTool>Typst 0.14.2</xmp:CreatorTool><dc:language><rdf:Bag><rdf:li>en</rdf:li></rdf:Bag></dc:language><xmp:ModifyDate>2026-07-07T21:47:08+08:00</xmp:ModifyDate><xmp:CreateDate>2026-07-07T21:47:08+08:00</xmp:CreateDate><xmpTPg:NPages>5</xmpTPg:NPages><dc:format>application/pdf</dc:format><xmpMM:InstanceID>iAZ1pfLx2+RA2bvzoxLVRg==</xmpMM:InstanceID><xmpMM:DocumentID>ai+oikWk7x4DVXVMvRY78Q==</xmpMM:DocumentID><xmpMM:RenditionClass>proof</xmpMM:RenditionClass><pdf:PDFVersion>1.7</pdf:PDFVersion></rdf:Description></rdf:RDF></x:xmpmeta><?xpacket end="r"?>
+<?xpacket begin="﻿" id="W5M0MpCehiHzreSzNTczkc9d"?><x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="xmp-writer"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/"  xmlns:xmp="http://ns.adobe.com/xap/1.0/"  xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"  xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"  xmlns:pdf="http://ns.adobe.com/pdf/1.3/" ><dc:title><rdf:Alt><rdf:li xml:lang="x-default">Technical Note: Model Predictive Path Integral Control — Derivation and Implementation</rdf:li></rdf:Alt></dc:title><dc:creator><rdf:Seq><rdf:li>Ruixiang Du</rdf:li></rdf:Seq></dc:creator><xmp:CreatorTool>Typst 0.14.2</xmp:CreatorTool><dc:language><rdf:Bag><rdf:li>en</rdf:li></rdf:Bag></dc:language><xmp:ModifyDate>2026-07-10T09:00:45+08:00</xmp:ModifyDate><xmp:CreateDate>2026-07-10T09:00:45+08:00</xmp:CreateDate><xmpTPg:NPages>5</xmpTPg:NPages><dc:format>application/pdf</dc:format><xmpMM:InstanceID>NxNnaHPzdGfb9OGWxWZa4A==</xmpMM:InstanceID><xmpMM:DocumentID>ai+oikWk7x4DVXVMvRY78Q==</xmpMM:DocumentID><xmpMM:RenditionClass>proof</xmpMM:RenditionClass><pdf:PDFVersion>1.7</pdf:PDFVersion></rdf:Description></rdf:RDF></x:xmpmeta><?xpacket end="r"?>
 endstream
 endobj
 
@@ -6530,7 +6530,7 @@ trailer
   /Size 496
   /Root 495 0 R
   /Info 493 0 R
-  /ID [(ai+oikWk7x4DVXVMvRY78Q==) (iAZ1pfLx2+RA2bvzoxLVRg==)]
+  /ID [(ai+oikWk7x4DVXVMvRY78Q==) (NxNnaHPzdGfb9OGWxWZa4A==)]
 >>
 startxref
 149043

--- a/src/control/models/include/xmnav/models/bicycle_accel.hpp
+++ b/src/control/models/include/xmnav/models/bicycle_accel.hpp
@@ -8,6 +8,9 @@
  * continuous derivative (for RK4, see rk4.hpp) and the discrete Step
  * concept the rest of the stack uses (forward Euler).
  *
+ * Equations, conventions, parameters, and validation oracles:
+ * docs/typst/models.typ (compiled: models.pdf).
+ *
  * Copyright (c) 2026 Ruixiang Du (rdu)
  */
 

--- a/src/control/models/include/xmnav/models/cartpole.hpp
+++ b/src/control/models/include/xmnav/models/cartpole.hpp
@@ -1,0 +1,72 @@
+/*
+ * @file cartpole.hpp
+ * @brief Cart-pole (inverted pendulum on a cart).
+ *
+ * The classical underactuated benchmark, in the formulation of Barto,
+ * Sutton & Anderson, "Neuronlike adaptive elements that can solve
+ * difficult learning control problems", IEEE T-SMC 1983 (uniform pole,
+ * frictionless). Default parameters are the literature-standard set
+ * (1 kg cart, 0.1 kg pole, 0.5 m half-length).
+ *
+ * State [x (m), x_dot (m/s), theta (rad), theta_dot (rad/s)] with theta
+ * measured FROM UPRIGHT (theta = 0 is the unstable equilibrium, theta =
+ * pi hangs down); control [force (N)].
+ *
+ * Equations, conventions, parameters, and validation oracles:
+ * docs/typst/models.typ (compiled: models.pdf).
+ *
+ * Copyright (c) 2026 Ruixiang Du (rdu)
+ */
+
+#ifndef XMNAV_MODELS_CARTPOLE_HPP
+#define XMNAV_MODELS_CARTPOLE_HPP
+
+#include <cmath>
+
+#include <eigen3/Eigen/Dense>
+
+#include "xmnav/models/model_core.hpp"
+
+namespace xmotion {
+
+struct CartPoleModel {
+  static constexpr int kStateDim = 4;
+  static constexpr int kControlDim = 1;
+
+  using State = Eigen::Matrix<double, kStateDim, 1>;
+  using Control = Eigen::Matrix<double, kControlDim, 1>;
+
+  double cart_mass = 1.0;         // kg
+  double pole_mass = 0.1;         // kg
+  double pole_half_length = 0.5;  // m, pivot to pole CoM
+  double gravity = 9.81;
+
+  State Deriv(const State &x, const Control &u) const {
+    State xd;
+    model_core::CartPoleDeriv(x.data(), u.data(), cart_mass, pole_mass,
+                              pole_half_length, gravity, xd.data());
+    return xd;
+  }
+
+  State Step(const State &x, const Control &u, int /*t*/, double dt) const {
+    return x + Deriv(x, u) * dt;
+  }
+
+  // total mechanical energy (uniform pole: I_com = m (2l)^2 / 12); zero
+  // potential at the upright pole. Conserved when unforced — the test
+  // oracle for the dynamics.
+  double Energy(const State &x) const {
+    const double l = pole_half_length;
+    const double vpx = x(1) + l * x(3) * std::cos(x(2));
+    const double vpy = -l * x(3) * std::sin(x(2));
+    const double i_com = pole_mass * (2.0 * l) * (2.0 * l) / 12.0;
+    return 0.5 * cart_mass * x(1) * x(1) +
+           0.5 * pole_mass * (vpx * vpx + vpy * vpy) +
+           0.5 * i_com * x(3) * x(3) +
+           pole_mass * gravity * l * (std::cos(x(2)) - 1.0);
+  }
+};
+
+}  // namespace xmotion
+
+#endif  // XMNAV_MODELS_CARTPOLE_HPP

--- a/src/control/models/include/xmnav/models/dynamic_bicycle.hpp
+++ b/src/control/models/include/xmnav/models/dynamic_bicycle.hpp
@@ -13,7 +13,9 @@
  * world position/heading, body-frame velocities, yaw rate; control
  * [ax (m/s^2), delta (rad)] — longitudinal acceleration command and
  * front steering angle. The linear tire model is meaningless near
- * standstill: slip-angle denominators clamp at vx_min.
+ * standstill: slip-angle denominators clamp at vx_min. FORWARD MOTION
+ * ONLY — the clamp also makes reverse driving (vx < 0) silently behave
+ * as slow forward motion; use a kinematic model for reversing.
  *
  * Equations, conventions, parameters, and validation oracles:
  * docs/typst/models.typ (compiled: models.pdf).
@@ -60,6 +62,13 @@ struct DynamicBicycleModel {
   // steady-state yaw rate under constant speed and steering (Rajamani):
   // r_ss = vx / (L + Kus vx^2) * delta, Kus = m/L (lr/Cf - lf/Cr) —
   // the closed-form test oracle
+  // front/rear tire slip angles at a state/steering (the quantities to
+  // plot when studying the mismatch behavior)
+  Eigen::Vector2d SlipAngles(const State &x, double delta) const {
+    const double vx = x(3) > vx_min ? x(3) : vx_min;
+    return {(x(4) + lf * x(5)) / vx - delta, (x(4) - lr * x(5)) / vx};
+  }
+
   double SteadyStateYawRate(double vx, double delta) const {
     const double L = lf + lr;
     const double kus =

--- a/src/control/models/include/xmnav/models/dynamic_bicycle.hpp
+++ b/src/control/models/include/xmnav/models/dynamic_bicycle.hpp
@@ -1,0 +1,73 @@
+/*
+ * @file dynamic_bicycle.hpp
+ * @brief Single-track ("bicycle") model with linear tires.
+ *
+ * The standard vehicle lateral-dynamics benchmark (Rajamani, "Vehicle
+ * Dynamics and Control", ch. 2; the kinematic-vs-dynamic comparison
+ * model of Kong et al., IV 2015). Its role in this repo: the designated
+ * MISMATCH PLANT — planners use the kinematic bicycle; this plant slips.
+ * Default parameters are a mid-size passenger car (Rajamani's typical
+ * values).
+ *
+ * State [X (m), Y (m), psi (rad), vx (m/s), vy (m/s), r (rad/s)] —
+ * world position/heading, body-frame velocities, yaw rate; control
+ * [ax (m/s^2), delta (rad)] — longitudinal acceleration command and
+ * front steering angle. The linear tire model is meaningless near
+ * standstill: slip-angle denominators clamp at vx_min.
+ *
+ * Equations, conventions, parameters, and validation oracles:
+ * docs/typst/models.typ (compiled: models.pdf).
+ *
+ * Copyright (c) 2026 Ruixiang Du (rdu)
+ */
+
+#ifndef XMNAV_MODELS_DYNAMIC_BICYCLE_HPP
+#define XMNAV_MODELS_DYNAMIC_BICYCLE_HPP
+
+#include <eigen3/Eigen/Dense>
+
+#include "xmnav/models/model_core.hpp"
+
+namespace xmotion {
+
+struct DynamicBicycleModel {
+  static constexpr int kStateDim = 6;
+  static constexpr int kControlDim = 2;
+
+  using State = Eigen::Matrix<double, kStateDim, 1>;
+  using Control = Eigen::Matrix<double, kControlDim, 1>;
+
+  double mass = 1500.0;             // kg
+  double yaw_inertia = 2500.0;      // kg m^2
+  double lf = 1.2;                  // m, CoM to front axle
+  double lr = 1.6;                  // m, CoM to rear axle
+  double cornering_front = 80000.0; // N/rad, per axle
+  double cornering_rear = 80000.0;  // N/rad, per axle
+  double vx_min = 0.5;              // m/s, tire-model validity clamp
+
+  State Deriv(const State &x, const Control &u) const {
+    State xd;
+    model_core::DynamicBicycleDeriv(x.data(), u.data(), mass, yaw_inertia,
+                                    lf, lr, cornering_front, cornering_rear,
+                                    vx_min, xd.data());
+    return xd;
+  }
+
+  State Step(const State &x, const Control &u, int /*t*/, double dt) const {
+    return x + Deriv(x, u) * dt;
+  }
+
+  // steady-state yaw rate under constant speed and steering (Rajamani):
+  // r_ss = vx / (L + Kus vx^2) * delta, Kus = m/L (lr/Cf - lf/Cr) —
+  // the closed-form test oracle
+  double SteadyStateYawRate(double vx, double delta) const {
+    const double L = lf + lr;
+    const double kus =
+        mass / L * (lr / cornering_front - lf / cornering_rear);
+    return vx / (L + kus * vx * vx) * delta;
+  }
+};
+
+}  // namespace xmotion
+
+#endif  // XMNAV_MODELS_DYNAMIC_BICYCLE_HPP

--- a/src/control/models/include/xmnav/models/linearize.hpp
+++ b/src/control/models/include/xmnav/models/linearize.hpp
@@ -1,0 +1,51 @@
+/*
+ * @file linearize.hpp
+ * @brief Numeric linearization of Deriv-concept models.
+ *
+ * Central-difference Jacobians of the continuous dynamics about an
+ * operating point — the standard bridge from the nonlinear models to
+ * linear tools (SolveDlqr, StateFeedbackController): linearize, Euler-
+ * discretize (A_d = I + A dt, B_d = B dt, consistent with the models'
+ * Step), synthesize. Works for any model exposing
+ * State Deriv(State, Control).
+ *
+ * Copyright (c) 2026 Ruixiang Du (rdu)
+ */
+
+#ifndef XMNAV_MODELS_LINEARIZE_HPP
+#define XMNAV_MODELS_LINEARIZE_HPP
+
+#include <eigen3/Eigen/Dense>
+
+namespace xmotion {
+
+template <typename Model>
+struct Linearization {
+  Eigen::Matrix<double, Model::kStateDim, Model::kStateDim> A;
+  Eigen::Matrix<double, Model::kStateDim, Model::kControlDim> B;
+};
+
+template <typename Model>
+Linearization<Model> LinearizeNumeric(const Model &model,
+                                      const typename Model::State &x0,
+                                      const typename Model::Control &u0,
+                                      double eps = 1e-6) {
+  Linearization<Model> lin;
+  for (int j = 0; j < Model::kStateDim; ++j) {
+    typename Model::State xp = x0, xm = x0;
+    xp(j) += eps;
+    xm(j) -= eps;
+    lin.A.col(j) = (model.Deriv(xp, u0) - model.Deriv(xm, u0)) / (2.0 * eps);
+  }
+  for (int j = 0; j < Model::kControlDim; ++j) {
+    typename Model::Control up = u0, um = u0;
+    up(j) += eps;
+    um(j) -= eps;
+    lin.B.col(j) = (model.Deriv(x0, up) - model.Deriv(x0, um)) / (2.0 * eps);
+  }
+  return lin;
+}
+
+}  // namespace xmotion
+
+#endif  // XMNAV_MODELS_LINEARIZE_HPP

--- a/src/control/models/include/xmnav/models/model_core.hpp
+++ b/src/control/models/include/xmnav/models/model_core.hpp
@@ -148,6 +148,94 @@ XMNAV_HD inline void SrbQuadrupedStep(const Scalar x[13], const Scalar u[12],
   for (int i = 0; i < 3; ++i) next[10 + i] = omega[i] + omega_dot[i] * dt;
 }
 
+// Cart-pole (inverted pendulum on a cart), the classical underactuated
+// benchmark, in the exact formulation of Barto, Sutton & Anderson 1983
+// (uniform pole, frictionless; pole_half_length is l, the pivot-to-CoM
+// distance). State [x, x_dot, theta, theta_dot] with theta measured FROM
+// UPRIGHT (theta = 0 is the unstable equilibrium); control [force].
+template <typename Scalar>
+XMNAV_HD inline void CartPoleDeriv(const Scalar x[4], const Scalar u[1],
+                                   Scalar cart_mass, Scalar pole_mass,
+                                   Scalar pole_half_length, Scalar gravity,
+                                   Scalar xd[4]) {
+  const Scalar st = std::sin(x[2]);
+  const Scalar ct = std::cos(x[2]);
+  const Scalar total = cart_mass + pole_mass;
+  const Scalar tmp =
+      (u[0] + pole_mass * pole_half_length * x[3] * x[3] * st) / total;
+  const Scalar theta_dd =
+      (gravity * st - ct * tmp) /
+      (pole_half_length *
+       (Scalar(4.0 / 3.0) - pole_mass * ct * ct / total));
+  const Scalar x_dd =
+      tmp - pole_mass * pole_half_length * theta_dd * ct / total;
+  xd[0] = x[1];
+  xd[1] = x_dd;
+  xd[2] = x[3];
+  xd[3] = theta_dd;
+}
+
+// Single-track ("bicycle") model with linear tires, Rajamani ch. 2:
+// body-frame lateral dynamics with front/rear cornering stiffness. State
+// [X, Y, psi, vx, vy, r] (world position/heading, body velocities, yaw
+// rate); control [ax, delta] (longitudinal acceleration command, front
+// steering angle). Denominators use max(vx, vx_min) — the linear tire
+// model is meaningless near standstill.
+template <typename Scalar>
+XMNAV_HD inline void DynamicBicycleDeriv(
+    const Scalar x[6], const Scalar u[2], Scalar mass, Scalar yaw_inertia,
+    Scalar lf, Scalar lr, Scalar cornering_front, Scalar cornering_rear,
+    Scalar vx_min, Scalar xd[6]) {
+  const Scalar vx = x[3] > vx_min ? x[3] : vx_min;
+  const Scalar alpha_f = (x[4] + lf * x[5]) / vx - u[1];
+  const Scalar alpha_r = (x[4] - lr * x[5]) / vx;
+  const Scalar fyf = -cornering_front * alpha_f;
+  const Scalar fyr = -cornering_rear * alpha_r;
+  const Scalar cd = std::cos(u[1]);
+  const Scalar cp = std::cos(x[2]);
+  const Scalar sp = std::sin(x[2]);
+  xd[0] = x[3] * cp - x[4] * sp;
+  xd[1] = x[3] * sp + x[4] * cp;
+  xd[2] = x[5];
+  xd[3] = u[0] + x[4] * x[5];
+  xd[4] = (fyf * cd + fyr) / mass - x[3] * x[5];
+  xd[5] = (lf * fyf * cd - lr * fyr) / yaw_inertia;
+}
+
+// Quadrotor rigid-body dynamics, Mellinger & Kumar 2011. State
+// [p(3), v(3), q(4, wxyz body->world), omega(3, BODY frame — note the
+// SRB quadruped uses world-frame omega)]; control [thrust, tau(3)]
+// (total thrust along body z, body-frame moments). Derivative of the
+// quaternion is returned in xd[6..9] (q_dot = 0.5 q (x) (0, omega));
+// integrators must renormalize q after stepping.
+template <typename Scalar>
+XMNAV_HD inline void QuadrotorDeriv(const Scalar x[13], const Scalar u[4],
+                                    Scalar mass,
+                                    const Scalar inertia_diag[3],
+                                    Scalar gravity, Scalar xd[13]) {
+  const Scalar *q = x + 6;
+  const Scalar *w = x + 10;
+  Scalar R[9];
+  QuatToRotation(q, R);
+  // v_dot = -g e3 + (thrust/m) R e3
+  xd[0] = x[3];
+  xd[1] = x[4];
+  xd[2] = x[5];
+  xd[3] = (u[0] / mass) * R[2];
+  xd[4] = (u[0] / mass) * R[5];
+  xd[5] = (u[0] / mass) * R[8] - gravity;
+  // q_dot = 0.5 q (x) (0, omega_body)
+  const Scalar half_w[4] = {Scalar(0), Scalar(0.5) * w[0],
+                            Scalar(0.5) * w[1], Scalar(0.5) * w[2]};
+  QuatMultiply(q, half_w, xd + 6);
+  // omega_dot = I^-1 (tau - omega x I omega)
+  const Scalar Iw[3] = {inertia_diag[0] * w[0], inertia_diag[1] * w[1],
+                        inertia_diag[2] * w[2]};
+  xd[10] = (u[1] - (w[1] * Iw[2] - w[2] * Iw[1])) / inertia_diag[0];
+  xd[11] = (u[2] - (w[2] * Iw[0] - w[0] * Iw[2])) / inertia_diag[1];
+  xd[12] = (u[3] - (w[0] * Iw[1] - w[1] * Iw[0])) / inertia_diag[2];
+}
+
 }  // namespace model_core
 }  // namespace xmotion
 

--- a/src/control/models/include/xmnav/models/quadrotor.hpp
+++ b/src/control/models/include/xmnav/models/quadrotor.hpp
@@ -1,0 +1,82 @@
+/*
+ * @file quadrotor.hpp
+ * @brief Quadrotor rigid-body dynamics.
+ *
+ * The canonical aerial benchmark (Mellinger & Kumar, "Minimum snap
+ * trajectory generation and control for quadrotors", ICRA 2011). Default
+ * parameters are a Kumar-lab-scale small quadrotor.
+ *
+ * State (13): [p(3) m, v(3) m/s, q(4, wxyz body->world),
+ * omega(3) rad/s in the BODY frame — note the SRB quadruped model uses
+ * world-frame omega]; control (4): [thrust (N, along body z),
+ * tau(3) (N m, body frame)]. Step() renormalizes the quaternion.
+ *
+ * Equations, conventions, parameters, and validation oracles:
+ * docs/typst/models.typ (compiled: models.pdf).
+ *
+ * Copyright (c) 2026 Ruixiang Du (rdu)
+ */
+
+#ifndef XMNAV_MODELS_QUADROTOR_HPP
+#define XMNAV_MODELS_QUADROTOR_HPP
+
+#include <eigen3/Eigen/Dense>
+#include <eigen3/Eigen/Geometry>
+
+#include "xmnav/models/model_core.hpp"
+
+namespace xmotion {
+
+struct QuadrotorModel {
+  static constexpr int kStateDim = 13;
+  static constexpr int kControlDim = 4;
+
+  using State = Eigen::Matrix<double, kStateDim, 1>;
+  using Control = Eigen::Matrix<double, kControlDim, 1>;
+
+  double mass = 0.5;  // kg
+  Eigen::Vector3d inertia_diag{2.32e-3, 2.32e-3, 4.0e-3};  // kg m^2
+  double gravity = 9.81;
+
+  static State MakeState(const Eigen::Vector3d &p, const Eigen::Vector3d &v,
+                         const Eigen::Quaterniond &q,
+                         const Eigen::Vector3d &omega_body) {
+    State x;
+    x.segment<3>(0) = p;
+    x.segment<3>(3) = v;
+    x(6) = q.w();
+    x(7) = q.x();
+    x(8) = q.y();
+    x(9) = q.z();
+    x.segment<3>(10) = omega_body;
+    return x;
+  }
+  static Eigen::Vector3d Position(const State &x) { return x.segment<3>(0); }
+  static Eigen::Vector3d Velocity(const State &x) { return x.segment<3>(3); }
+  static Eigen::Quaterniond Orientation(const State &x) {
+    return Eigen::Quaterniond(x(6), x(7), x(8), x(9));
+  }
+  static Eigen::Vector3d BodyRates(const State &x) {
+    return x.segment<3>(10);
+  }
+
+  // gravity-compensating hover thrust
+  double HoverThrust() const { return mass * gravity; }
+
+  State Deriv(const State &x, const Control &u) const {
+    State xd;
+    model_core::QuadrotorDeriv(x.data(), u.data(), mass,
+                               inertia_diag.data(), gravity, xd.data());
+    return xd;
+  }
+
+  State Step(const State &x, const Control &u, int /*t*/, double dt) const {
+    State next = x + Deriv(x, u) * dt;
+    model_core::QuatNormalize(next.data() + 6);
+    return next;
+  }
+};
+
+}  // namespace xmotion
+
+#endif  // XMNAV_MODELS_QUADROTOR_HPP

--- a/src/control/models/test/test_models.cpp
+++ b/src/control/models/test/test_models.cpp
@@ -194,3 +194,32 @@ TEST(BenchmarkModelsTest, QuadrotorFreeFallAndYawSpin) {
               1e-3 / model.inertia_diag(2) * 2.0, 1e-6);
   EXPECT_NEAR(QuadrotorModel::Orientation(s).norm(), 1.0, 1e-9);
 }
+
+#include "xmnav/models/linearize.hpp"
+
+// numeric linearization pins the known analytic Jacobian structure of
+// the double integrator exactly (Deriv is linear: differences are exact)
+TEST(BenchmarkModelsTest, NumericLinearizationMatchesLinearModel) {
+  BicycleAccelModel model;  // nonlinear check: bicycle at a straight run
+  BicycleAccelModel::State x0;
+  x0 << 0.0, 0.0, 5.0, 0.0;
+  const auto lin =
+      LinearizeNumeric(model, x0, BicycleAccelModel::Control::Zero());
+  // d(x_dot)/d(v) = cos(theta) = 1; d(y_dot)/d(theta) = v = 5
+  EXPECT_NEAR(lin.A(0, 2), 1.0, 1e-6);
+  EXPECT_NEAR(lin.A(1, 3), 5.0, 1e-6);
+  // d(v_dot)/d(a) = 1; d(theta_dot)/d(delta) = v/L at delta = 0
+  EXPECT_NEAR(lin.B(2, 0), 1.0, 1e-6);
+  EXPECT_NEAR(lin.B(3, 1), 5.0 / model.wheelbase, 1e-5);
+}
+
+TEST(BenchmarkModelsTest, DynamicBicycleSlipAnglesConsistent) {
+  DynamicBicycleModel model;
+  DynamicBicycleModel::State x = DynamicBicycleModel::State::Zero();
+  x(3) = 20.0;
+  x(4) = 0.3;
+  x(5) = 0.1;
+  const auto alphas = model.SlipAngles(x, 0.05);
+  EXPECT_NEAR(alphas(0), (0.3 + model.lf * 0.1) / 20.0 - 0.05, 1e-12);
+  EXPECT_NEAR(alphas(1), (0.3 - model.lr * 0.1) / 20.0, 1e-12);
+}

--- a/src/control/models/test/test_models.cpp
+++ b/src/control/models/test/test_models.cpp
@@ -97,3 +97,100 @@ TEST(ModelsTest, PlanarModelsStepSanity) {
   auto xi = di.Step(DoubleIntegratorModel::State::Zero(), ui, 0, 0.1);
   EXPECT_TRUE(xi.allFinite());
 }
+
+// --- classical benchmark models (cart-pole / dynamic bicycle / quadrotor) ---
+
+#include "xmnav/models/cartpole.hpp"
+#include "xmnav/models/dynamic_bicycle.hpp"
+#include "xmnav/models/quadrotor.hpp"
+
+// unforced frictionless cart-pole conserves mechanical energy (the
+// dynamics oracle for the Barto/Sutton formulation)
+TEST(BenchmarkModelsTest, CartPoleEnergyConservedUnforced) {
+  CartPoleModel model;
+  CartPoleModel::State x;
+  x << 0.0, 0.0, 2.5, 0.0;  // large swing, at rest
+  const double e0 = model.Energy(x);
+  const CartPoleModel::Control u = CartPoleModel::Control::Zero();
+  x = Rk4Propagate(model, x, u, 0.0, 10.0, 1e-3);
+  EXPECT_NEAR(model.Energy(x), e0, 1e-6 * std::abs(e0));
+}
+
+TEST(BenchmarkModelsTest, CartPoleUprightUnstableHangingStable) {
+  CartPoleModel model;
+  const CartPoleModel::Control u = CartPoleModel::Control::Zero();
+  // small perturbation at the upright equilibrium grows
+  CartPoleModel::State up;
+  up << 0.0, 0.0, 1e-3, 0.0;
+  up = Rk4Propagate(model, up, u, 0.0, 2.0, 1e-3);
+  EXPECT_GT(std::abs(up(2)), 0.1);
+  // ... and near the hanging equilibrium it oscillates, bounded
+  CartPoleModel::State down;
+  down << 0.0, 0.0, M_PI - 0.05, 0.0;
+  down = Rk4Propagate(model, down, u, 0.0, 5.0, 1e-3);
+  EXPECT_LT(std::abs(down(2) - M_PI), 0.10);
+}
+
+// constant speed + steering settles to Rajamani's steady-state yaw rate
+TEST(BenchmarkModelsTest, DynamicBicycleSteadyStateCornering) {
+  DynamicBicycleModel model;
+  DynamicBicycleModel::State x = DynamicBicycleModel::State::Zero();
+  x(3) = 20.0;  // m/s
+  const double delta = 0.05;
+  for (int i = 0; i < 5000; ++i) {
+    DynamicBicycleModel::Control u;
+    u << -x(4) * x(5), delta;  // ax cancels vy*r: vx held exactly
+    x = model.Step(x, u, i, 1e-3);
+  }
+  EXPECT_NEAR(x(3), 20.0, 1e-9);
+  EXPECT_NEAR(x(5), model.SteadyStateYawRate(20.0, delta),
+              0.01 * std::abs(model.SteadyStateYawRate(20.0, delta)));
+}
+
+// at low speed the dynamic model degenerates to the kinematic bicycle
+TEST(BenchmarkModelsTest, DynamicBicycleLowSpeedMatchesKinematic) {
+  DynamicBicycleModel model;
+  DynamicBicycleModel::State x = DynamicBicycleModel::State::Zero();
+  x(3) = 2.0;
+  const double delta = 0.05;
+  for (int i = 0; i < 5000; ++i) {
+    DynamicBicycleModel::Control u;
+    u << -x(4) * x(5), delta;
+    x = model.Step(x, u, i, 1e-3);
+  }
+  const double kinematic_r = 2.0 / (model.lf + model.lr) * std::tan(delta);
+  EXPECT_NEAR(x(5), kinematic_r, 0.02 * kinematic_r);
+}
+
+TEST(BenchmarkModelsTest, QuadrotorHoverIsEquilibrium) {
+  QuadrotorModel model;
+  const auto x0 = QuadrotorModel::MakeState(
+      Eigen::Vector3d(1.0, -2.0, 3.0), Eigen::Vector3d::Zero(),
+      Eigen::Quaterniond::Identity(), Eigen::Vector3d::Zero());
+  QuadrotorModel::Control u;
+  u << model.HoverThrust(), 0.0, 0.0, 0.0;
+  const auto x = Rk4Propagate(model, x0, u, 0.0, 1.0, 1e-3);
+  EXPECT_LT((x - x0).norm(), 1e-9);
+}
+
+TEST(BenchmarkModelsTest, QuadrotorFreeFallAndYawSpin) {
+  QuadrotorModel model;
+  // free fall: z = -g t^2 / 2
+  auto x = QuadrotorModel::MakeState(
+      Eigen::Vector3d::Zero(), Eigen::Vector3d::Zero(),
+      Eigen::Quaterniond::Identity(), Eigen::Vector3d::Zero());
+  x = Rk4Propagate(model, x, QuadrotorModel::Control::Zero(), 0.0, 1.0,
+                   1e-3);
+  EXPECT_NEAR(x(2), -0.5 * model.gravity, 1e-9);
+  // constant yaw moment: omega_z = tau_z / Izz * t exactly (gyroscopic
+  // term vanishes for pure z rotation); quaternion stays unit
+  auto s = QuadrotorModel::MakeState(
+      Eigen::Vector3d::Zero(), Eigen::Vector3d::Zero(),
+      Eigen::Quaterniond::Identity(), Eigen::Vector3d::Zero());
+  QuadrotorModel::Control u;
+  u << model.HoverThrust(), 0.0, 0.0, 1e-3;
+  s = Rk4Propagate(model, s, u, 0.0, 2.0, 1e-4);
+  EXPECT_NEAR(QuadrotorModel::BodyRates(s)(2),
+              1e-3 / model.inertia_diag(2) * 2.0, 1e-6);
+  EXPECT_NEAR(QuadrotorModel::Orientation(s).norm(), 1.0, 1e-9);
+}

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -17,3 +17,15 @@ add_executable(campaign_diffdrive campaign_diffdrive.cpp)
 target_link_libraries(campaign_diffdrive
     mppi shield sim gtest gtest_main)
 gtest_discover_tests(campaign_diffdrive PROPERTIES LABELS campaign)
+
+add_executable(test_pipeline_cartpole test_pipeline_cartpole.cpp)
+target_link_libraries(test_pipeline_cartpole models mppi pid gtest gtest_main)
+gtest_discover_tests(test_pipeline_cartpole PROPERTIES LABELS integration)
+
+add_executable(test_pipeline_quadrotor test_pipeline_quadrotor.cpp)
+target_link_libraries(test_pipeline_quadrotor models mppi gtest gtest_main)
+gtest_discover_tests(test_pipeline_quadrotor PROPERTIES LABELS integration)
+
+add_executable(campaign_bicycle_mismatch campaign_bicycle_mismatch.cpp)
+target_link_libraries(campaign_bicycle_mismatch models mppi gtest gtest_main)
+gtest_discover_tests(campaign_bicycle_mismatch PROPERTIES LABELS campaign)

--- a/tests/integration/campaign_bicycle_mismatch.cpp
+++ b/tests/integration/campaign_bicycle_mismatch.cpp
@@ -1,0 +1,129 @@
+/*
+ * campaign_bicycle_mismatch.cpp
+ *
+ * Robustness campaign (ctest label: campaign — nightly): the classic
+ * kinematic-planner vs dynamic-plant benchmark (Kong et al., IV 2015).
+ * MPPI plans with the KINEMATIC bicycle; the true plant is the
+ * single-track linear-tire model (Rajamani) that slips, with per-seed
+ * tire-stiffness variation — the canonical model-mismatch axis.
+ *
+ * Interface between the two: the planner commands [v, delta]; the plant
+ * runs a longitudinal speed loop ax = kv (v_cmd - vx) and takes delta
+ * directly. Acceptance is the pass rate across seeds.
+ *
+ * Mismatch (stated test conditions):
+ *   - planner model: kinematic bicycle, wheelbase 2.8 m (matches lf+lr)
+ *   - plant: dynamic bicycle, Cf/Cr independently scaled U(0.7, 1.3)
+ *   - speed loop kv = 1.5 1/s; process noise (2 mm, 2 mm, 1 mrad)
+ *
+ * Copyright (c) 2026 Ruixiang Du (rdu)
+ */
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <cstdio>
+#include <random>
+
+#include "xmnav/models/ackermann.hpp"
+#include "xmnav/models/dynamic_bicycle.hpp"
+#include "xmnav/mppi/critics.hpp"
+#include "xmnav/mppi/mppi.hpp"
+
+using namespace xmotion;
+
+namespace {
+
+#if !defined(NDEBUG) || defined(__SANITIZE_ADDRESS__) || \
+    defined(__SANITIZE_THREAD__)
+constexpr int kSamples = 128;
+constexpr int kRuns = 4;
+#else
+constexpr int kSamples = 512;
+constexpr int kRuns = 25;
+#endif
+
+constexpr double kDt = 0.05;
+const Eigen::Vector2d kGoal{40.0, 6.0};  // a lane-change-and-advance task
+
+struct RunResult {
+  bool reached = false;
+  bool spun = false;
+  double final_dist = 0.0;
+};
+
+RunResult RunOnce(std::uint64_t seed) {
+  Se2GoalCost goal_cost;
+  goal_cost.goal << kGoal.x(), kGoal.y(), 0.0;
+  goal_cost.position_weight = 1.0;
+
+  AckermannModel planner_model;
+  planner_model.wheelbase = 2.8;  // matches the plant's lf + lr
+
+  using Controller = Mppi<AckermannModel, Se2GoalCost>;
+  Controller::Params p;
+  p.num_samples = kSamples;
+  p.horizon_steps = 30;
+  p.dt = kDt;
+  p.lambda = 0.3;
+  p.sigma << 1.5, 0.05;
+  p.u_min << 0.0, -0.4;
+  p.u_max << 15.0, 0.4;
+  p.normalize_cost_spread = true;
+  p.seed = seed;
+  Controller mppi(planner_model, goal_cost, p);
+
+  std::mt19937_64 rng(seed ^ 0xda3e39cb94b95bdbULL);
+  std::normal_distribution<double> unit;
+  std::uniform_real_distribution<double> tire(0.7, 1.3);
+
+  DynamicBicycleModel plant;
+  plant.cornering_front *= tire(rng);
+  plant.cornering_rear *= tire(rng);
+
+  DynamicBicycleModel::State x = DynamicBicycleModel::State::Zero();
+  x(3) = 10.0;  // entering at speed
+  RunResult result;
+  for (int t = 0; t < 200; ++t) {  // 10 s budget
+    AckermannModel::State x_planner;
+    x_planner << x(0), x(1), x(2);
+    mppi.Plan(x_planner);
+    const auto cmd = mppi.Command();  // [v_cmd, delta]
+    DynamicBicycleModel::Control u;
+    u << 1.5 * (cmd(0) - x(3)), cmd(1);  // speed loop + direct steering
+    x = plant.Step(x, u, t, kDt);
+    x(0) += 0.002 * unit(rng);
+    x(1) += 0.002 * unit(rng);
+    x(2) += 0.001 * unit(rng);
+    if (std::abs(x(4)) > 3.0) {  // lateral velocity blow-up = spin
+      result.spun = true;
+      break;
+    }
+    if ((x.head<2>() - kGoal).norm() < 1.5) {
+      result.reached = true;
+      break;
+    }
+  }
+  result.final_dist = (x.head<2>() - kGoal).norm();
+  return result;
+}
+
+}  // namespace
+
+TEST(BicycleMismatchCampaignTest, KinematicPlannerHandlesTireSlipPlant) {
+  int reached = 0, spins = 0;
+  for (int i = 0; i < kRuns; ++i) {
+    const auto r = RunOnce(2000 + static_cast<std::uint64_t>(i));
+    reached += r.reached ? 1 : 0;
+    spins += r.spun ? 1 : 0;
+    if (!r.reached) {
+      std::printf("  seed %d: final_dist=%.2f spun=%d\n", 2000 + i,
+                  r.final_dist, r.spun ? 1 : 0);
+    }
+  }
+  const double pass_rate = static_cast<double>(reached) / kRuns;
+  std::printf("campaign: %d/%d reached (%.0f%%), %d spins\n", reached,
+              kRuns, 100.0 * pass_rate, spins);
+  EXPECT_GE(pass_rate, 0.9);
+  EXPECT_EQ(spins, 0);
+}

--- a/tests/integration/test_pipeline_cartpole.cpp
+++ b/tests/integration/test_pipeline_cartpole.cpp
@@ -1,0 +1,151 @@
+/*
+ * test_pipeline_cartpole.cpp
+ *
+ * Integration scenario: cart-pole swing-up and catch — the classical
+ * controller-handover benchmark.
+ *
+ *   MPPI (global, nonlinear swing-up) --near upright--> AlignOutput()
+ *   --> DLQR state feedback (local catch + hold)
+ *
+ * The DLQR gain is synthesized in-test from a NUMERIC linearization of
+ * the model at the upright equilibrium (finite differences on Deriv),
+ * so the test also pins the model/linearization/dlqr/state-feedback
+ * tool chain end to end. The plant integrates with RK4 while MPPI plans
+ * with its own Euler rollouts — a deliberate integration-method
+ * mismatch, stated here per the test-conditions rule.
+ *
+ * Copyright (c) 2026 Ruixiang Du (rdu)
+ */
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+#include "xmnav/models/cartpole.hpp"
+#include "xmnav/models/rk4.hpp"
+#include "xmnav/mppi/mppi.hpp"
+#include "xmnav/pid/dlqr.hpp"
+#include "xmnav/pid/state_feedback.hpp"
+
+using namespace xmotion;
+
+namespace {
+
+#if !defined(NDEBUG) || defined(__SANITIZE_ADDRESS__) || \
+    defined(__SANITIZE_THREAD__)
+constexpr int kSamples = 128;
+#else
+constexpr int kSamples = 512;
+#endif
+
+constexpr double kDt = 0.02;
+
+double WrapAngle(double a) {
+  while (a > M_PI) a -= 2.0 * M_PI;
+  while (a < -M_PI) a += 2.0 * M_PI;
+  return a;
+}
+
+// swing-up cost: pole up (wrap-free via cos), cart near the origin, mild
+// damping on the rates
+struct SwingUpCost {
+  using State = CartPoleModel::State;
+  using Control = CartPoleModel::Control;
+  double StageCost(const State &x, const Control & /*u*/, int /*t*/) const {
+    return 10.0 * (1.0 - std::cos(x(2))) + 0.05 * x(0) * x(0) +
+           0.05 * x(1) * x(1) + 0.01 * x(3) * x(3);
+  }
+  double TerminalCost(const State &x) const {
+    return 10.0 * StageCost(x, Control::Zero(), 0);
+  }
+};
+
+// numeric Jacobians of the continuous dynamics at the upright equilibrium
+void LinearizeUpright(const CartPoleModel &model, Eigen::Matrix4d *A,
+                      Eigen::Vector4d *B) {
+  const CartPoleModel::State x0 = CartPoleModel::State::Zero();
+  const CartPoleModel::Control u0 = CartPoleModel::Control::Zero();
+  const double eps = 1e-6;
+  for (int j = 0; j < 4; ++j) {
+    CartPoleModel::State xp = x0, xm = x0;
+    xp(j) += eps;
+    xm(j) -= eps;
+    A->col(j) = (model.Deriv(xp, u0) - model.Deriv(xm, u0)) / (2.0 * eps);
+  }
+  CartPoleModel::Control up = u0, um = u0;
+  up(0) += eps;
+  um(0) -= eps;
+  *B = (model.Deriv(x0, up) - model.Deriv(x0, um)) / (2.0 * eps);
+}
+
+}  // namespace
+
+TEST(PipelineIntegrationTest, CartPoleSwingUpThenDlqrCatch) {
+  CartPoleModel model;
+
+  // --- global controller: MPPI swing-up ---
+  using Controller = Mppi<CartPoleModel, SwingUpCost>;
+  Controller::Params p;
+  p.num_samples = kSamples;
+  p.horizon_steps = 60;  // 1.2 s lookahead
+  p.dt = kDt;
+  p.lambda = 0.3;
+  p.sigma << 6.0;
+  p.u_min << -10.0;
+  p.u_max << 10.0;
+  p.normalize_cost_spread = true;
+  Controller mppi(CartPoleModel{}, SwingUpCost{}, p);
+
+  // --- local controller: DLQR catch, gain synthesized in-test ---
+  Eigen::Matrix4d Ac;
+  Eigen::Vector4d Bc;
+  LinearizeUpright(model, &Ac, &Bc);
+  const Eigen::Matrix4d Ad = Eigen::Matrix4d::Identity() + Ac * kDt;
+  const Eigen::Vector4d Bd = Bc * kDt;
+  Eigen::Matrix4d Q = Eigen::Matrix4d::Zero();
+  Q.diagonal() << 10.0, 1.0, 100.0, 10.0;
+  const auto lqr = SolveDlqr<4, 1>(Ad, Bd, Q,
+                                   Eigen::Matrix<double, 1, 1>::Identity());
+  ASSERT_TRUE(lqr.converged);
+  StateFeedbackController<4, 1>::Config fc;
+  fc.K = lqr.K;
+  fc.u_min << -10.0;
+  fc.u_max << 10.0;
+  StateFeedbackController<4, 1> catcher(fc);
+
+  // --- closed loop: hanging start, RK4 plant ---
+  CartPoleModel::State x;
+  x << 0.0, 0.0, M_PI, 0.0;
+  bool caught = false;
+  int catch_tick = -1;
+  const int total_ticks = 500;  // 10 s
+  for (int t = 0; t < total_ticks; ++t) {
+    CartPoleModel::Control u;
+    const double theta = WrapAngle(x(2));
+    if (!caught && std::abs(theta) < 0.35 && std::abs(x(3)) < 2.0) {
+      caught = true;
+      catch_tick = t;
+      // bumpless handover at the current operating point
+      CartPoleModel::State x_fb = x;
+      x_fb(2) = theta;
+      catcher.AlignOutput(mppi.Command(), CartPoleModel::State::Zero(),
+                          x_fb);
+    }
+    if (caught) {
+      CartPoleModel::State x_fb = x;
+      x_fb(2) = theta;  // feedback operates on the wrapped angle
+      u = catcher.Update(CartPoleModel::State::Zero(), x_fb, kDt);
+    } else {
+      mppi.Plan(x);
+      u = mppi.Command();
+    }
+    x = Rk4Propagate(model, x, u, 0.0, kDt, kDt / 4.0);
+  }
+
+  ASSERT_TRUE(caught) << "swing-up never reached the catch region";
+  EXPECT_LT(catch_tick, 350) << "swing-up too slow (7 s budget)";
+  // held upright at the end: pole up, cart bounded, rates settled
+  EXPECT_LT(std::abs(WrapAngle(x(2))), 0.05);
+  EXPECT_LT(std::abs(x(3)), 0.5);
+  EXPECT_LT(std::abs(x(0)), 2.0);
+}

--- a/tests/integration/test_pipeline_cartpole.cpp
+++ b/tests/integration/test_pipeline_cartpole.cpp
@@ -22,6 +22,7 @@
 #include <cmath>
 
 #include "xmnav/models/cartpole.hpp"
+#include "xmnav/models/linearize.hpp"
 #include "xmnav/models/rk4.hpp"
 #include "xmnav/mppi/mppi.hpp"
 #include "xmnav/pid/dlqr.hpp"
@@ -60,24 +61,6 @@ struct SwingUpCost {
   }
 };
 
-// numeric Jacobians of the continuous dynamics at the upright equilibrium
-void LinearizeUpright(const CartPoleModel &model, Eigen::Matrix4d *A,
-                      Eigen::Vector4d *B) {
-  const CartPoleModel::State x0 = CartPoleModel::State::Zero();
-  const CartPoleModel::Control u0 = CartPoleModel::Control::Zero();
-  const double eps = 1e-6;
-  for (int j = 0; j < 4; ++j) {
-    CartPoleModel::State xp = x0, xm = x0;
-    xp(j) += eps;
-    xm(j) -= eps;
-    A->col(j) = (model.Deriv(xp, u0) - model.Deriv(xm, u0)) / (2.0 * eps);
-  }
-  CartPoleModel::Control up = u0, um = u0;
-  up(0) += eps;
-  um(0) -= eps;
-  *B = (model.Deriv(x0, up) - model.Deriv(x0, um)) / (2.0 * eps);
-}
-
 }  // namespace
 
 TEST(PipelineIntegrationTest, CartPoleSwingUpThenDlqrCatch) {
@@ -97,11 +80,10 @@ TEST(PipelineIntegrationTest, CartPoleSwingUpThenDlqrCatch) {
   Controller mppi(CartPoleModel{}, SwingUpCost{}, p);
 
   // --- local controller: DLQR catch, gain synthesized in-test ---
-  Eigen::Matrix4d Ac;
-  Eigen::Vector4d Bc;
-  LinearizeUpright(model, &Ac, &Bc);
-  const Eigen::Matrix4d Ad = Eigen::Matrix4d::Identity() + Ac * kDt;
-  const Eigen::Vector4d Bd = Bc * kDt;
+  const auto lin = LinearizeNumeric(model, CartPoleModel::State::Zero(),
+                                    CartPoleModel::Control::Zero());
+  const Eigen::Matrix4d Ad = Eigen::Matrix4d::Identity() + lin.A * kDt;
+  const Eigen::Vector4d Bd = lin.B * kDt;
   Eigen::Matrix4d Q = Eigen::Matrix4d::Zero();
   Q.diagonal() << 10.0, 1.0, 100.0, 10.0;
   const auto lqr = SolveDlqr<4, 1>(Ad, Bd, Q,

--- a/tests/integration/test_pipeline_quadrotor.cpp
+++ b/tests/integration/test_pipeline_quadrotor.cpp
@@ -1,0 +1,102 @@
+/*
+ * test_pipeline_quadrotor.cpp
+ *
+ * Integration scenario: quadrotor waypoint capture and hold with MPPI
+ * planning directly on the rigid-body dynamics (Mellinger/Kumar model),
+ * gravity-compensated warm start, process noise on velocity and body
+ * rates. Exercises the controller on a genuinely 3D attitude state
+ * (quaternion + body rates) — the planar scenarios cannot.
+ *
+ * Test conditions: nominal plant (the controller's own model) with
+ * additive process noise; deterministic seeds.
+ *
+ * Copyright (c) 2026 Ruixiang Du (rdu)
+ */
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <random>
+
+#include "xmnav/models/quadrotor.hpp"
+#include "xmnav/mppi/mppi.hpp"
+
+using namespace xmotion;
+
+namespace {
+
+#if !defined(NDEBUG) || defined(__SANITIZE_ADDRESS__) || \
+    defined(__SANITIZE_THREAD__)
+constexpr int kSamples = 128;
+#else
+constexpr int kSamples = 512;
+#endif
+
+constexpr double kDt = 0.02;
+const Eigen::Vector3d kWaypoint{2.0, 1.0, 1.5};
+
+struct WaypointCost {
+  using State = QuadrotorModel::State;
+  using Control = QuadrotorModel::Control;
+  double hover_thrust = 0.5 * 9.81;
+  double StageCost(const State &x, const Control &u, int /*t*/) const {
+    const Eigen::Vector3d pe = QuadrotorModel::Position(x) - kWaypoint;
+    const Eigen::Vector3d v = QuadrotorModel::Velocity(x);
+    const Eigen::Vector3d w = QuadrotorModel::BodyRates(x);
+    // tilt via R(2,2) of the unit quaternion (1 when level)
+    const double body_z_z =
+        1.0 - 2.0 * (x(7) * x(7) + x(8) * x(8));
+    const double du = u(0) - hover_thrust;
+    return 4.0 * pe.squaredNorm() + 1.0 * v.squaredNorm() +
+           20.0 * (1.0 - body_z_z) + 0.05 * w.squaredNorm() +
+           0.1 * du * du + 2.0 * u.tail<3>().squaredNorm();
+  }
+  double TerminalCost(const State &x) const {
+    return 10.0 * StageCost(x, Control::Zero(), 0);
+  }
+};
+
+}  // namespace
+
+TEST(PipelineIntegrationTest, QuadrotorReachesAndHoldsWaypoint) {
+  QuadrotorModel model;
+  using Controller = Mppi<QuadrotorModel, WaypointCost>;
+  Controller::Params p;
+  p.num_samples = kSamples;
+  p.horizon_steps = 50;  // 1 s lookahead
+  p.dt = kDt;
+  p.lambda = 0.2;
+  p.sigma << 1.0, 0.02, 0.02, 0.01;
+  p.u_min << 0.0, -0.05, -0.05, -0.02;
+  p.u_max << 2.0 * model.HoverThrust(), 0.05, 0.05, 0.02;
+  p.normalize_cost_spread = true;
+  WaypointCost cost;
+  cost.hover_thrust = model.HoverThrust();
+  Controller mppi(model, cost, p);
+  // gravity-compensating warm start (the standard force-space seed)
+  Controller::Control hover = Controller::Control::Zero();
+  hover(0) = model.HoverThrust();
+  mppi.SeedSequence(hover);
+
+  std::mt19937_64 rng(5);
+  std::normal_distribution<double> unit;
+
+  auto x = QuadrotorModel::MakeState(
+      Eigen::Vector3d::Zero(), Eigen::Vector3d::Zero(),
+      Eigen::Quaterniond::Identity(), Eigen::Vector3d::Zero());
+  double max_tilt = 0.0;
+  for (int t = 0; t < 400; ++t) {  // 8 s
+    mppi.Plan(x);
+    x = model.Step(x, mppi.Command(), t, kDt);
+    for (int i = 3; i < 6; ++i) x(i) += 0.005 * unit(rng);   // v noise
+    for (int i = 10; i < 13; ++i) x(i) += 0.002 * unit(rng); // w noise
+    const double body_z_z = 1.0 - 2.0 * (x(7) * x(7) + x(8) * x(8));
+    max_tilt = std::max(max_tilt, 1.0 - body_z_z);
+    ASSERT_TRUE(x.allFinite()) << "tick " << t;
+  }
+
+  EXPECT_LT((QuadrotorModel::Position(x) - kWaypoint).norm(), 0.3)
+      << "final position: " << QuadrotorModel::Position(x).transpose();
+  EXPECT_LT(QuadrotorModel::Velocity(x).norm(), 0.5);
+  EXPECT_LT(max_tilt, 0.3) << "excessive tilt during the maneuver";
+}


### PR DESCRIPTION
## Summary

Stacked on #69 (retargets to devel when it merges). The full proposed benchmark-model set, as **library assets in `control/models`** (usable by applications — MPPI plants, reachability, sim — not test fixtures), each with a raw-span `Deriv` core in `model_core.hpp` (CUDA-shareable), literature-cited defaults, and closed-form oracles:

| Model | Anchor | Oracles |
|---|---|---|
| **Cart-pole** | Barto/Sutton/Anderson 1983 (exact formulation, θ from upright) | energy conservation <1e-6 rel over 10 s RK4; upright unstable / hanging bounded |
| **Dynamic bicycle** (single-track, linear tires) | Rajamani ch. 2; Kong et al. IV 2015 | steady-state yaw rate vs the understeer-gradient formula to 1%; low-speed degeneration to kinematic to 2% |
| **Quadrotor** (rigid body) | Mellinger & Kumar ICRA 2011 (body-frame ω) | exact hover equilibrium; free-fall closed form; exact yaw spin-up, unit quaternion preserved |

**Simulation scenarios** (integration tier from #69):
- **Cart-pole swing-up + catch** (`integration`): MPPI swings up globally; DLQR state feedback catches via bumpless `AlignOutput()` — the gain synthesized in-test from a *numeric* linearization, so the model → DLQR → state-feedback chain is pinned end to end. Catch < 7 s, held upright |θ| < 0.05.
- **Quadrotor waypoint + hold** (`integration`): MPPI directly on the 13-state rigid-body dynamics, gravity-compensated warm start, process noise on v/ω; tilt bounded throughout.
- **Bicycle mismatch campaign** (`campaign`, nightly): the classic kinematic-planner vs tire-slip-plant benchmark with per-seed Cf/Cr variation U(0.7, 1.3) — **25/25 reached, 0 spins**.

**Documentation** (requested): `docs/typst/models.typ` (+ compiled PDF) — governing equations, state/control layouts and frame conventions, default parameters, and the validation oracle for *every* model in the module (including the pre-existing ones), with IEEE-style references; each model header points to it. The frame difference between the quadrotor (body-frame ω, Mellinger convention) and the SRB (world-frame ω) is documented explicitly.

## Verification

WERROR viz-on 95/95 (`-LE campaign`) plus both campaigns (65 closed-loop runs total); viz-off 94/94; ASan clean on all new binaries at reduced scale.