### PR TITLE
test: rewindability regression — snapshot, resume, bitwise-diff the tail

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5,7 +5,7 @@ Active near-term work. Status: `[ ]` open · `[~]` in progress · `[x]` done. De
 ## Verification & CI (IHMC study "adopt now" items — docs/research/ihmc-open-robotics-software.md §6)
 
 - [x] Allocation-testing category: malloc-hook counters around steady-state `Mppi::Plan()`, `WheeledShield::Filter()`, and MEKF/PID `Update()`; nightly `allocation` ctest label
-- [ ] Rewindability regression: run → rewind `SimLog` → re-simulate → diff-to-zero
+- [x] Rewindability regression: run → rewind `SimLog` → re-simulate → diff-to-zero
 - [ ] Self-hosted CUDA runner so the CUDA rollout backends build and test in CI
 
 ## Estimation

--- a/src/simulation/include/xmnav/sim/sim_log.hpp
+++ b/src/simulation/include/xmnav/sim/sim_log.hpp
@@ -42,6 +42,7 @@ class SimLog {
     return controls_.row(i).transpose();
   }
   const Eigen::MatrixXd &states() const { return states_; }
+  const Eigen::MatrixXd &measurements() const { return measurements_; }
   const Eigen::MatrixXd &controls() const { return controls_; }
 
   // one JSON object per run

