### PR TITLE
docs(todo): refresh TODO files to the current roadmap

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,30 @@
-# TODO List
+# TODO
 
-* refactor async_io
-* use epoll or libevent to handle IO events
-* Fix implementation of "void LookupTable::LoadLookupTableFromFile(std::string filename)" in "src/planning/state_lattice/src/lookup_table.cpp"
+Active near-term work. Status: `[ ]` open · `[~]` in progress · `[x]` done. Deferred and dormant items live in [docs/TODO.md](docs/TODO.md).
+
+## Verification & CI (IHMC study "adopt now" items — docs/research/ihmc-open-robotics-software.md §6)
+
+- [ ] Allocation-testing category: malloc-hook counters around steady-state `Mppi::Plan()`, `WheeledShield::Filter()`, and MEKF/PID `Update()`; nightly `allocation` ctest label
+- [ ] Rewindability regression: run → rewind `SimLog` → re-simulate → diff-to-zero
+- [ ] Self-hosted CUDA runner so the CUDA rollout backends build and test in CI
+
+## Estimation
+
+- [ ] Golden-log regressions: replay real IMU MCAP recordings against MEKF6/MEKF9 (blocked: pending hardware data — docs/typst/main.typ)
+
+## Control / MPPI
+
+- [ ] Per-sample counter-seeded noise streams on the CPU rollout backend (lifts the sampling Amdahl cap — docs/typst/mppi.typ)
+- [ ] On-device spline-knot sampling for the SRB CUDA program
+- [ ] Jetson Orin deployment pass (unified memory: pinned staging maps zero-copy)
+- [ ] Safety shield S5: quadruped GRF friction-cone projection, with the SRB shield (docs/control/safety_shield.md)
+
+## Telemetry & visualization
+
+- [ ] Telemetry evolution: hierarchical named variables + per-tick recording
+- [ ] Viewer sessions over MCAP (quickviz roadmap)
+
+## Docs & process
+
+- [ ] Umbrella ADR: workspace-overlay dependency resolution
+- [ ] Formalize (or retire) the W#/M# milestone labels in a committed roadmap doc — today they exist only in branch/commit names

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,41 +1,32 @@
-# TODO List
+# Backlog — deferred and dormant
 
-## Modules
+Active near-term work is tracked in the root [TODO.md](../TODO.md). Items here are recorded but not scheduled; each is gated on a revival decision or an external trigger.
 
-- [ ] Remove CGAL dependency if possible
-- [ ] Add memory leak check tests for all modules in "kernel"
-- [*] Cleanup dependencies on LCM, create a comm package 
-- [*] Put all finding folder path function into one place 
+## Road-network revival (gates the state_lattice apps)
 
-## Planning
+- Re-enable `state_lattice/apps` — `gen_lookup_table` depends on the retired `traffic_map` module (src/planning/state_lattice/CMakeLists.txt)
+- Fix CSV loading in `LookupTable::LoadLookupTableFromFile` (src/planning/state_lattice/src/lookup_table.cpp)
+- Make state_lattice data locations explicit configuration instead of path probing (src/planning/state_lattice/src/data_path.hpp)
+- OSM-defined paths, traffic sim, and Monte-Carlo AV scenarios (carried over from the pre-reorg backlog; only meaningful after the revival)
 
-- [ ] Extend roadmap and traffic sim to support definition of path in osm file
-- [ ] Memory management of ReferenceTrajectory/LookaheadZone
-- [ ] Monte Carlo simulation for autonomous vehicles
-- [ ] Priority queue that supports element priority update
-- [ ] RRT and RRT* with Dubins model  
-- [*] Use line strip instead of points to represent center line (strip won't work due to ambiguity in direction)
-- [*] Check possible memory leak issue of SquareGrid
-- [*] Remove the requirement of friendship inside Graph_t for search algorithms
-- [*] Remove dependency on OpenCV (now only visualization depends on OpenCV)
-- [*] Road network model
-- [*] Iterators for Vertex_t and Edge_t
+## Decision
+
+- Verify `prediction` threat-model behavior and re-enable it in the build (src/decision/CMakeLists.txt; static_threat_model.hpp / vehicle_threat.hpp carry "not sure if behavior is correct" markers)
+- Record reachability Monte-Carlo samples through telemetry (XM_* / MCAP) (src/decision/reachability/src/monte_carlo_sim.cpp)
+
+## Geometry
+
+- Reimplement the stubbed polygon predicates (bounded-side, intersection, optimal convex partition) without CGAL (src/planning/geometry/src/polygon.cpp)
 
 ## Control
 
-- [ ] Kalman filter for RC Car
+- Preallocated QP solver for the safety shield — only if QuadProg++ per-solve allocation ever shows in traces (docs/control/safety_shield.md)
 
-## Simulation
+## Deferred until a second platform exists
 
-- [*] Finish RC Car simulation interface with LCM/FastRTPS
+- Per-platform template integration scenarios
+- Cross-engine simulation validation vs MuJoCo
 
-## Visualization
+---
 
-- [ ] Better surface visualization
-- [*] ~~Graph visualization using Cairo~~ new visualization is now built on top of CvDraw
-
-## Misc
-
-- ~~Update the command to invoke uavcan type generator~~
-- ~~Fix "ENABLE_LOGGING" macro definition~~
-- ~~Gurobi related code is broken under Ubuntu 16.04/Debian Stretch~~
+The historical checklist previously in this file (LCM cleanup, RC-Car Kalman filter and LCM/FastRTPS sim interface, CGAL removal, kernel leak checks, uavcan/Gurobi items) was either completed or superseded by the estimation (MEKF6/9), simulation-tier, and telemetry arcs; see git history for the old list.


### PR DESCRIPTION
## Summary

Both TODO files predated the navigation-stack era (async_io, RC-Car LCM sim, CGAL removal) and no longer described any real work. This PR rebuilds them from the follow-ups actually recorded in the repo.

- **`TODO.md` (root)** — now the active near-term roadmap, collected from:
  - the typst technical notes: MEKF golden-log MCAP replay (`docs/typst/main.typ`), CPU counter-seeded noise streams, on-device spline-knot sampling, Jetson Orin deployment (`docs/typst/mppi.typ`)
  - `docs/control/safety_shield.md`: shield scenario S5 (quadruped GRF friction cone)
  - the IHMC study adoption table (`docs/research/ihmc-open-robotics-software.md` §6): allocation-testing CI category, rewindability regression, self-hosted CUDA runner, telemetry evolution, workspace-overlay ADR
- **`docs/TODO.md`** — now the deferred/dormant backlog, with each item's gating condition named: road-network revival (state_lattice apps + CSV loader fix), the disabled `prediction` module, CGAL-stubbed polygon predicates, preallocated shield QP, second-platform items (scenario templates, MuJoCo cross-engine).

Also records that the W#/M# milestone labels exist only in branch/commit names — added a TODO to formalize or retire them.

## Notes

- Docs-only change; no code or build impact.
- The only surviving item from the old files is the state_lattice `LookupTable` CSV-loader fix, now filed under the road-network revival gate.