### PR TITLE
fix(estimation): gate MEKF observations on raw magnitude (self-lock)

### DIFF
--- a/docs/typst/mekf-errata.typ
+++ b/docs/typst/mekf-errata.typ
@@ -13,7 +13,7 @@
 
 = Summary
 
-Five errors were found in the derivation document and eight in the implementation. They fall into three classes: (1) *process-noise errors* in the document, copied into the code, that break the covariance's symmetry and consistency; (2) a *structural bookkeeping error* — the document omitted the bias fold-in and error-state reset, and the code consequently never accumulated bias estimates; (3) *production defects* in the code only (console I/O in the hot path, numerically fragile covariance update, no observation gating, no input validation).
+Five errors were found in the derivation document and nine in the implementation. They fall into three classes: (1) *process-noise errors* in the document, copied into the code, that break the covariance's symmetry and consistency; (2) a *structural bookkeeping error* — the document omitted the bias fold-in and error-state reset, and the code consequently never accumulated bias estimates; (3) *production defects* in the code only (console I/O in the hot path, numerically fragile covariance update, no observation gating, no input validation).
 
 = Errors in the derivation document
 
@@ -129,6 +129,10 @@ The gravity observation was applied unconditionally. Under dynamic acceleration 
 
 Float literals (`2.0f`, `3.0f`) mixed into double expressions; `q.inverse()` where `conjugate()` suffices on a normalized quaternion; no input validation (`dt <= 0`, NaN propagate silently — now rejected with the state untouched, pinned by `Mekf6Test.RejectsInvalidInput`).
 
+== C9 — Observation gate keyed on the bias-corrected magnitude (self-lock)
+
+The gate added in C7 (and the magnetometer gate) test the *bias-corrected* magnitude, $|thin| ||bold(a) - bold(beta)_f|| - g thin| <= tau$, coupling each gate to the very bias it helps estimate. This creates a feedback lock. Under sustained motion the accelerometer is (correctly) gated out, yet the magnetometer update still runs and, through the covariance cross-terms, drives $bold(beta)_f$ away from zero while the attitude is uncorrected. Once $bold(beta)_f$ has drifted, $||bold(a) - bold(beta)_f||$ no longer resembles $g$ *even when the device is static with clean gravity* — so the accelerometer stays gated, and since it is the only observation that corrects both the attitude and $bold(beta)_f$, the estimate cannot recover: roll and pitch lock at a tilted offset. *Fix:* gate on the *raw* measured magnitude, $|thin| ||tilde(bold(a))|| - g thin| <= tau$ (and likewise $||tilde(bold(m))||$ for the magnetometer) — the gate is a quasi-static / interference detector on the measurement, not the estimate; the innovation still uses the bias-corrected value. *Pinned by:* `Mekf9Test.AccelGateUsesRawMagnitudeNotBiasCorrected` and `Mekf9Test.MagGateUsesRawMagnitudeNotBiasCorrected` — a large seeded bias with a clean static reading must still be accepted. *Related:* the failure is most acute for a factory-calibrated IMU whose true bias is $approx 0$; such sensors should additionally pin the bias states with tight priors (cf. `CleanSensorParams`) so the bias never drifts to begin with.
+
 = Error-to-fix map
 
 #table(
@@ -145,6 +149,7 @@ Float literals (`2.0f`, `3.0f`) mixed into double expressions; `q.inverse()` whe
   [C6 covariance update form], [code], [CovarianceStaysSymmetricPositive],
   [C7 no gating], [code], [AccelGateRejectsDynamicAcceleration],
   [C8 validation/hygiene], [code], [RejectsInvalidInput],
+  [C9 gate self-lock on diverged bias], [code (Mekf9)], [AccelGate/MagGateUsesRawMagnitude],
 )
 
 Behavioral correctness of the whole is additionally pinned by `StaticAttitudeConvergence` (12° initial error converging below 0.5°, with the attitude/accel-bias observability manifold documented in the test) and `TracksSlowRollRotation` (sustained-motion tracking, gravity-direction error below 1°).

