### PR TITLE
test: allocation tier — zero-heap contracts for the steady-state hot paths

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Test
         working-directory: ${{runner.workspace}}/build
         shell: bash
-        run: ctest -LE campaign --output-on-failure
+        run: ctest -LE "campaign|allocation" --output-on-failure
 
   sanitizers:
     runs-on: ubuntu-24.04
@@ -103,4 +103,4 @@ jobs:
       - name: Test
         working-directory: build
         shell: bash
-        run: ctest -LE campaign --output-on-failure
+        run: ctest -LE "campaign|allocation" --output-on-failure

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,5 +1,7 @@
 # Nightly validation: the campaign-labeled robustness suites (Monte-Carlo
-# closed loops under plant-model mismatch) that are too long for PR CI.
+# closed loops under plant-model mismatch) that are too long for PR CI,
+# plus the allocation-labeled zero-heap-allocation contracts of the
+# steady-state hot paths (tests/allocation/).
 # Scheduled runs execute on the default branch (devel).
 name: Nightly
 
@@ -42,3 +44,7 @@ jobs:
         working-directory: build
         shell: bash
         run: ctest -L campaign --output-on-failure
+      - name: Allocation tests
+        working-directory: build
+        shell: bash
+        run: ctest -L allocation --output-on-failure

--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,7 @@ Active near-term work. Status: `[ ]` open · `[~]` in progress · `[x]` done. De
 
 ## Verification & CI (IHMC study "adopt now" items — docs/research/ihmc-open-robotics-software.md §6)
 
-- [ ] Allocation-testing category: malloc-hook counters around steady-state `Mppi::Plan()`, `WheeledShield::Filter()`, and MEKF/PID `Update()`; nightly `allocation` ctest label
+- [x] Allocation-testing category: malloc-hook counters around steady-state `Mppi::Plan()`, `WheeledShield::Filter()`, and MEKF/PID `Update()`; nightly `allocation` ctest label
 - [ ] Rewindability regression: run → rewind `SimLog` → re-simulate → diff-to-zero
 - [ ] Self-hosted CUDA runner so the CUDA rollout backends build and test in CI
 

