### PR TITLE
build: adopt xmBase 0.5.0 — geometry-tier consumers link xmBaseGeometry

### DIFF
--- a/src/control/kinematics/CMakeLists.txt
+++ b/src/control/kinematics/CMakeLists.txt
@@ -4,7 +4,7 @@ find_package(Eigen3 REQUIRED NO_MODULE)
 ## Add libraries
 add_library(kinematics
     src/swerve_drive_kinematics.cpp)
-target_link_libraries(kinematics PUBLIC xmotion::xmBase Eigen3::Eigen)
+target_link_libraries(kinematics PUBLIC xmotion::xmBase xmotion::xmBaseGeometry Eigen3::Eigen)
 target_include_directories(kinematics PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>

--- a/src/mapping/map_processing/CMakeLists.txt
+++ b/src/mapping/map_processing/CMakeLists.txt
@@ -14,6 +14,7 @@ add_library(map_processing
 )
 target_link_libraries(map_processing PUBLIC
     xmotion::xmBase
+    xmotion::xmBaseGeometry
     xmotion::navtypes
     Eigen3::Eigen
     ${OpenCV_LIBS}

--- a/src/types/CMakeLists.txt
+++ b/src/types/CMakeLists.txt
@@ -7,7 +7,7 @@ add_library(navtypes INTERFACE)
 target_include_directories(navtypes INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>)
-target_link_libraries(navtypes INTERFACE xmotion::xmBase)
+target_link_libraries(navtypes INTERFACE xmotion::xmBase xmotion::xmBaseGeometry)
 add_library(xmotion::navtypes ALIAS navtypes)
 
 install(TARGETS navtypes


### PR DESCRIPTION
Consumer side of the ADR 0007 Eigen split (found by the umbrella pin-wave build): navtypes/map_processing/kinematics use the Eigen-backed geometry tier, now behind `xmotion::xmBaseGeometry`. Bundled xmBase → v0.5.0. 114/114 against the new pin. Part of the ADR 0007 pin wave — merge before the umbrella repin.