--- a/src/estimation/src/mekf9.cpp
+++ b/src/estimation/src/mekf9.cpp
@@ -137,10 +137,19 @@ bool Mekf9::Update(const ControlInput &gyro_tilde,
   P_ = 0.5 * (P_ + P_.transpose());
 
   // --- gravity observation (gated) ---
+  // Gate on the RAW specific-force magnitude, not the bias-corrected
+  // |accel - b_f|. The gate is a quasi-static detector ("is |a| ~ g right
+  // now?"), which is a property of the measurement, not of the estimated bias.
+  // Keying it on b_f creates a feedback lock: if b_f diverges (e.g. it absorbed
+  // error while the accel was gated out during motion), the bias-corrected
+  // magnitude no longer looks like gravity, so the filter rejects the
+  // accelerometer even while stationary with clean gravity -- and since the
+  // accelerometer is the only observation that corrects both attitude and b_f,
+  // it can never recover. The update below still uses the bias-corrected accel.
   const Eigen::Vector3d g_i(0.0, 0.0, -params_.gravity_constant);
   last_accel_used_ =
       params_.accel_gate_threshold <= 0.0 ||
-      std::abs(accel.norm() - params_.gravity_constant) <=
+      std::abs(accel_tilde.norm() - params_.gravity_constant) <=
           params_.accel_gate_threshold;
   if (last_accel_used_) {
     const Eigen::Vector3d h_a = q_hat_.conjugate() * g_i;
@@ -150,8 +159,10 @@ bool Mekf9::Update(const ControlInput &gyro_tilde,
   }
 
   // --- magnetometer observation (gated) ---
+  // Same rationale as the accelerometer: gate on the raw magnitude so a diverged
+  // magnetometer bias b_m cannot lock the magnetometer out.
   last_mag_used_ = params_.mag_gate_threshold <= 0.0 ||
-                   std::abs(mag.norm() - params_.mag_reference.norm()) <=
+                   std::abs(mag_tilde.norm() - params_.mag_reference.norm()) <=
                        params_.mag_gate_threshold;
   if (last_mag_used_) {
     const Eigen::Vector3d h_m = q_hat_.conjugate() * params_.mag_reference;

--- a/src/estimation/test/test_mekf9.cpp
+++ b/src/estimation/test/test_mekf9.cpp
@@ -152,3 +152,36 @@ TEST(Mekf9Test, RejectsInvalidInput) {
                            Eigen::Vector3d(NAN, 0, 0), 0.01));
   EXPECT_TRUE(before.coeffs().isApprox(mekf.GetQuaternion().coeffs()));
 }
+
+// Regression: a diverged inertial-bias estimate must not lock its own sensor
+// out of the filter. The observation gate is a quasi-static / interference
+// detector on the RAW measurement magnitude; keying it on the bias-corrected
+// magnitude let a runaway bias reject a clean measurement forever, so the
+// attitude could never re-level. See docs/typst/mekf-errata.typ.
+TEST(Mekf9Test, AccelGateUsesRawMagnitudeNotBiasCorrected) {
+  Mekf9 mekf;
+  Mekf9::Params p = DefaultParams();
+  p.accel_gate_threshold = 0.5;
+  p.init_accel_bias = Eigen::Vector3d(0.0, 0.0, 3.0);  // large, wrong accel bias
+  mekf.Initialize(p);
+
+  // Device is static: the raw accelerometer reads pure gravity (|a| = g), so the
+  // gate must accept it regardless of the (diverged) bias estimate.
+  const Eigen::Quaterniond q = Eigen::Quaterniond::Identity();
+  ASSERT_TRUE(mekf.Update(Eigen::Vector3d::Zero(), GravityReading(q),
+                          MagReading(q), 0.01));
+  EXPECT_TRUE(mekf.LastUpdateUsedAccel());  // false under the |a - b_f| gate
+}
+
+TEST(Mekf9Test, MagGateUsesRawMagnitudeNotBiasCorrected) {
+  Mekf9 mekf;
+  Mekf9::Params p = DefaultParams();
+  p.mag_gate_threshold = 0.2 * kMagRef.norm();
+  p.init_mag_bias = kMagRef;  // large, wrong mag bias (~100% of the field)
+  mekf.Initialize(p);
+
+  const Eigen::Quaterniond q = Eigen::Quaterniond::Identity();
+  ASSERT_TRUE(mekf.Update(Eigen::Vector3d::Zero(), GravityReading(q),
+                          MagReading(q), 0.01));
+  EXPECT_TRUE(mekf.LastUpdateUsedMag());  // false under the |m - b_m| gate
+}


### PR DESCRIPTION
## Problem

`Mekf9`'s accelerometer and magnetometer validity gates test the **bias-corrected** magnitude — `|‖a − b_f‖ − g|` and `|‖m − b_m‖ − ‖m_ref‖|`. This couples each gate to the very bias state it helps estimate, which creates a **self-lock**:

- During sustained motion the accelerometer is (correctly) gated out, but the magnetometer update still runs and, through the covariance cross-terms, drives `b_f` away from zero while the attitude is uncorrected.
- Once `b_f` has drifted, `‖a − b_f‖` no longer resembles `g` **even when the device is static with clean gravity** — so the accelerometer stays gated.
- Since the accelerometer is the *only* observation that corrects both the attitude and `b_f`, the estimate can never recover: **roll/pitch lock at a tilted offset**, and a diverged gyro bias drives phantom **yaw drift**.

Observed on a real HiPNUC flat→move→flat recording: after a vigorous move, roll stuck at ~7–43° with the accelerometer 100% gated while stationary.

## Fix

Gate on the **raw** measured magnitude (`‖ã‖`, `‖m̃‖`). The gate is a quasi-static / interference detector — a property of the measurement, not of the estimate. The measurement update still uses the bias-corrected value. One-line change per gate.

## Tests

New regression tests (seed a large `init_accel_bias`/`init_mag_bias`, feed a clean static reading → the sensor must still be used):
- `Mekf9Test.AccelGateUsesRawMagnitudeNotBiasCorrected`
- `Mekf9Test.MagGateUsesRawMagnitudeNotBiasCorrected`

Both **fail against the old gate** and **pass with the fix**. Full estimation suite unchanged: `test_mekf9` 7/7, `test_mekf_consistency` 2/2 (NEES), `test_mekf6` 6/6.

Documented as **errata C9** in `docs/typst/mekf-errata.typ`.

## Note

The failure is most acute for factory-calibrated IMUs whose true bias ≈ 0; such sensors should additionally pin the bias states with tight priors (cf. `CleanSensorParams`) so the bias never drifts to begin with.