### PR TITLE
build: per-tier opt-in gating + ctfsm double-provision guard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,15 @@ option(XMOTION_DEV_MODE "Development mode forces building tests" OFF)
 option(XMOTION_WERROR "Treat warnings as errors (-Wall -Wextra -Werror)" OFF)
 option(XMNAV_WITH_CUDA "Build CUDA rollout backends (requires CUDA toolkit)" OFF)
 
+# Per-tier opt-in gating (default ON). A consumer that only needs the control +
+# estimation algorithms (e.g. a locomotion-controller app) can turn the higher
+# planning-stack tiers OFF so they are never configured or built — narrow
+# ingestion to match narrow linkage, without splitting the repo (family stays
+# coarse; the CMake target is the dependency unit).
+option(XMNAV_WITH_PLANNING "Build the planning tier (graph/sampling/lattice/decomp/geometry)" ON)
+option(XMNAV_WITH_MAPPING "Build the mapping tier (occupancy / point-cloud processing)" ON)
+option(XMNAV_WITH_DECISION "Build the decision tier (markov / reachability / prediction)" ON)
+
 if (DEFINED ENV{ROS_DISTRO})
   set(BUILD_WITH_ROS ON)
 endif ()
@@ -168,21 +177,29 @@ endif ()
 
 ## Aggregate interface target: consumers link a single `xmotion::xmNavigation` to pull
 ## in the XMotion algorithm libraries (estimation, control, planning).
-add_library(xmNavigation INTERFACE)
-target_link_libraries(xmNavigation INTERFACE
+# Core (always present): types + estimation + control foundation. The higher
+# tiers are appended only when their XMNAV_WITH_* option is ON, so the aggregate
+# never references a target that gating removed. (`ctfsm`/`models` fixed here:
+# the list previously named `fsm`/`model`, which are not defined targets —
+# they resolved to phantom `-lfsm -lmodel` link flags for aggregate consumers.)
+set(_xmnav_targets
     navtypes
     estimation
     kinematics
     pid
-    fsm
-    model
-    geometry
-    decomp
-    sampling
-    map_processing
-    lattice
-    markov
-    reachability)
+    ctfsm
+    models)
+if (XMNAV_WITH_PLANNING)
+  list(APPEND _xmnav_targets geometry decomp sampling lattice)
+endif ()
+if (XMNAV_WITH_MAPPING)
+  list(APPEND _xmnav_targets map_processing)
+endif ()
+if (XMNAV_WITH_DECISION)
+  list(APPEND _xmnav_targets markov reachability)
+endif ()
+add_library(xmNavigation INTERFACE)
+target_link_libraries(xmNavigation INTERFACE ${_xmnav_targets})
 add_library(xmotion::xmNavigation ALIAS xmNavigation)
 install(TARGETS xmNavigation
     EXPORT xmNavigationTargets

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,11 +1,19 @@
 ## Add source directories
-# Modules
+# Modules. types/estimation/control/simulation are always built (the control +
+# estimation foundation). The higher planning-stack tiers are opt-in (see the
+# XMNAV_WITH_* options) so a control-only consumer configures just what it uses.
 add_subdirectory(types)
-add_subdirectory(mapping)
-add_subdirectory(decision)
+if (XMNAV_WITH_MAPPING)
+  add_subdirectory(mapping)
+endif ()
+if (XMNAV_WITH_DECISION)
+  add_subdirectory(decision)
+endif ()
 add_subdirectory(estimation)
 add_subdirectory(control)
-add_subdirectory(planning)
+if (XMNAV_WITH_PLANNING)
+  add_subdirectory(planning)
+endif ()
 add_subdirectory(simulation)
 
 if (ENABLE_VISUALIZATION)

--- a/src/control/CMakeLists.txt
+++ b/src/control/CMakeLists.txt
@@ -2,8 +2,16 @@
 # compile-time-verified FSM engine; tests/examples are upstream-gated.
 # Install/export stays ON: exported consumers (shield) link ctfsm::ctfsm,
 # so the target must belong to an installed export set.
-set(CTFSM_INSTALL ON)
-add_subdirectory(fsm)
+#
+# Guard against double provision: an application that also consumes the
+# standalone ctfsm (e.g. as its own submodule) defines `ctfsm` before adding
+# xmNavigation. In that case reuse the parent's target — adding our vendored
+# copy would clash on the `ctfsm` target name. (The parent is then responsible
+# for exporting ctfsm; ours does so via CTFSM_INSTALL when we own it.)
+if (NOT TARGET ctfsm)
+  set(CTFSM_INSTALL ON)
+  add_subdirectory(fsm)
+endif ()
 add_subdirectory(models)
 add_subdirectory(pid)
 add_subdirectory(kinematics)


### PR DESCRIPTION
## What & why

Enable a **control + estimation** consumer (e.g. a legged locomotion-controller app) to depend on xmNavigation without dragging in the planning stack, and without a target-name clash when the app also provides the standalone `ctfsm`. Keeps the family **coarse** — selection is by CMake *target*, not by splitting the repo.

## Changes

- **Per-tier opt-in gating.** New options `XMNAV_WITH_PLANNING` / `XMNAV_WITH_MAPPING` / `XMNAV_WITH_DECISION` (default **ON** → default behavior unchanged). `src/CMakeLists.txt` gates those three subdirs; `types` / `estimation` / `control` / `simulation` always build. A control-only consumer sets the three OFF and never configures the planning-stack tiers.
- **ctfsm double-provision guard.** `add_subdirectory(fsm)` is now wrapped in `if (NOT TARGET ctfsm)`, so a parent that already defines the standalone `ctfsm` (its own submodule, added first) is reused instead of clashing on the `ctfsm` target. The parent then owns ctfsm's export.
- **Aggregate fix (bonus).** `xmotion::xmNavigation` linked **non-existent targets `fsm` and `model`** — these silently degraded to phantom `-lfsm -lmodel` link flags for anyone linking the aggregate into a binary. Corrected to the real `ctfsm` / `models`, and the link list is now built conditionally so it never names a gated-out target.

## Verification

- **Standalone, all tiers (default):** configures + builds (`estimation`, `reachability`).
- **Control-only** (`-DXMNAV_WITH_PLANNING=OFF -DXMNAV_WITH_MAPPING=OFF -DXMNAV_WITH_DECISION=OFF`): configures faster; `estimation` builds; `reachability` is absent (`unknown target`).
- **Guard scenario:** a harness that provides + exports the standalone `ctfsm` first, then `add_subdirectory`s nav (control-only), configures with **no duplicate-target and no `install(EXPORT)` error**, and successfully links an executable against `xmotion::xmNavigation` (also proving the phantom `-lfsm/-lmodel` are gone).

## Notes

- Default builds are byte-for-byte behavior-equivalent except the aggregate now links real targets instead of phantom flags (a strict fix).
- Install/export is intentionally left **unconditional** (matches the family convention where each component self-installs even as a module, which the umbrella superbuild relies on).