--- a/src/control/mppi/include/xmnav/mppi/mppi.hpp
+++ b/src/control/mppi/include/xmnav/mppi/mppi.hpp
@@ -109,7 +109,10 @@ template <typename Sequence>
 inline void ShiftSequence(Sequence &u) {
   const Eigen::Index horizon = u.rows();
   if (horizon < 2) return;
-  u.topRows(horizon - 1) = u.bottomRows(horizon - 1).eval();
+  // in-place row-wise shift: copying row t <- t+1 in ascending order has
+  // no aliasing hazard, unlike the overlapping block assignment whose
+  // .eval() would heap-allocate a temporary every Plan()
+  for (Eigen::Index t = 0; t + 1 < horizon; ++t) u.row(t) = u.row(t + 1);
   u.row(horizon - 1) = u.row(horizon - 2);
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(integration)
+add_subdirectory(allocation)

--- a/tests/allocation/CMakeLists.txt
+++ b/tests/allocation/CMakeLists.txt
@@ -1,0 +1,17 @@
+## Allocation tier: malloc-hook counters assert the documented
+## zero-heap-allocation contract of the steady-state hot paths —
+## Mppi::Plan(), WheeledShield::Filter(), Mekf6/Mekf9::Update(),
+## PidController::Update() (the "adopt now" item of
+## docs/research/ihmc-open-robotics-software.md §6). The tier is one
+## dedicated binary because the malloc interposition is process-global.
+##
+## Labels:
+##   allocation — excluded from PR ctest and the sanitizer lane
+##                (-LE "campaign|allocation"; interposition is inactive
+##                under ASan/TSan anyway), run nightly. The binary still
+##                BUILDS on PRs so it cannot rot.
+
+add_executable(test_allocation alloc_counter.cpp test_allocation.cpp)
+target_link_libraries(test_allocation
+    estimation mppi pid shield gtest gtest_main)
+gtest_discover_tests(test_allocation PROPERTIES LABELS allocation)

--- a/tests/allocation/alloc_counter.cpp
+++ b/tests/allocation/alloc_counter.cpp
@@ -1,0 +1,105 @@
+/*
+ * alloc_counter.cpp
+ *
+ * Strong definitions of the glibc malloc-family entry points that count
+ * allocating calls and forward to the __libc_* implementations. Symbol
+ * interposition is process-global, which is why the allocation tier is a
+ * single dedicated binary (see CMakeLists.txt in this directory).
+ *
+ * Under ASan/TSan the sanitizer runtime owns these symbols, and on
+ * non-glibc platforms __libc_* does not exist, so the counter compiles to
+ * an inactive stub and the tests skip.
+ *
+ * Copyright (c) 2026 Ruixiang Du (rdu)
+ */
+
+#include "alloc_counter.hpp"
+
+#include <atomic>
+#include <cstdlib>
+
+#if defined(__GLIBC__) && !defined(__SANITIZE_ADDRESS__) && \
+    !defined(__SANITIZE_THREAD__)
+#define XMNAV_ALLOC_COUNTING_ACTIVE 1
+#else
+#define XMNAV_ALLOC_COUNTING_ACTIVE 0
+#endif
+
+namespace {
+// constant-initialized: interposed calls arrive before any dynamic init
+std::atomic<long> g_allocating_calls{0};
+}  // namespace
+
+#if XMNAV_ALLOC_COUNTING_ACTIVE
+
+#include <cerrno>
+#include <cstddef>
+
+extern "C" {
+// glibc's real allocator entry points (always exported by glibc)
+void *__libc_malloc(std::size_t size);
+void *__libc_calloc(std::size_t nmemb, std::size_t size);
+void *__libc_realloc(void *ptr, std::size_t size);
+void *__libc_memalign(std::size_t alignment, std::size_t size);
+void __libc_free(void *ptr);
+}
+
+extern "C" void *malloc(std::size_t size) noexcept {
+  g_allocating_calls.fetch_add(1, std::memory_order_relaxed);
+  return __libc_malloc(size);
+}
+
+extern "C" void *calloc(std::size_t nmemb, std::size_t size) noexcept {
+  g_allocating_calls.fetch_add(1, std::memory_order_relaxed);
+  return __libc_calloc(nmemb, size);
+}
+
+extern "C" void *realloc(void *ptr, std::size_t size) noexcept {
+  g_allocating_calls.fetch_add(1, std::memory_order_relaxed);
+  return __libc_realloc(ptr, size);
+}
+
+extern "C" void *aligned_alloc(std::size_t alignment,
+                               std::size_t size) noexcept {
+  g_allocating_calls.fetch_add(1, std::memory_order_relaxed);
+  return __libc_memalign(alignment, size);
+}
+
+extern "C" void *memalign(std::size_t alignment, std::size_t size) noexcept {
+  g_allocating_calls.fetch_add(1, std::memory_order_relaxed);
+  return __libc_memalign(alignment, size);
+}
+
+extern "C" int posix_memalign(void **memptr, std::size_t alignment,
+                              std::size_t size) noexcept {
+  // POSIX contract: alignment must be a power of two and a multiple of
+  // sizeof(void *); on failure *memptr is left unmodified
+  if (alignment == 0 || alignment % sizeof(void *) != 0 ||
+      (alignment & (alignment - 1)) != 0) {
+    return EINVAL;
+  }
+  g_allocating_calls.fetch_add(1, std::memory_order_relaxed);
+  void *p = __libc_memalign(alignment, size);
+  if (p == nullptr) return ENOMEM;
+  *memptr = p;
+  return 0;
+}
+
+extern "C" void free(void *ptr) noexcept { __libc_free(ptr); }
+
+#endif  // XMNAV_ALLOC_COUNTING_ACTIVE
+
+namespace xmotion {
+namespace alloc_test {
+
+bool AllocCountingActive() { return XMNAV_ALLOC_COUNTING_ACTIVE != 0; }
+
+AllocationProbe::AllocationProbe()
+    : start_(g_allocating_calls.load(std::memory_order_relaxed)) {}
+
+long AllocationProbe::Count() const {
+  return g_allocating_calls.load(std::memory_order_relaxed) - start_;
+}
+
+}  // namespace alloc_test
+}  // namespace xmotion

--- a/tests/allocation/alloc_counter.hpp
+++ b/tests/allocation/alloc_counter.hpp
@@ -1,0 +1,36 @@
+/*
+ * alloc_counter.hpp
+ *
+ * Process-global heap-allocation counter for the allocation test tier.
+ * The matching .cpp interposes the glibc malloc family (not operator new:
+ * Eigen's dynamic-size allocations reach std::malloc directly through
+ * Eigen::internal::aligned_malloc) and counts every allocating call.
+ *
+ * Copyright (c) 2026 Ruixiang Du (rdu)
+ */
+
+#ifndef XMNAV_TESTS_ALLOCATION_ALLOC_COUNTER_HPP
+#define XMNAV_TESTS_ALLOCATION_ALLOC_COUNTER_HPP
+
+namespace xmotion {
+namespace alloc_test {
+
+// true when the malloc interposition is compiled in (glibc, no ASan/TSan);
+// allocation tests skip when it is not
+bool AllocCountingActive();
+
+// Allocating calls (malloc/calloc/realloc/aligned_alloc/posix_memalign/
+// memalign) observed process-wide since construction; free is not counted.
+class AllocationProbe {
+ public:
+  AllocationProbe();
+  long Count() const;
+
+ private:
+  long start_;
+};
+
+}  // namespace alloc_test
+}  // namespace xmotion
+
+#endif  // XMNAV_TESTS_ALLOCATION_ALLOC_COUNTER_HPP

--- a/tests/allocation/test_allocation.cpp
+++ b/tests/allocation/test_allocation.cpp
@@ -1,0 +1,224 @@
+/*
+ * test_allocation.cpp
+ *
+ * Zero-heap-allocation contracts of the steady-state hot paths (the
+ * "adopt now" item of docs/research/ihmc-open-robotics-software.md §6):
+ * Mppi::Plan(), WheeledShield::Filter(), Mekf6/Mekf9::Update(), and
+ * PidController::Update(). Each test constructs and warms up outside the
+ * probe window (construction and first-call buffer sizing may allocate),
+ * then asserts that many steady-state iterations allocate nothing.
+ *
+ * Copyright (c) 2026 Ruixiang Du (rdu)
+ */
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+#include "alloc_counter.hpp"
+#include "xmnav/estimation/mekf6.hpp"
+#include "xmnav/estimation/mekf9.hpp"
+#include "xmnav/models/diff_drive.hpp"
+#include "xmnav/mppi/critics.hpp"
+#include "xmnav/mppi/mppi.hpp"
+#include "xmnav/pid/pid_controller.hpp"
+#include "xmnav/shield/wheeled_shield.hpp"
+
+using namespace xmotion;
+using alloc_test::AllocationProbe;
+using alloc_test::AllocCountingActive;
+
+namespace {
+
+constexpr int kSteadyStateIters = 1000;
+constexpr double kGravity = 9.81;
+const Eigen::Vector3d kMagRef(0.5, 0.0, -0.6);
+
+#define XMNAV_REQUIRE_ALLOC_COUNTING()                                  \
+  if (!AllocCountingActive())                                           \
+  GTEST_SKIP() << "malloc interposition inactive (sanitizer or non-glibc)"
+
+// accelerometer reading for a body at rest with attitude q (body-to-inertial)
+Eigen::Vector3d GravityReading(const Eigen::Quaterniond &q_true) {
+  return q_true.conjugate() * Eigen::Vector3d(0, 0, -kGravity);
+}
+
+Eigen::Vector3d MagReading(const Eigen::Quaterniond &q_true) {
+  return q_true.conjugate() * kMagRef;
+}
+
+Mekf6::Params Mekf6Params() {
+  Mekf6::Params p;
+  p.gravity_constant = kGravity;
+  p.init_state_cov = Mekf6::StateCovariance::Identity() * 0.1;
+  p.init_observation_noise_cov =
+      Mekf6::ObservationNoiseCovariance::Identity() * 0.05;
+  p.sigma_omega = Eigen::Vector3d::Constant(0.01);
+  p.sigma_f = Eigen::Vector3d::Constant(0.05);
+  p.sigma_beta_omega = Eigen::Vector3d::Constant(0.001);
+  p.sigma_beta_f = Eigen::Vector3d::Constant(0.001);
+  return p;
+}
+
+Mekf9::Params Mekf9Params() {
+  Mekf9::Params p;
+  p.gravity_constant = kGravity;
+  p.mag_reference = kMagRef;
+  p.init_state_cov = Mekf9::StateCovariance::Identity() * 0.1;
+  p.accel_noise_cov = Mekf9::ObservationNoiseCovariance::Identity() * 0.05;
+  p.mag_noise_cov = Mekf9::ObservationNoiseCovariance::Identity() * 0.01;
+  p.sigma_omega = Eigen::Vector3d::Constant(0.01);
+  p.sigma_f = Eigen::Vector3d::Constant(0.05);
+  p.sigma_beta_omega = Eigen::Vector3d::Constant(0.001);
+  p.sigma_beta_f = Eigen::Vector3d::Constant(0.001);
+  p.sigma_beta_m = Eigen::Vector3d::Constant(0.001);
+  return p;
+}
+
+}  // namespace
+
+TEST(AllocationTest, PidUpdateAllocatesNothing) {
+  XMNAV_REQUIRE_ALLOC_COUNTING();
+
+  PidController::Config cfg;
+  cfg.kp = 2.0;
+  cfg.ki = 0.5;
+  cfg.kd = 0.1;
+  cfg.d_filter_tau = 0.05;
+  cfg.u_min = -1.0;
+  cfg.u_max = 1.0;
+  // non-empty name: telemetry handles are acquired at construction, which
+  // may allocate — Update() must not
+  cfg.name = "alloc_probe";
+  PidController pid(cfg);
+
+  const double dt = 0.01;
+  for (int i = 0; i < 10; ++i) pid.Update(1.0, 0.1 * i, dt);
+
+  double u = 0.0;
+  AllocationProbe probe;
+  for (int i = 0; i < kSteadyStateIters; ++i) {
+    u = pid.Update(1.0, std::sin(0.01 * i), dt);
+  }
+  EXPECT_EQ(probe.Count(), 0) << "PidController::Update allocated";
+  EXPECT_TRUE(std::isfinite(u));
+}
+
+TEST(AllocationTest, Mekf6UpdateAllocatesNothing) {
+  XMNAV_REQUIRE_ALLOC_COUNTING();
+
+  const Eigen::Quaterniond q_true =
+      Eigen::AngleAxisd(10.0 * M_PI / 180.0, Eigen::Vector3d::UnitX()) *
+      Eigen::AngleAxisd(-7.0 * M_PI / 180.0, Eigen::Vector3d::UnitY());
+  Mekf6 mekf;
+  mekf.Initialize(Mekf6Params());
+
+  const double dt = 0.01;
+  const Eigen::Vector3d gyro = Eigen::Vector3d::Zero();
+  const Eigen::Vector3d accel = GravityReading(q_true);
+  for (int i = 0; i < 10; ++i) ASSERT_TRUE(mekf.Update(gyro, accel, dt));
+
+  AllocationProbe probe;
+  bool ok = true;
+  for (int i = 0; i < kSteadyStateIters; ++i) {
+    ok = ok && mekf.Update(gyro, accel, dt);
+  }
+  EXPECT_EQ(probe.Count(), 0) << "Mekf6::Update allocated";
+  EXPECT_TRUE(ok);
+}
+
+TEST(AllocationTest, Mekf9UpdateAllocatesNothing) {
+  XMNAV_REQUIRE_ALLOC_COUNTING();
+
+  const Eigen::Quaterniond q_true =
+      Eigen::AngleAxisd(30.0 * M_PI / 180.0, Eigen::Vector3d::UnitZ()) *
+      Eigen::AngleAxisd(10.0 * M_PI / 180.0, Eigen::Vector3d::UnitX());
+  Mekf9 mekf;
+  mekf.Initialize(Mekf9Params());
+
+  const double dt = 0.01;
+  const Eigen::Vector3d gyro = Eigen::Vector3d::Zero();
+  const Eigen::Vector3d accel = GravityReading(q_true);
+  const Eigen::Vector3d mag = MagReading(q_true);
+  for (int i = 0; i < 10; ++i) ASSERT_TRUE(mekf.Update(gyro, accel, mag, dt));
+
+  AllocationProbe probe;
+  bool ok = true;
+  for (int i = 0; i < kSteadyStateIters; ++i) {
+    ok = ok && mekf.Update(gyro, accel, mag, dt);
+  }
+  EXPECT_EQ(probe.Count(), 0) << "Mekf9::Update allocated";
+  EXPECT_TRUE(ok);
+}
+
+TEST(AllocationTest, MppiPlanAllocatesNothing) {
+  XMNAV_REQUIRE_ALLOC_COUNTING();
+
+  Se2GoalCost cost;
+  cost.goal << 2.0, 1.0, M_PI / 2.0;
+
+  using Controller = Mppi<DiffDriveModel, Se2GoalCost>;
+  Controller::Params p;
+  p.num_samples = 256;
+  p.horizon_steps = 40;
+  p.dt = 0.05;
+  p.lambda = 0.3;
+  p.sigma << 0.3, 0.8;
+  p.u_min << -0.8, -2.0;
+  p.u_max << 0.8, 2.0;
+  // SavitzkyGolay5 copies the sequence every call — a documented
+  // conditional path, out of the steady-state zero-alloc contract
+  p.smooth_output = false;
+  Controller mppi(DiffDriveModel{}, cost, p);
+
+  DiffDriveModel model;
+  Controller::State x = Controller::State::Zero();
+  // first Plan() sizes the weighted-update buffer; warm up past it
+  for (int i = 0; i < 3; ++i) {
+    mppi.Plan(x);
+    x = model.Step(x, mppi.Command(), 0, p.dt);
+  }
+
+  AllocationProbe probe;
+  for (int i = 0; i < 100; ++i) {
+    mppi.Plan(x);
+    x = model.Step(x, mppi.Command(), 0, p.dt);
+  }
+  EXPECT_EQ(probe.Count(), 0) << "Mppi::Plan allocated";
+  EXPECT_TRUE(x.allFinite());
+}
+
+TEST(AllocationTest, WheeledShieldFilterAllocatesNothing) {
+  XMNAV_REQUIRE_ALLOC_COUNTING();
+
+  // No obstacles: the barrier path builds per-call std::vectors and the
+  // QP solver allocates per solve (known limitations, tracked in the
+  // backlog) — this pins the envelope + ladder passthrough path.
+  WheeledShield::Config cfg;
+  cfg.envelope.u_min << -0.8, -2.0;
+  cfg.envelope.u_max << 0.8, 2.0;
+  cfg.envelope.rate_limit << 2.0, 8.0;  // [m/s^2, rad/s^2]
+  cfg.ladder.hold_timeout = 0.1;
+  cfg.ladder.stop_ramp_time = 0.2;
+  cfg.state_staleness_max = 0.1;
+  cfg.enable_barrier = false;
+  WheeledShield shield(cfg);
+
+  const double dt = 0.02;
+  const WheeledShield::State origin = WheeledShield::State::Zero();
+  WheeledShield::Control u = WheeledShield::Control::Zero();
+  for (int i = 0; i < 50; ++i) {
+    u = shield.Filter(WheeledShield::Control(0.5, 0.0), origin, 0.0, dt);
+  }
+  ASSERT_EQ(shield.mode(), ShieldMode::kNormal);
+
+  AllocationProbe probe;
+  for (int i = 0; i < kSteadyStateIters; ++i) {
+    const WheeledShield::Control cmd(0.5 + 0.2 * std::sin(0.01 * i),
+                                     0.1 * std::cos(0.01 * i));
+    u = shield.Filter(cmd, origin, 0.0, dt);
+  }
+  EXPECT_EQ(probe.Count(), 0) << "WheeledShield::Filter allocated";
+  EXPECT_EQ(shield.mode(), ShieldMode::kNormal);
+  EXPECT_TRUE(u.allFinite());
+}


### PR DESCRIPTION
## Summary

Implements the first "adopt now" item from the IHMC study (`docs/research/ihmc-open-robotics-software.md` §6): an `allocation` test tier that mechanically enforces the zero-heap-allocation contracts of the steady-state hot paths.

- **`tests/allocation/`** — new tier, one dedicated binary (malloc interposition is process-global):
  - `alloc_counter.{hpp,cpp}`: strong definitions of the glibc malloc family (`malloc`/`calloc`/`realloc`/`aligned_alloc`/`posix_memalign`/`memalign`/`free`) forwarding to `__libc_*` with an atomic counter, plus an RAII `AllocationProbe`. Counting at the malloc level, not `operator new`, because Eigen's dynamic-size allocations go straight to `malloc`. Compiles to an inactive stub under ASan/TSan or non-glibc; the tests `GTEST_SKIP` there.
  - `test_allocation.cpp`: warm up outside the probe window, then assert zero allocating calls over many steady-state iterations of `PidController::Update()`, `Mekf6::Update()`, `Mekf9::Update()`, `Mppi::Plan()` (CPU backend, `smooth_output=false`, introspection off), and `WheeledShield::Filter()` (no-obstacle envelope+ladder path — the barrier/QP path's per-solve allocation is a documented limitation tracked in the backlog).

## Bug found and fixed

The MPPI test immediately caught a violation of the header's documented "no heap allocation on the hot path" contract: **`Mppi::Plan()` allocated exactly once per call** — the `.eval()` heap temporary in `mppi_detail::ShiftSequence`. Replaced with an in-place ascending row-wise shift (no aliasing hazard, no temporary). Behavior is identical; the ShiftSequence unit test and the full suite pass.

## CI wiring

- `cpp.yml` `test` + `sanitizers` jobs: `ctest -LE "campaign|allocation"` (interposition is inactive under ASan anyway).
- `nightly.yml`: new `Allocation tests` step running `ctest -L allocation` after the campaigns.
- The binary still builds on PRs so it cannot rot (same policy as the campaign tier).

## Verification

Fresh Release build (glibc, no sanitizers): `ctest -L allocation` → 5/5 passed, 0 skipped; full `ctest -LE campaign` → 109/109 passed.

Also ticks the allocation-testing item in TODO.md.