### PR TITLE
refactor: repatriate SkewSymmetric from xmbase/math to estimation

### DIFF
--- a/src/estimation/include/xmnav/estimation/matrix_utils.hpp
+++ b/src/estimation/include/xmnav/estimation/matrix_utils.hpp
@@ -1,0 +1,32 @@
+/*
+ * matrix_utils.hpp
+ *
+ * Small Eigen helpers for the estimation filters (MEKF attitude math).
+ *
+ * Repatriated from xmbase/math (ADR 0007 placement rule: one function,
+ * one consumer component — a primitive with a single consumer lives with
+ * that consumer, and the foundation stays Eigen-light).
+ *
+ * Copyright (c) 2024-2026 Ruixiang Du (rdu)
+ */
+
+#ifndef XMNAV_ESTIMATION_MATRIX_UTILS_HPP
+#define XMNAV_ESTIMATION_MATRIX_UTILS_HPP
+
+#include <eigen3/Eigen/Dense>
+
+namespace xmotion {
+namespace MathUtils {
+inline Eigen::Matrix<double, 3, 3> SkewSymmetric(const Eigen::Vector3d& v) {
+  Eigen::Matrix<double, 3, 3> m;
+  // clang-format off
+  m <<     0, -v.z(),  v.y(),
+       v.z(),      0, -v.x(),
+      -v.y(),  v.x(),      0;
+  // clang-format on
+  return m;
+}
+}  // namespace MathUtils
+}  // namespace xmotion
+
+#endif  // XMNAV_ESTIMATION_MATRIX_UTILS_HPP

--- a/src/estimation/src/mekf6.cpp
+++ b/src/estimation/src/mekf6.cpp
@@ -12,7 +12,7 @@
 
 #include <cmath>
 
-#include "xmbase/math/matrix_utils.hpp"
+#include "xmnav/estimation/matrix_utils.hpp"
 
 namespace xmotion {
 namespace {

--- a/src/estimation/src/mekf9.cpp
+++ b/src/estimation/src/mekf9.cpp
@@ -14,7 +14,7 @@
 
 #include <cmath>
 
-#include "xmbase/math/matrix_utils.hpp"
+#include "xmnav/estimation/matrix_utils.hpp"
 
 namespace xmotion {
 namespace {


### PR DESCRIPTION
## Summary

ADR 0007 (XMotion#30) placement rule applied: `xmbase/math/matrix_utils.hpp` contains one function (`SkewSymmetric`) with exactly two call sites, both in this repo's estimation filters — a single-consumer primitive lives with its consumer. Moved to `xmnav/estimation/matrix_utils.hpp` (same `xmotion::MathUtils` namespace; call sites change only the include line). Companion xmBase PR removes the now-orphaned `math/` module, taking xmBase one step toward an Eigen-light core.

## Test plan
- [x] Full suite: 114/114 pass
- [x] No `xmbase/math` includes remain (grep)