--- a/src/simulation/include/xmnav/sim/sim_loop.hpp
+++ b/src/simulation/include/xmnav/sim/sim_loop.hpp
@@ -62,11 +62,24 @@ class SimLoop {
   // records the true state, measurement, and control per step.
   State Run(const State &x0, const Agent &agent, SimLog *log = nullptr,
             const Observer &observer = {}) {
+    return RunFrom(0, config_.steps, x0, agent, log, observer);
+  }
+
+  // run a segment: ticks t0..t0+steps-1 from state x0. Agent, plant, and
+  // logged times all see the GLOBAL tick index, so time-dependent behavior
+  // matches a full run. Resume contract (rewindability): the observer fires
+  // at a clean RNG boundary — all of tick t's noise draws are complete when
+  // it is called — so a COPY of this loop taken in the observer at tick k-1
+  // carries the RNG mid-stream, and RunFrom(k, ...) on that copy from the
+  // tick-(k-1) logged state reproduces the original run's tail bitwise.
+  State RunFrom(int t0, int steps, const State &x0, const Agent &agent,
+                SimLog *log = nullptr, const Observer &observer = {}) {
     if (log != nullptr) {
-      log->Reset(config_.steps, kStateDim, kControlDim);
+      log->Reset(steps, kStateDim, kControlDim);
     }
     State x = x0;
-    for (int t = 0; t < config_.steps; ++t) {
+    for (int i = 0; i < steps; ++i) {
+      const int t = t0 + i;
       const State z = x + Noise(config_.measurement_noise);
       const Control u = agent(z, t);
       x = plant_.Step(x, u, t, config_.dt);

--- a/tests/integration/CMakeLists.txt
+++ b/tests/integration/CMakeLists.txt
@@ -7,11 +7,20 @@
 ##   campaign    — Monte-Carlo robustness with plant-model mismatch;
 ##                 excluded from PR ctest (-LE campaign), run nightly.
 ##                 Campaign binaries still BUILD on PRs so they cannot rot.
+##
+## Rewindability contract (test_rewindability): every stack component is a
+## self-contained value — a mid-run COPY of the SimLoop + algorithm stack,
+## resumed via SimLoop::RunFrom, must reproduce the recorded tail bitwise.
 
 add_executable(test_pipeline_diffdrive test_pipeline_diffdrive.cpp)
 target_link_libraries(test_pipeline_diffdrive
     estimation mppi shield sim gtest gtest_main)
 gtest_discover_tests(test_pipeline_diffdrive PROPERTIES LABELS integration)
+
+add_executable(test_rewindability test_rewindability.cpp)
+target_link_libraries(test_rewindability
+    mppi shield sim gtest gtest_main)
+gtest_discover_tests(test_rewindability PROPERTIES LABELS integration)
 
 add_executable(campaign_diffdrive campaign_diffdrive.cpp)
 target_link_libraries(campaign_diffdrive

--- a/tests/integration/test_rewindability.cpp
+++ b/tests/integration/test_rewindability.cpp
@@ -1,0 +1,178 @@
+/*
+ * test_rewindability.cpp
+ *
+ * Rewindability regression (the second "adopt now" item of
+ * docs/research/ihmc-open-robotics-software.md §6, after IHMC's
+ * DRCFlatGroundRewindabilityTest): run a scenario, snapshot the loop and
+ * the algorithm stack mid-run by COPY, resume the copies from that tick,
+ * and bitwise-diff the recorded tail against the original run.
+ *
+ * What this pins that the units cannot: every component in the loop is a
+ * self-contained value — copying it captures ALL state that influences
+ * future outputs (RNG streams, warm-start buffers, rate-limit memory,
+ * FSM state). Any hidden state, shallow copy, or nondeterminism shows up
+ * as a bitwise mismatch in the resumed tail. Bitwise is the contract on
+ * the CPU path (mppi.hpp documents determinism for any thread count); do
+ * not weaken these asserts to isApprox.
+ *
+ * Snapshot boundary: the SimLoop observer fires after the process-noise
+ * draw of its tick, i.e. at a clean RNG boundary — copying at tick k-1
+ * captures the generator exactly where tick k's draws begin (contract
+ * documented on SimLoop::RunFrom).
+ *
+ * Copyright (c) 2026 Ruixiang Du (rdu)
+ */
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <optional>
+
+#include "xmnav/models/diff_drive.hpp"
+#include "xmnav/mppi/critics.hpp"
+#include "xmnav/mppi/mppi.hpp"
+#include "xmnav/shield/wheeled_shield.hpp"
+#include "xmnav/sim/sim_loop.hpp"
+
+using namespace xmotion;
+
+namespace {
+
+#if !defined(NDEBUG) || defined(__SANITIZE_ADDRESS__) || \
+    defined(__SANITIZE_THREAD__)
+constexpr int kSamples = 128;
+#else
+constexpr int kSamples = 256;
+#endif
+
+constexpr double kDt = 0.05;
+
+// bitwise equality of log A rows [k, k+len) against log B rows [0, len)
+void ExpectTailBitwiseEqual(const SimLog &a, const SimLog &b, int k,
+                            int len) {
+  ASSERT_EQ(b.size(), len);
+  EXPECT_TRUE((a.states().middleRows(k, len).array() ==
+               b.states().array())
+                  .all());
+  EXPECT_TRUE((a.measurements().middleRows(k, len).array() ==
+               b.measurements().array())
+                  .all());
+  EXPECT_TRUE((a.controls().middleRows(k, len).array() ==
+               b.controls().array())
+                  .all());
+  for (int i = 0; i < len; ++i) {
+    EXPECT_EQ(a.time(k + i), b.time(i)) << "row " << i;
+  }
+}
+
+}  // namespace
+
+TEST(RewindabilityTest, SimLoopRewind) {
+  // plant-only determinism of the loop machinery: open-loop t-dependent
+  // agent, both noise channels ON so the snapshot must carry the RNG
+  constexpr int kSteps = 400;
+  constexpr int kRewindTick = 200;
+
+  SimLoop<DiffDriveModel>::Config cfg;
+  cfg.dt = kDt;
+  cfg.steps = kSteps;
+  cfg.seed = 7;
+  cfg.process_noise << 0.01, 0.01, 0.005;
+  cfg.measurement_noise << 0.02, 0.02, 0.01;
+
+  auto agent = [](const DiffDriveModel::State &, int t) {
+    return DiffDriveModel::Control(0.5, 0.4 * std::sin(0.1 * t));
+  };
+
+  SimLoop<DiffDriveModel> sim(DiffDriveModel{}, cfg);
+  std::optional<SimLoop<DiffDriveModel>> sim_snapshot;
+  DiffDriveModel::State x_snapshot = DiffDriveModel::State::Zero();
+
+  SimLog log_a;
+  sim.Run(DiffDriveModel::State::Zero(), agent, &log_a,
+          [&](const DiffDriveModel::State &x, const DiffDriveModel::Control &,
+              int t) {
+            if (t == kRewindTick - 1) {
+              sim_snapshot.emplace(sim);
+              x_snapshot = x;
+            }
+          });
+  ASSERT_TRUE(sim_snapshot.has_value());
+
+  constexpr int kTail = kSteps - kRewindTick;
+  SimLog log_b;
+  sim_snapshot->RunFrom(kRewindTick, kTail, x_snapshot, agent, &log_b);
+  ExpectTailBitwiseEqual(log_a, log_b, kRewindTick, kTail);
+}
+
+TEST(RewindabilityTest, ComposedPipelineRewind) {
+  // the real regression: Mppi (warm-start buffers + sampler RNG + thread
+  // pool) and WheeledShield (FSM + rate-limit memory) must be rewindable
+  // by copy alongside the loop
+  constexpr int kSteps = 300;
+  constexpr int kRewindTick = 150;
+
+  Se2GoalCost cost;
+  cost.goal << 3.0, 1.0, 0.0;
+  using Controller = Mppi<DiffDriveModel, Se2GoalCost>;
+  Controller::Params p;
+  p.num_samples = kSamples;
+  p.horizon_steps = 30;
+  p.dt = kDt;
+  p.lambda = 0.3;
+  p.sigma << 0.3, 0.8;
+  p.u_min << -0.8, -2.0;
+  p.u_max << 0.8, 2.0;
+  p.normalize_cost_spread = true;
+  Controller mppi(DiffDriveModel{}, cost, p);
+
+  // obstacle-free shield config (same rationale as the allocation tier):
+  // pins the envelope + ladder passthrough path
+  WheeledShield::Config sc;
+  sc.envelope.u_min = p.u_min;
+  sc.envelope.u_max = p.u_max;
+  sc.envelope.rate_limit << 3.0, 10.0;
+  sc.enable_barrier = false;
+  WheeledShield shield(sc);
+
+  SimLoop<DiffDriveModel>::Config cfg;
+  cfg.dt = kDt;
+  cfg.steps = kSteps;
+  cfg.seed = 21;
+  cfg.process_noise << 0.002, 0.002, 0.004;
+  cfg.measurement_noise << 0.01, 0.01, 0.005;
+
+  auto make_agent = [&](Controller &c, WheeledShield &s) {
+    return [&c, &s](const DiffDriveModel::State &z, int) {
+      c.Plan(z);
+      return s.Filter(c.Command(), z, /*state_age=*/0.0, kDt);
+    };
+  };
+
+  SimLoop<DiffDriveModel> sim(DiffDriveModel{}, cfg);
+  std::optional<SimLoop<DiffDriveModel>> sim_snapshot;
+  std::optional<Controller> mppi_snapshot;
+  std::optional<WheeledShield> shield_snapshot;
+  DiffDriveModel::State x_snapshot = DiffDriveModel::State::Zero();
+
+  SimLog log_a;
+  sim.Run(DiffDriveModel::State::Zero(), make_agent(mppi, shield), &log_a,
+          [&](const DiffDriveModel::State &x, const DiffDriveModel::Control &,
+              int t) {
+            if (t == kRewindTick - 1) {
+              sim_snapshot.emplace(sim);
+              mppi_snapshot.emplace(mppi);
+              shield_snapshot.emplace(shield);
+              x_snapshot = x;
+            }
+          });
+  ASSERT_TRUE(sim_snapshot.has_value());
+  ASSERT_EQ(shield.mode(), ShieldMode::kNormal);
+
+  constexpr int kTail = kSteps - kRewindTick;
+  SimLog log_b;
+  sim_snapshot->RunFrom(kRewindTick, kTail, x_snapshot,
+                        make_agent(*mppi_snapshot, *shield_snapshot),
+                        &log_b);
+  ExpectTailBitwiseEqual(log_a, log_b, kRewindTick, kTail);
+}


### PR DESCRIPTION
## Summary

Implements the second "adopt now" item from the IHMC study (`docs/research/ihmc-open-robotics-software.md` §6, after `DRCFlatGroundRewindabilityTest`): run a scenario, rewind, re-simulate, and compare the recorded tail — **bitwise**, never `isApprox`.

Since `SimLog` has no variable buffer to rewind (it records truth/measurement/control only), the rewind mechanism is **snapshot-by-copy**: every component in the stack is a self-contained value type, so a mid-run copy captures all state that influences future outputs — the sim loop's noise RNG (`mt19937_64` + the normal distribution's cached spare), the MPPI sampler engine and warm-start buffers, the shield's ctfsm ladder and rate-limit memory. Any hidden state, shallow copy, or nondeterminism shows up as a bitwise mismatch in the resumed tail.

## Changes

- **`SimLoop::RunFrom(t0, steps, x0, agent, log, observer)`** (additive) — runs global ticks `t0..t0+steps-1`; agent, plant, and logged times all see the global tick index. `Run()` is now a thin delegate (`RunFrom(0, config.steps, ...)`) — zero behavior change for existing callers. The resume contract (observer fires at a clean RNG boundary, so a copy taken at tick k−1 reproduces the tail from tick k) is documented on the method.
- **`SimLog::measurements()`** accessor (additive) — needed for the tail diff.
- **`tests/integration/test_rewindability.cpp`** — two `integration`-labeled tests (PR-time budget, ~0.3 s Release; samples scaled down for Debug/sanitizer like the pipeline tests):
  - `SimLoopRewind` — plant-only, open-loop t-dependent agent, both noise channels on; pins the loop RNG snapshot machinery. N=400, rewind at 200.
  - `ComposedPipelineRewind` — diff-drive + MPPI (CPU backend) + WheeledShield (obstacle-free envelope+ladder); pins the full stack's copy-rewindability. N=300, rewind at 150.

## Result

Bitwise equality held on the first try for both tests — no hidden-state or shallow-copy bugs in the current stack; the tests now pin that property against regression.

## Verification

Release build, `XMOTION_WERROR=ON`, warning-clean. `ctest -L integration`: 5/5. Full `ctest -LE campaign`: 111/111 (including the allocation-contract tests — the `RunFrom` refactor adds no hot-path allocations).

Also ticks the rewindability item in TODO.md — both §6 "adopt now" items are now done.